### PR TITLE
configure.ac: autodetect sin_len member in struct sockaddr_in.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,6 +243,8 @@ AC_CHECK_FUNCS(fnmatch)
 AC_CHECK_FUNCS(strndup)
 AC_CHECK_FUNCS(strcasestr)
 
+AC_CHECK_MEMBERS([struct sockaddr_in.sin_len], [], [], [[#include <netinet/in.h>]])
+
 if test x$host_is_linux = xyes; then
 	MPD_OPTIONAL_FUNC(eventfd, eventfd, USE_EVENTFD)
 	MPD_OPTIONAL_FUNC(signalfd, signalfd, USE_SIGNALFD)

--- a/src/net/IPv4Address.hxx
+++ b/src/net/IPv4Address.hxx
@@ -81,8 +81,7 @@ class IPv4Address {
 	static constexpr struct sockaddr_in Construct(struct in_addr address,
 						      uint16_t port) {
 		return {
-#if defined(__APPLE__) || \
-    defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__)
+#ifdef HAVE_STRUCT_SOCKADDR_IN_SIN_LEN
 			sizeof(struct sockaddr_in),
 #endif
 			AF_INET,


### PR DESCRIPTION
This fixes a build issue on Haiku as it does have sin_len.
Tested on Linux as well.

For some reason AC_CHECK_MEMBER doesn't generate the proper define
in config.h.in, so I used AC_CHECK_MEMBERS.