### PR TITLE
GME Plugin: fix track numbering, only load m3u when it exists

### DIFF
--- a/src/decoder/plugins/GmeDecoderPlugin.cxx
+++ b/src/decoder/plugins/GmeDecoderPlugin.cxx
@@ -27,6 +27,7 @@
 #include "tag/Builder.hxx"
 #include "fs/Path.hxx"
 #include "fs/AllocatedPath.hxx"
+#include "fs/FileSystem.hxx"
 #include "util/ScopeExit.hxx"
 #include "util/FormatString.hxx"
 #include "util/UriUtil.hxx"
@@ -126,7 +127,14 @@ LoadGmeAndM3u(GmeContainerPath container) {
 	std::string m3u_path(path,suffix);
 	m3u_path += "m3u";
 
-	gme_load_m3u(emu,m3u_path.c_str());
+    /*
+     * Some GME formats lose metadata if you attempt to
+     * load a non-existant M3U file, so check that one
+     * exists before loading.
+     */
+	if(FileExists(Path::FromFS(m3u_path.c_str()))) {
+		gme_load_m3u(emu,m3u_path.c_str());
+	}
 	return emu;
 }
 

--- a/src/decoder/plugins/GmeDecoderPlugin.cxx
+++ b/src/decoder/plugins/GmeDecoderPlugin.cxx
@@ -319,13 +319,13 @@ gme_container_scan(Path path_fs)
 	TagBuilder tag_builder;
 
 	auto tail = list.before_begin();
-	for (unsigned i = 1; i <= num_songs; ++i) {
+	for (unsigned i = 0; i < num_songs; ++i) {
 		ScanMusicEmu(emu, i,
 			     add_tag_handler, &tag_builder);
 
 		char track_name[64];
 		snprintf(track_name, sizeof(track_name),
-			 SUBTUNE_PREFIX "%03u.%s", i, subtune_suffix);
+			 SUBTUNE_PREFIX "%03u.%s", i+1, subtune_suffix);
 		tail = list.emplace_after(tail, track_name,
 					  tag_builder.Commit());
 	}


### PR DESCRIPTION
GME starts all track indexes at zero, but the subtune prefixes start at one. This caused an off-by-one error with track titles.

It also turns out, if you load an NSFE file (which has embedded track titles), then attempt to load an M3U file, it causes GME to lose all information found in the NSFE file. This adds a check that the M3U file exists before attempting to load.