### PR TITLE
Mount-Points are purged from database on update/rescan

### DIFF
--- a/src/db/plugins/simple/Directory.cxx
+++ b/src/db/plugins/simple/Directory.cxx
@@ -106,7 +106,7 @@ Directory::PruneEmpty() noexcept
 	     child != end;) {
 		child->PruneEmpty();
 
-		if (child->IsEmpty())
+		if (child->IsEmpty() && (!child->IsMount()))
 			child = children.erase_and_dispose(child,
 							   DeleteDisposer());
 		else

--- a/src/db/update/Walk.cxx
+++ b/src/db/update/Walk.cxx
@@ -104,7 +104,7 @@ inline void
 UpdateWalk::PurgeDeletedFromDirectory(Directory &directory)
 {
 	directory.ForEachChildSafe([&](Directory &child){
-			if (DirectoryExists(storage, child))
+			if (DirectoryExists(storage, child) || child.IsMount())
 				return;
 
 			editor.LockDeleteDirectory(&child);


### PR DESCRIPTION
Mount-Points are removed from the database on update/rescan because they are detected as empty. This pull request keeps the mount points intact on rescan of the base database.