### PR TITLE
Fix EventPipe file descriptors

### DIFF
--- a/src/system/EventPipe.cxx
+++ b/src/system/EventPipe.cxx
@@ -48,7 +48,7 @@ EventPipe::EventPipe()
 		throw MakeErrno("pipe() has failed");
 
 	fds[0] = r.Steal();
-	fds[1] = r.Steal();
+	fds[1] = w.Steal();
 #endif
 }
 


### PR DESCRIPTION
Current MPD head crashes on starting playback on macOS Sierra. On investigation this seems to be due to a typo in `EventPipe.cxx` attempting to use the read file descriptor as both R/W.

This patch fixes playback on my system.