### PR TITLE
db/upnp/Directory: improve parsing of duration

### DIFF
--- a/src/db/plugins/upnp/Directory.cxx
+++ b/src/db/plugins/upnp/Directory.cxx
@@ -55,23 +55,21 @@ ParseDuration(const char *duration) noexcept
 {
 	char *endptr;
 
-	unsigned result = ParseUnsigned(duration, &endptr);
+	int hours = ParseInt(duration, &endptr);
 	if (endptr == duration || *endptr != ':')
 		return SignedSongTime::Negative();
 
-	result *= 60;
 	duration = endptr + 1;
-	result += ParseUnsigned(duration, &endptr);
+	unsigned minutes = ParseUnsigned(duration, &endptr);
 	if (endptr == duration || *endptr != ':')
 		return SignedSongTime::Negative();
 
-	result *= 60;
 	duration = endptr + 1;
-	result += ParseUnsigned(duration, &endptr);
-	if (endptr == duration || *endptr != 0)
+	double seconds = ParseDouble(duration, &endptr);
+	if (endptr == duration || *endptr != 0 || seconds < 0.0)
 		return SignedSongTime::Negative();
 
-	return SignedSongTime::FromS(result);
+	return SignedSongTime::FromS((((hours * 60) + minutes) * 60) + seconds);
 }
 
 /**


### PR DESCRIPTION
According to http://www.upnp.org/schemas/av/didl-lite-v2.xsd the duration of a song can have fractions of seconds (quote from above url):

        The format of the duration string is:
        H+:MM:SS[.F+], or H+:MM:SS[.F0/F1]
        Where:
        +H              one or more digits to indicate elapsed hours,
        MM              exactly 2 digits to indicate minutes (00 to 59),
        SS              exactly 2 digits to indicate seconds (00 to 59),
        F+              any number of digits (including no digits) to indicate fractions of seconds,
        F0/F1   a fraction, with F0 and F1 at least one digit long,
                        and F0 < F1.
        The string may be preceded by an optional + or - sign, and the
        decimal point itself may be omitted if there are no fractional  seconds digits.

This patch enables to read durations in the first format, i.e. H+:MM:SS[.F+]
Previously, the duration could not be parsed, if it contained fractions of seconds.