### PR TITLE
Read MusicBrainz tags when using ffmpeg decoder.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -936,7 +936,8 @@ libtag_a_SOURCES =\
 	src/tag/Generic.cxx src/tag/Generic.hxx \
 	src/tag/ApeLoader.cxx src/tag/ApeLoader.hxx \
 	src/tag/ApeReplayGain.cxx src/tag/ApeReplayGain.hxx \
-	src/tag/ApeTag.cxx src/tag/ApeTag.hxx
+	src/tag/ApeTag.cxx src/tag/ApeTag.hxx \
+	src/tag/Id3MusicBrainz.cxx src/tag/Id3MusicBrainz.hxx
 
 if ENABLE_ID3TAG
 libtag_a_SOURCES += \

--- a/src/decoder/plugins/FfmpegMetaData.cxx
+++ b/src/decoder/plugins/FfmpegMetaData.cxx
@@ -24,6 +24,7 @@
 #include "FfmpegMetaData.hxx"
 #include "tag/Table.hxx"
 #include "tag/Handler.hxx"
+#include "tag/Id3MusicBrainz.hxx"
 
 extern "C" {
 #include <libavutil/dict.h>
@@ -72,6 +73,11 @@ FfmpegScanDictionary(AVDictionary *dict,
 				      handler, handler_ctx);
 
 		for (const struct tag_table *i = ffmpeg_tags;
+		     i->name != nullptr; ++i)
+			FfmpegScanTag(i->type, dict, i->name,
+				      handler, handler_ctx);
+
+		for (const struct tag_table *i = musicbrainz_txxx_tags;
 		     i->name != nullptr; ++i)
 			FfmpegScanTag(i->type, dict, i->name,
 				      handler, handler_ctx);

--- a/src/tag/Id3MusicBrainz.cxx
+++ b/src/tag/Id3MusicBrainz.cxx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2003-2017 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "Type.h"
+#include "Table.hxx"
+#include "Id3MusicBrainz.hxx"
+
+const struct tag_table musicbrainz_txxx_tags[] = {
+	{ "ALBUMARTISTSORT", TAG_ALBUM_ARTIST_SORT },
+	{ "MusicBrainz Artist Id", TAG_MUSICBRAINZ_ARTISTID },
+	{ "MusicBrainz Album Id", TAG_MUSICBRAINZ_ALBUMID },
+	{ "MusicBrainz Album Artist Id",
+	  TAG_MUSICBRAINZ_ALBUMARTISTID },
+	{ "MusicBrainz Track Id", TAG_MUSICBRAINZ_TRACKID },
+	{ "MusicBrainz Release Track Id",
+	  TAG_MUSICBRAINZ_RELEASETRACKID },
+	{ nullptr, TAG_NUM_OF_ITEM_TYPES }
+};

--- a/src/tag/Id3MusicBrainz.hxx
+++ b/src/tag/Id3MusicBrainz.hxx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2003-2017 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef MPD_TAG_ID3MUSICBRAINZ_HXX
+#define MPD_TAG_ID3MUSICBRAINZ_HXX
+
+extern const struct tag_table musicbrainz_txxx_tags[];
+
+#endif

--- a/src/tag/Id3Scan.cxx
+++ b/src/tag/Id3Scan.cxx
@@ -23,6 +23,7 @@
 #include "Handler.hxx"
 #include "Table.hxx"
 #include "Builder.hxx"
+#include "Id3MusicBrainz.hxx"
 #include "util/Alloc.hxx"
 #include "util/ScopeExit.hxx"
 #include "util/StringStrip.hxx"
@@ -209,19 +210,8 @@ gcc_pure
 static TagType
 tag_id3_parse_txxx_name(const char *name) noexcept
 {
-	static constexpr struct tag_table txxx_tags[] = {
-		{ "ALBUMARTISTSORT", TAG_ALBUM_ARTIST_SORT },
-		{ "MusicBrainz Artist Id", TAG_MUSICBRAINZ_ARTISTID },
-		{ "MusicBrainz Album Id", TAG_MUSICBRAINZ_ALBUMID },
-		{ "MusicBrainz Album Artist Id",
-		  TAG_MUSICBRAINZ_ALBUMARTISTID },
-		{ "MusicBrainz Track Id", TAG_MUSICBRAINZ_TRACKID },
-		{ "MusicBrainz Release Track Id",
-		  TAG_MUSICBRAINZ_RELEASETRACKID },
-		{ nullptr, TAG_NUM_OF_ITEM_TYPES }
-	};
 
-	return tag_table_lookup(txxx_tags, name);
+	return tag_table_lookup(musicbrainz_txxx_tags, name);
 }
 
 /**


### PR DESCRIPTION
Addresses #82.

When using the ffmpeg decoder to read song metadata, MusicBrainz tags
were not being read.

Ffmpeg doesn't tell us the metadata container format, so we accept the
ID3v2 as well as the Vorbis/APEv2 keys from this table: https://picard.musicbrainz.org/docs/mappings/