### PR TITLE
correct action for compile on Solaris 11.3 X86

### DIFF
--- a/src/util/WStringAPI.hxx
+++ b/src/util/WStringAPI.hxx
@@ -107,7 +107,11 @@ UnsafeCopyStringP(wchar_t *dest, const wchar_t *src) noexcept
   UnsafeCopyString(dest, src);
   return dest + StringLength(dest);
 #else
+#if defined(__sun) && defined (__SVR4)
+        return std::wcpcpy(dest, src);
+#else
   return wcpcpy(dest, src);
+#endif
 #endif
 }
 
@@ -159,7 +163,11 @@ gcc_malloc gcc_nonnull_all
 static inline wchar_t *
 DuplicateString(const wchar_t *p)
 {
+#if defined(__sun) && defined (__SVR4)
+	return std::wcsdup(p);
+#else
 	return wcsdup(p);
+#endif
 }
 
 #endif


### PR DESCRIPTION
SunOS snooky-dev.nest.org.ru 5.11 11.3 i86pc i386 i86pc Solaris
gcc (GCC) 5.4.0
boost-git
gmake V=1
Compile error ([full output](https://gist.github.com/ilyxa/853f834e2aa00cc421355bb0b87414cd) )
```
src/util/WStringAPI.hxx: In function 'wchar_t* UnsafeCopyStringP(wchar_t*, const wchar_t*)':
src/util/WStringAPI.hxx:110:26: error: 'wcpcpy' was not declared in this scope
   return wcpcpy(dest, src);

src/util/WStringAPI.hxx: In function 'wchar_t* DuplicateString(const wchar_t*)':
src/util/WStringAPI.hxx:162:17: error: 'wcsdup' was not declared in this scope
  return wcsdup(p);
```
Patch ([git diff](https://gist.github.com/ilyxa/34cfa182b84c159698f934e28b261665) ):
```
diff --git a/src/util/WStringAPI.hxx b/src/util/WStringAPI.hxx
index 6ed7889..869f058 100644
--- a/src/util/WStringAPI.hxx
+++ b/src/util/WStringAPI.hxx
@@ -107,8 +107,12 @@ UnsafeCopyStringP(wchar_t *dest, const wchar_t *src) noexcept
   UnsafeCopyString(dest, src);
   return dest + StringLength(dest);
 #else
+#if defined(__sun) && defined (__SVR4)
+        return std::wcpcpy(dest, src);
+#else
   return wcpcpy(dest, src);
 #endif
+#endif
 }
 
 /**
@@ -159,7 +163,11 @@ gcc_malloc gcc_nonnull_all
 static inline wchar_t *
 DuplicateString(const wchar_t *p)
 {
+#if defined(__sun) && defined (__SVR4)
+       return std::wcsdup(p);
+#else
        return wcsdup(p);
+#endif
 }
 
 #endif
```