### PR TITLE
Remove Content-Type check for webdav

### DIFF
--- a/src/storage/plugins/CurlStorage.cxx
+++ b/src/storage/plugins/CurlStorage.cxx
@@ -270,11 +270,6 @@ private:
 		if (status != 207)
 			throw FormatRuntimeError("Status %d from WebDAV server; expected \"207 Multi-Status\"",
 						 status);
-
-		auto i = headers.find("content-type");
-		if (i == headers.end() ||
-		    strncmp(i->second.c_str(), "text/xml", 8) != 0)
-			throw std::runtime_error("Unexpected Content-Type from WebDAV server");
 	}
 
 	void OnData(ConstBuffer<void> _data) final {


### PR DESCRIPTION
This removes the Content-Type check if webdav is used as storage.
Several implementations of common WebDav servers (Synology File Stations, Nginx) do not correctly implement the RFC or in another way then expected from MPD. 
The RFC does not explicitly state that an client must check this header so therefore I completely removed the check.

This patch was tested against an password protected Nginx WebDav share and worked flawlessly. Reading and playing files from this share worked as expected.