### PR TITLE
support for mime-type `audio-mpegurl` for M3U playlists

### DIFF
--- a/src/playlist/plugins/M3uPlaylistPlugin.cxx
+++ b/src/playlist/plugins/M3uPlaylistPlugin.cxx
@@ -66,6 +66,7 @@ static const char *const m3u_suffixes[] = {
 
 static const char *const m3u_mime_types[] = {
 	"audio/x-mpegurl",
+	"audio/mpegurl",
 	nullptr
 };
 


### PR DESCRIPTION
It looks that there are several mime-types for M3U playlists around (see https://en.wikipedia.org/wiki/M3U); this PR should help mpd to manage a wider range of playlists.

As specific case see: https://github.com/diraimondo/gmusicproxy/issues/93
