### PR TITLE
lib/upnp: use include path without upnp/ prefix and honor pkg-config …

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -792,6 +792,7 @@ libneighbor_a_SOURCES += \
 NEIGHBOR_LIBS += \
 	$(EXPAT_LIBS) \
 	$(UPNP_LIBS)
+libneighbor_a_CXXFLAGS = $(UPNP_CFLAGS)
 endif
 
 endif
@@ -843,6 +844,7 @@ libdb_plugins_a_SOURCES += \
 DB_LIBS += \
 	$(EXPAT_LIBS) \
 	$(UPNP_LIBS)
+libdb_plugins_a_CXXFLAGS = $(UPNP_CFLAGS)
 endif
 
 endif

--- a/src/lib/upnp/Action.hxx
+++ b/src/lib/upnp/Action.hxx
@@ -22,7 +22,7 @@
 
 #include "Compiler.h"
 
-#include <upnp/upnptools.h>
+#include <upnptools.h>
 
 static inline constexpr unsigned
 CountNameValuePairs() noexcept

--- a/src/lib/upnp/Callback.hxx
+++ b/src/lib/upnp/Callback.hxx
@@ -20,7 +20,7 @@
 #ifndef MPD_UPNP_CALLBACK_HXX
 #define MPD_UPNP_CALLBACK_HXX
 
-#include <upnp/upnp.h>
+#include <upnp.h>
 
 /**
  * A class that is supposed to be used for libupnp asynchronous

--- a/src/lib/upnp/ClientInit.cxx
+++ b/src/lib/upnp/ClientInit.cxx
@@ -24,7 +24,7 @@
 #include "thread/Mutex.hxx"
 #include "util/RuntimeError.hxx"
 
-#include <upnp/upnptools.h>
+#include <upnptools.h>
 
 #include <assert.h>
 

--- a/src/lib/upnp/ClientInit.hxx
+++ b/src/lib/upnp/ClientInit.hxx
@@ -22,7 +22,7 @@
 
 #include "check.h"
 
-#include <upnp/upnp.h>
+#include <upnp.h>
 
 void
 UpnpClientGlobalInit(UpnpClient_Handle &handle);

--- a/src/lib/upnp/Compat.hxx
+++ b/src/lib/upnp/Compat.hxx
@@ -20,7 +20,7 @@
 #ifndef MPD_UPNP_COMPAT_HXX
 #define MPD_UPNP_COMPAT_HXX
 
-#include <upnp/upnp.h>
+#include <upnp.h>
 
 #if UPNP_VERSION < 10800
 /* emulate the libupnp 1.8 API with older versions */

--- a/src/lib/upnp/ContentDirectoryService.hxx
+++ b/src/lib/upnp/ContentDirectoryService.hxx
@@ -22,7 +22,7 @@
 
 #include "Compiler.h"
 
-#include <upnp/upnp.h>
+#include <upnp.h>
 
 #include <string>
 #include <list>

--- a/src/lib/upnp/Discovery.cxx
+++ b/src/lib/upnp/Discovery.cxx
@@ -27,7 +27,7 @@
 #include "util/ScopeExit.hxx"
 #include "util/RuntimeError.hxx"
 
-#include <upnp/upnptools.h>
+#include <upnptools.h>
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/lib/upnp/Discovery.hxx
+++ b/src/lib/upnp/Discovery.hxx
@@ -30,7 +30,7 @@
 #include "event/DeferEvent.hxx"
 #include "Compiler.h"
 
-#include <upnp/upnp.h>
+#include <upnp.h>
 
 #include <boost/intrusive/list.hpp>
 

--- a/src/lib/upnp/Init.cxx
+++ b/src/lib/upnp/Init.cxx
@@ -22,9 +22,9 @@
 #include "thread/Mutex.hxx"
 #include "util/RuntimeError.hxx"
 
-#include <upnp/upnp.h>
-#include <upnp/upnptools.h>
-#include <upnp/ixml.h>
+#include <upnp.h>
+#include <upnptools.h>
+#include <ixml.h>
 
 #include <assert.h>
 

--- a/src/lib/upnp/UniqueIxml.hxx
+++ b/src/lib/upnp/UniqueIxml.hxx
@@ -20,7 +20,7 @@
 #ifndef MPD_UPNP_UNIQUE_XML_HXX
 #define MPD_UPNP_UNIQUE_XML_HXX
 
-#include <upnp/ixml.h>
+#include <ixml.h>
 
 #include <memory>
 

--- a/src/lib/upnp/ixmlwrap.hxx
+++ b/src/lib/upnp/ixmlwrap.hxx
@@ -17,7 +17,7 @@
 #ifndef _IXMLWRAP_H_INCLUDED_
 #define _IXMLWRAP_H_INCLUDED_
 
-#include <upnp/ixml.h>
+#include <ixml.h>
 
 #include <string>
 


### PR DESCRIPTION
…CFLAGS

If libupnp is installed in a non-standard location we must rely on the
include path provided by $(pkg-config --cflags libupnp). Relative to the
path given from that command no prefix must be used to find the respective
files.