### PR TITLE
opus stream chaining

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,8 @@ ver 0.21 (not yet released)
   - sndio: remove support for the broken RoarAudio sndio emulation
 * mixer
   - sndio: new mixer plugin
+* encoder
+  - opus: support for sending metadata using ogg stream chaining
 * require GCC 5.0
 
 ver 0.20.18 (2018/02/24)

--- a/doc/user.xml
+++ b/doc/user.xml
@@ -3251,6 +3251,23 @@ run</programlisting>
                   (the default), "voice" and "music".
                 </entry>
               </row>
+
+              <row>
+                <entry>
+                  <varname>opustags</varname>
+                  <parameter>yes|no</parameter>
+                </entry>
+                <entry>
+                  Configures how metadata is interleaved into the stream.
+                  If set to <parameter>yes</parameter>, then metadata
+                  is inserted using ogg stream chaining, as specified
+                  in <ulink url="https://tools.ietf.org/html/rfc7845.html#section-7.2">RFC
+                  7845</ulink>. If set to <parameter>no</parameter>
+                  (the default), then ogg stream chaining is avoided
+                  and other output-dependent method is used, if
+                  available.
+                </entry>
+              </row>
             </tbody>
           </tgroup>
         </informaltable>


### PR DESCRIPTION
support for chaining streams to enable changing stream' metadata on the fly.
currently support is opt-in because lots of clients can't handle this properly yet.