### PR TITLE
Add sndio mixer, fix building on BSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1469,6 +1469,7 @@ if ENABLE_SNDIO
 liboutput_plugins_a_SOURCES += \
 	src/output/plugins/SndioOutputPlugin.cxx \
 	src/output/plugins/SndioOutputPlugin.hxx
+libmixer_plugins_a_SOURCES += src/mixer/plugins/SndioMixerPlugin.cxx
 endif
 
 if ENABLE_HAIKU

--- a/doc/mpdconf.example
+++ b/doc/mpdconf.example
@@ -310,7 +310,7 @@ input {
 #audio_output {
 #	type		"sndio"
 #	name		"sndio output"
-#	mixer_type	"software"
+#	mixer_type	"hardware"
 #}
 #
 # An example of an OS X output:

--- a/src/mixer/MixerList.hxx
+++ b/src/mixer/MixerList.hxx
@@ -36,5 +36,6 @@ extern const MixerPlugin osx_mixer_plugin;
 extern const MixerPlugin roar_mixer_plugin;
 extern const MixerPlugin pulse_mixer_plugin;
 extern const MixerPlugin winmm_mixer_plugin;
+extern const MixerPlugin sndio_mixer_plugin;
 
 #endif

--- a/src/mixer/plugins/SndioMixerPlugin.cxx
+++ b/src/mixer/plugins/SndioMixerPlugin.cxx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Christopher Zimmermann <christopher@gmerlin.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "config.h"
+#include "mixer/MixerInternal.hxx"
+#include "mixer/Listener.hxx"
+#include "output/plugins/SndioOutputPlugin.hxx"
+
+#include <sndio.h>
+
+class SndioMixer final : public Mixer {
+	SndioOutput &output;
+
+public:
+	SndioMixer(SndioOutput &_output, MixerListener &_listener)
+		:Mixer(sndio_mixer_plugin, _listener), output(_output)
+	{
+		output.RegisterMixerListener(this, &_listener);
+	}
+
+	/* virtual methods from class Mixer */
+	void Open() override {}
+
+	void Close() noexcept override {}
+
+	int GetVolume() override {
+		return output.GetVolume();
+	}
+
+	void SetVolume(unsigned volume) override {
+		output.SetVolume(volume);
+	}
+
+};
+
+static Mixer *
+sndio_mixer_init(gcc_unused EventLoop &event_loop,
+		AudioOutput &ao,
+		MixerListener &listener,
+		gcc_unused const ConfigBlock &block)
+{
+	return new SndioMixer((SndioOutput &)ao, listener);
+}
+
+const MixerPlugin sndio_mixer_plugin = {
+	sndio_mixer_init,
+	false,
+};

--- a/src/output/plugins/SndioOutputPlugin.hxx
+++ b/src/output/plugins/SndioOutputPlugin.hxx
@@ -18,6 +18,7 @@
  */
 
 #include "../OutputAPI.hxx"
+#include "mixer/Listener.hxx"
 
 #ifndef MPD_SNDIO_OUTPUT_PLUGIN_HXX
 #define MPD_SNDIO_OUTPUT_PLUGIN_HXX
@@ -25,15 +26,23 @@
 extern const struct AudioOutputPlugin sndio_output_plugin;
 
 class SndioOutput final : AudioOutput {
+	Mixer *mixer = nullptr;
+	MixerListener *listener = nullptr;
 	const char *const device;
 	const unsigned buffer_time; /* in ms */
 	struct sio_hdl *sio_hdl;
+	int raw_volume;
 
 public:
 	SndioOutput(const ConfigBlock &block);
 
 	static AudioOutput *Create(EventLoop &,
-				   const ConfigBlock &block);
+		const ConfigBlock &block);
+
+	void SetVolume(unsigned int _volume);
+	unsigned int GetVolume();
+	void VolumeChanged(int _volume);
+	void RegisterMixerListener(Mixer *_mixer, MixerListener *_listener);
 
 private:
 	void Open(AudioFormat &audio_format) override;


### PR DESCRIPTION
Building on any unix with ``sin_size`` in ``sockaddr_in`` is broken.
I fix this not by using additional ``#ifdef``s, but by initializing the anonymous ``sockaddr_in`` with explicit field names. The ``sin_size`` field does not require initialization and is implicitly initialized to ``0``.