### PR TITLE
Calling visit on mounted databases creates wrong uris

### DIFF
--- a/src/db/plugins/simple/Directory.cxx
+++ b/src/db/plugins/simple/Directory.cxx
@@ -227,7 +227,7 @@ Directory::Walk(bool recursive, const SongFilter *filter,
 		   call will lock it again */
 		const ScopeDatabaseUnlock unlock;
 		WalkMount(GetPath(), *mounted_database,
-			  recursive, filter,
+			  "", recursive, filter,
 			  visit_directory, visit_song,
 			  visit_playlist);
 		return;

--- a/src/db/plugins/simple/Mount.cxx
+++ b/src/db/plugins/simple/Mount.cxx
@@ -72,7 +72,7 @@ PrefixVisitPlaylist(const char *base, const VisitPlaylist &visit_playlist,
 
 void
 WalkMount(const char *base, const Database &db,
-	  bool recursive, const SongFilter *filter,
+	  const char* uri, bool recursive, const SongFilter *filter,
 	  const VisitDirectory &visit_directory, const VisitSong &visit_song,
 	  const VisitPlaylist &visit_playlist)
 {
@@ -93,5 +93,5 @@ WalkMount(const char *base, const Database &db,
 		vp = std::bind(PrefixVisitPlaylist,
 			       base, std::ref(visit_playlist), _1, _2);
 
-	db.Visit(DatabaseSelection("", recursive, filter), vd, vs, vp);
+	db.Visit(DatabaseSelection(uri, recursive, filter), vd, vs, vp);
 }

--- a/src/db/plugins/simple/Mount.hxx
+++ b/src/db/plugins/simple/Mount.hxx
@@ -27,7 +27,7 @@ class SongFilter;
 
 void
 WalkMount(const char *base, const Database &db,
-	  bool recursive, const SongFilter *filter,
+	  const char* uri, bool recursive, const SongFilter *filter,
 	  const VisitDirectory &visit_directory, const VisitSong &visit_song,
 	  const VisitPlaylist &visit_playlist);
 

--- a/src/db/plugins/simple/SimpleDatabasePlugin.cxx
+++ b/src/db/plugins/simple/SimpleDatabasePlugin.cxx
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "SimpleDatabasePlugin.hxx"
 #include "PrefixedLightSong.hxx"
+#include "Mount.hxx"
 #include "db/DatabasePlugin.hxx"
 #include "db/Selection.hxx"
 #include "db/Helpers.hxx"
@@ -271,6 +272,18 @@ SimpleDatabase::Visit(const DatabaseSelection &selection,
 	ScopeDatabaseLock protect;
 
 	auto r = root->LookupDirectory(selection.uri.c_str());
+
+	if (r.directory->IsMount()) {
+		/* pass the request and the remaining uri to the mounted database */
+		protect.unlock();
+
+		WalkMount(r.directory->GetPath(), *(r.directory->mounted_database),
+			(r.uri == nullptr)?"":r.uri, selection.recursive, selection.filter,
+			visit_directory, visit_song, visit_playlist);
+
+		return;
+	}
+
 	if (r.uri == nullptr) {
 		/* it's a directory */
 


### PR DESCRIPTION
If `SimpleDatabase::Visit` is called on a database that contains a mounted directry the URIs of the elements passed to the callbacks are not prefixed by the mountpoint path. This leads to `lsinfo` and `add` not working because they use the wrong URI.