### PR TITLE
playlist/Queue: add one-shot to single mode 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -946,6 +946,7 @@ endif
 libbasic_a_SOURCES = \
 	src/ReplayGainConfig.hxx \
 	src/ReplayGainMode.cxx src/ReplayGainMode.hxx \
+	src/SingleMode.cxx src/SingleMode.hxx \
 	src/ReplayGainInfo.cxx src/ReplayGainInfo.hxx
 
 # configuration library

--- a/doc/protocol.xml
+++ b/doc/protocol.xml
@@ -464,8 +464,8 @@
               <listitem>
                <para>
                 <varname>single</varname>:
-                <footnote id="since_0_15"><simpara>Introduced with <application>MPD</application> 0.15</simpara></footnote>
-                <returnvalue>0 or 1</returnvalue>
+                <footnote id="since_0_15"><simpara>Introduced with <application>MPD</application> 0.15 (oneshot introduced with 0.20)</simpara></footnote>
+                <returnvalue>0, 1, or oneshot</returnvalue>
                </para>
               </listitem>
               <listitem>

--- a/src/Partition.cxx
+++ b/src/Partition.cxx
@@ -110,6 +110,12 @@ Partition::SyncWithPlayer()
 }
 
 void
+Partition::BorderPause()
+{
+	playlist.BorderPause();
+}
+
+void
 Partition::OnQueueModified()
 {
 	EmitIdle(IDLE_PLAYLIST);
@@ -140,6 +146,12 @@ Partition::OnPlayerTagModified() noexcept
 }
 
 void
+Partition::OnBorderPause() noexcept
+{
+	EmitGlobalEvent(BORDER_PAUSE);
+}
+
+void
 Partition::OnMixerVolumeChanged(gcc_unused Mixer &mixer, gcc_unused int volume)
 {
 	InvalidateHardwareVolume();
@@ -156,4 +168,7 @@ Partition::OnGlobalEvent(unsigned mask)
 
 	if ((mask & TAG_MODIFIED) != 0)
 		TagModified();
+
+	if ((mask & BORDER_PAUSE) != 0)
+		BorderPause();
 }

--- a/src/Partition.cxx
+++ b/src/Partition.cxx
@@ -112,7 +112,7 @@ Partition::SyncWithPlayer()
 void
 Partition::BorderPause()
 {
-	playlist.BorderPause();
+	playlist.BorderPause(pc);
 }
 
 void

--- a/src/Partition.hxx
+++ b/src/Partition.hxx
@@ -28,6 +28,7 @@
 #include "player/Control.hxx"
 #include "player/Listener.hxx"
 #include "ReplayGainMode.hxx"
+#include "SingleMode.hxx"
 #include "Chrono.hxx"
 #include "Compiler.h"
 
@@ -46,6 +47,7 @@ class ClientListener;
 struct Partition final : QueueListener, PlayerListener, MixerListener {
 	static constexpr unsigned TAG_MODIFIED = 0x1;
 	static constexpr unsigned SYNC_WITH_PLAYER = 0x2;
+	static constexpr unsigned BORDER_PAUSE = 0x4;
 
 	Instance &instance;
 
@@ -184,7 +186,7 @@ struct Partition final : QueueListener, PlayerListener, MixerListener {
 		playlist.SetRandom(pc, new_value);
 	}
 
-	void SetSingle(bool new_value) {
+	void SetSingle(SingleMode new_value) {
 		playlist.SetSingle(pc, new_value);
 	}
 
@@ -237,6 +239,12 @@ struct Partition final : QueueListener, PlayerListener, MixerListener {
 	 */
 	void SyncWithPlayer();
 
+	/**
+	 * Border pause has just been enabled. Change single mode to off
+	 * if it was one-shot.
+	 */
+	void BorderPause();
+
 private:
 	/* virtual methods from class QueueListener */
 	void OnQueueModified() override;
@@ -246,6 +254,7 @@ private:
 	/* virtual methods from class PlayerListener */
 	void OnPlayerSync() noexcept override;
 	void OnPlayerTagModified() noexcept override;
+	void OnBorderPause() noexcept override;
 
 	/* virtual methods from class MixerListener */
 	void OnMixerVolumeChanged(Mixer &mixer, int volume) override;

--- a/src/SingleMode.cxx
+++ b/src/SingleMode.cxx
@@ -28,14 +28,14 @@ const char *
 SingleToString(SingleMode mode) noexcept
 {
 	switch (mode) {
-	case SingleMode::ONE_SHOT:
-		return "oneshot";
-
 	case SingleMode::OFF:
-		return "off";
+		return "0";
 
 	case SingleMode::ON:
-		return "on";
+		return "1";
+
+	case SingleMode::ONE_SHOT:
+		return "oneshot";
 	}
 
 	assert(false);
@@ -47,17 +47,12 @@ SingleFromString(const char *s)
 {
 	assert(s != nullptr);
 
-	if (strcmp(s, "off") == 0)
+	if (strcmp(s, "0") == 0)
 		return SingleMode::OFF;
-	else if (strcmp(s, "on") == 0)
+	else if (strcmp(s, "1") == 0)
 		return SingleMode::ON;
 	else if (strcmp(s, "oneshot") == 0)
 		return SingleMode::ONE_SHOT;
-	// backward compatibility?
-	else if (strcmp(s, "1") == 0)
-		return SingleMode::ON;
-	else if (strcmp(s, "0") == 0)
-		return SingleMode::OFF;
 	else
-		throw std::invalid_argument("Unrecognized single mode");
+		throw std::invalid_argument("Unrecognized single mode, expected 0, 1, or oneshot");
 }

--- a/src/SingleMode.cxx
+++ b/src/SingleMode.cxx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2003-2017 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "SingleMode.hxx"
+
+#include <stdexcept>
+
+#include <assert.h>
+#include <string.h>
+
+const char *
+SingleToString(SingleMode mode) noexcept
+{
+	switch (mode) {
+	case SingleMode::ONE_SHOT:
+		return "oneshot";
+
+	case SingleMode::OFF:
+		return "off";
+
+	case SingleMode::ON:
+		return "on";
+	}
+
+	assert(false);
+	gcc_unreachable();
+}
+
+SingleMode
+SingleFromString(const char *s)
+{
+	assert(s != nullptr);
+
+	if (strcmp(s, "off") == 0)
+		return SingleMode::OFF;
+	else if (strcmp(s, "on") == 0)
+		return SingleMode::ON;
+	else if (strcmp(s, "oneshot") == 0)
+		return SingleMode::ONE_SHOT;
+	// backward compatibility?
+	else if (strcmp(s, "1") == 0)
+		return SingleMode::ON;
+	else if (strcmp(s, "0") == 0)
+		return SingleMode::OFF;
+	else
+		throw std::invalid_argument("Unrecognized single mode");
+}

--- a/src/SingleMode.hxx
+++ b/src/SingleMode.hxx
@@ -38,7 +38,7 @@ const char *
 SingleToString(SingleMode mode) noexcept;
 
 /**
- * Parse a string to a #SingleMode.  Throws std::runtime_error on error.
+ * Parse a string to a #SingleMode.  Throws std::invalid_argument on error.
  */
 SingleMode
 SingleFromString(const char *s);

--- a/src/SingleMode.hxx
+++ b/src/SingleMode.hxx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2003-2017 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef MPD_SINGLE_MODE_HXX
+#define MPD_SINGLE_MODE_HXX
+
+#include "Compiler.h"
+
+#include <stdint.h>
+
+enum class SingleMode : uint8_t {
+	OFF,
+	ON,
+	ONE_SHOT,
+};
+
+/**
+ * Return the string representation of a #SingleMode.
+ */
+gcc_pure
+const char *
+SingleToString(SingleMode mode) noexcept;
+
+/**
+ * Parse a string to a #SingleMode.  Throws std::runtime_error on error.
+ */
+SingleMode
+SingleFromString(const char *s);
+
+// #define SingleToString ToString
+// #define SingleFromString FromString
+#endif

--- a/src/SingleMode.hxx
+++ b/src/SingleMode.hxx
@@ -43,6 +43,4 @@ SingleToString(SingleMode mode) noexcept;
 SingleMode
 SingleFromString(const char *s);
 
-// #define SingleToString ToString
-// #define SingleFromString FromString
 #endif

--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -183,7 +183,7 @@ static constexpr struct command commands[] = {
 	{ "sendmessage", PERMISSION_CONTROL, 2, 2, handle_send_message },
 	{ "setvol", PERMISSION_CONTROL, 1, 1, handle_setvol },
 	{ "shuffle", PERMISSION_CONTROL, 0, 1, handle_shuffle },
-	{ "single", PERMISSION_CONTROL, 1, 2, handle_single },
+	{ "single", PERMISSION_CONTROL, 1, 1, handle_single },
 	{ "stats", PERMISSION_READ, 0, 0, handle_stats },
 	{ "status", PERMISSION_READ, 0, 0, handle_status },
 #ifdef ENABLE_SQLITE

--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -183,7 +183,7 @@ static constexpr struct command commands[] = {
 	{ "sendmessage", PERMISSION_CONTROL, 2, 2, handle_send_message },
 	{ "setvol", PERMISSION_CONTROL, 1, 1, handle_setvol },
 	{ "shuffle", PERMISSION_CONTROL, 0, 1, handle_shuffle },
-	{ "single", PERMISSION_CONTROL, 1, 1, handle_single },
+	{ "single", PERMISSION_CONTROL, 1, 2, handle_single },
 	{ "stats", PERMISSION_READ, 0, 0, handle_stats },
 	{ "status", PERMISSION_READ, 0, 0, handle_status },
 #ifdef ENABLE_SQLITE

--- a/src/command/PlayerCommands.cxx
+++ b/src/command/PlayerCommands.cxx
@@ -135,7 +135,7 @@ handle_status(Client &client, gcc_unused Request args, Response &r)
 
 	r.Format(COMMAND_STATUS_REPEAT ": %i\n"
 		 COMMAND_STATUS_RANDOM ": %i\n"
-		 COMMAND_STATUS_SINGLE ": %i\n" // FIXME?
+		 COMMAND_STATUS_SINGLE ": %i\n"
 		 COMMAND_STATUS_CONSUME ": %i\n"
 		 COMMAND_STATUS_PLAYLIST ": %li\n"
 		 COMMAND_STATUS_PLAYLIST_LENGTH ": %i\n"
@@ -143,7 +143,7 @@ handle_status(Client &client, gcc_unused Request args, Response &r)
 		 COMMAND_STATUS_STATE ": %s\n",
 		 playlist.GetRepeat(),
 		 playlist.GetRandom(),
-		 (int)playlist.GetSingle(), // FIXME?
+		 (int)playlist.GetSingle(),
 		 playlist.GetConsume(),
 		 (unsigned long)playlist.GetVersion(),
 		 playlist.GetLength(),
@@ -250,9 +250,7 @@ CommandResult
 handle_single(Client &client, Request args, gcc_unused Response &r)
 {
 	auto new_mode = SingleFromString(args.front());
-	// client.GetPartition().SetSingle(new_mode);
-	auto &partition = client.GetPartition();
-	partition.SetSingle(new_mode);
+	client.GetPartition().SetSingle(new_mode);
 	return CommandResult::OK;
 }
 

--- a/src/command/PlayerCommands.cxx
+++ b/src/command/PlayerCommands.cxx
@@ -135,7 +135,7 @@ handle_status(Client &client, gcc_unused Request args, Response &r)
 
 	r.Format(COMMAND_STATUS_REPEAT ": %i\n"
 		 COMMAND_STATUS_RANDOM ": %i\n"
-		 COMMAND_STATUS_SINGLE ": %i\n"
+		 COMMAND_STATUS_SINGLE ": %s\n"
 		 COMMAND_STATUS_CONSUME ": %i\n"
 		 COMMAND_STATUS_PLAYLIST ": %li\n"
 		 COMMAND_STATUS_PLAYLIST_LENGTH ": %i\n"
@@ -143,7 +143,7 @@ handle_status(Client &client, gcc_unused Request args, Response &r)
 		 COMMAND_STATUS_STATE ": %s\n",
 		 playlist.GetRepeat(),
 		 playlist.GetRandom(),
-		 (int)playlist.GetSingle(),
+		 SingleToString(playlist.GetSingle()),
 		 playlist.GetConsume(),
 		 (unsigned long)playlist.GetVersion(),
 		 playlist.GetLength(),

--- a/src/command/PlayerCommands.cxx
+++ b/src/command/PlayerCommands.cxx
@@ -23,6 +23,7 @@
 #include "CommandError.hxx"
 #include "queue/Playlist.hxx"
 #include "PlaylistPrint.hxx"
+#include "SingleMode.hxx"
 #include "client/Client.hxx"
 #include "client/Response.hxx"
 #include "mixer/Volume.hxx"
@@ -134,7 +135,7 @@ handle_status(Client &client, gcc_unused Request args, Response &r)
 
 	r.Format(COMMAND_STATUS_REPEAT ": %i\n"
 		 COMMAND_STATUS_RANDOM ": %i\n"
-		 COMMAND_STATUS_SINGLE ": %i\n"
+		 COMMAND_STATUS_SINGLE ": %i\n" // FIXME?
 		 COMMAND_STATUS_CONSUME ": %i\n"
 		 COMMAND_STATUS_PLAYLIST ": %li\n"
 		 COMMAND_STATUS_PLAYLIST_LENGTH ": %i\n"
@@ -142,7 +143,7 @@ handle_status(Client &client, gcc_unused Request args, Response &r)
 		 COMMAND_STATUS_STATE ": %s\n",
 		 playlist.GetRepeat(),
 		 playlist.GetRandom(),
-		 playlist.GetSingle(),
+		 (int)playlist.GetSingle(), // FIXME?
 		 playlist.GetConsume(),
 		 (unsigned long)playlist.GetVersion(),
 		 playlist.GetLength(),
@@ -218,8 +219,8 @@ handle_next(Client &client, gcc_unused Request args, gcc_unused Response &r)
 
 	/* single mode is not considered when this is user who
 	 * wants to change song. */
-	const bool single = playlist.queue.single;
-	playlist.queue.single = false;
+	const SingleMode single = playlist.queue.single;
+	playlist.queue.single = SingleMode::OFF;
 
 	AtScopeExit(&playlist, single) {
 		playlist.queue.single = single;
@@ -248,8 +249,10 @@ handle_repeat(Client &client, Request args, gcc_unused Response &r)
 CommandResult
 handle_single(Client &client, Request args, gcc_unused Response &r)
 {
-	bool status = args.ParseBool(0);
-	client.GetPartition().SetSingle(status);
+	auto new_mode = SingleFromString(args.front());
+	// client.GetPartition().SetSingle(new_mode);
+	auto &partition = client.GetPartition();
+	partition.SetSingle(new_mode);
 	return CommandResult::OK;
 }
 

--- a/src/player/Listener.hxx
+++ b/src/player/Listener.hxx
@@ -31,6 +31,11 @@ public:
 	 * The current song's tag has changed.
 	 */
 	virtual void OnPlayerTagModified() noexcept = 0;
+
+	/**
+	 * Playback went into border pause.
+	 */
+	virtual void OnBorderPause() noexcept = 0;
 };
 
 #endif

--- a/src/player/Thread.cxx
+++ b/src/player/Thread.cxx
@@ -929,6 +929,7 @@ Player::SongBorder() noexcept
 
 	const bool border_pause = pc.ApplyBorderPause();
 	if (border_pause) {
+		pc.listener.OnBorderPause();
 		paused = true;
 		idle_add(IDLE_PLAYER);
 	}

--- a/src/player/Thread.cxx
+++ b/src/player/Thread.cxx
@@ -929,8 +929,8 @@ Player::SongBorder() noexcept
 
 	const bool border_pause = pc.ApplyBorderPause();
 	if (border_pause) {
-		pc.listener.OnBorderPause();
 		paused = true;
+		pc.listener.OnBorderPause();
 		idle_add(IDLE_PLAYER);
 	}
 }

--- a/src/queue/Playlist.cxx
+++ b/src/queue/Playlist.cxx
@@ -372,10 +372,12 @@ playlist::GetNextPosition() const noexcept
 }
 
 void
-playlist::BorderPause()
+playlist::BorderPause(PlayerControl &pc)
 {
-	if (queue.single == SingleMode::ONE_SHOT)
+	if (queue.single == SingleMode::ONE_SHOT) {
 		queue.single = SingleMode::OFF;
+		pc.LockSetBorderPause(false);
 
-	listener.OnQueueOptionsChanged();
+		listener.OnQueueOptionsChanged();
+	}
 }

--- a/src/queue/Playlist.cxx
+++ b/src/queue/Playlist.cxx
@@ -258,9 +258,7 @@ playlist::SetRepeat(PlayerControl &pc, bool status)
 
 	queue.repeat = status;
 
-	pc.LockSetBorderPause((queue.single == SingleMode::ON
-			       || queue.single == SingleMode::ONE_SHOT)
-			      && !queue.repeat);
+	pc.LockSetBorderPause(queue.single != SingleMode::OFF && !queue.repeat);
 
 	/* if the last song is currently being played, the "next song"
 	   might change when repeat mode is toggled */
@@ -288,9 +286,7 @@ playlist::SetSingle(PlayerControl &pc, SingleMode status)
 	queue.single = status;
 
 
-	pc.LockSetBorderPause((queue.single == SingleMode::ON
-			       || queue.single == SingleMode::ONE_SHOT)
-			      && !queue.repeat);
+	pc.LockSetBorderPause(queue.single != SingleMode::OFF && !queue.repeat);
 
 	/* if the last song is currently being played, the "next song"
 	   might change when single mode is toggled */
@@ -359,9 +355,7 @@ playlist::GetNextPosition() const noexcept
 	if (current < 0)
 		return -1;
 
-	if ((queue.single == SingleMode::ON
-	     || queue.single == SingleMode::ONE_SHOT)
-	    && queue.repeat)
+	if (queue.single != SingleMode::OFF && queue.repeat)
 		return queue.OrderToPosition(current);
 	else if (queue.IsValidOrder(current + 1))
 		return queue.OrderToPosition(current + 1);

--- a/src/queue/Playlist.cxx
+++ b/src/queue/Playlist.cxx
@@ -23,6 +23,7 @@
 #include "PlaylistError.hxx"
 #include "player/Control.hxx"
 #include "DetachedSong.hxx"
+#include "SingleMode.hxx"
 #include "Log.hxx"
 
 #include <assert.h>
@@ -136,7 +137,7 @@ playlist::UpdateQueuedSong(PlayerControl &pc, const DetachedSong *prev)
 		? queue.GetNextOrder(current)
 		: 0;
 
-	if (next_order == 0 && queue.random && !queue.single) {
+	if (next_order == 0 && queue.random && queue.single == SingleMode::OFF) {
 		/* shuffle the song order again, so we get a different
 		   order each time the playlist is played
 		   completely */
@@ -257,7 +258,9 @@ playlist::SetRepeat(PlayerControl &pc, bool status)
 
 	queue.repeat = status;
 
-	pc.LockSetBorderPause(queue.single && !queue.repeat);
+	pc.LockSetBorderPause((queue.single == SingleMode::ON
+			       || queue.single == SingleMode::ONE_SHOT)
+			      && !queue.repeat);
 
 	/* if the last song is currently being played, the "next song"
 	   might change when repeat mode is toggled */
@@ -277,14 +280,17 @@ playlist_order(playlist &playlist)
 }
 
 void
-playlist::SetSingle(PlayerControl &pc, bool status)
+playlist::SetSingle(PlayerControl &pc, SingleMode status)
 {
 	if (status == queue.single)
 		return;
 
 	queue.single = status;
 
-	pc.LockSetBorderPause(queue.single && !queue.repeat);
+
+	pc.LockSetBorderPause((queue.single == SingleMode::ON
+			       || queue.single == SingleMode::ONE_SHOT)
+			      && !queue.repeat);
 
 	/* if the last song is currently being played, the "next song"
 	   might change when single mode is toggled */
@@ -353,7 +359,7 @@ playlist::GetNextPosition() const noexcept
 	if (current < 0)
 		return -1;
 
-	if (queue.single && queue.repeat)
+	if (queue.single == SingleMode::ON && queue.repeat)
 		return queue.OrderToPosition(current);
 	else if (queue.IsValidOrder(current + 1))
 		return queue.OrderToPosition(current + 1);
@@ -361,4 +367,13 @@ playlist::GetNextPosition() const noexcept
 		return queue.OrderToPosition(0);
 
 	return -1;
+}
+
+void
+playlist::BorderPause()
+{
+	if (queue.single == SingleMode::ONE_SHOT)
+		queue.single = SingleMode::OFF;
+
+	listener.OnQueueOptionsChanged();
 }

--- a/src/queue/Playlist.cxx
+++ b/src/queue/Playlist.cxx
@@ -359,7 +359,9 @@ playlist::GetNextPosition() const noexcept
 	if (current < 0)
 		return -1;
 
-	if (queue.single == SingleMode::ON && queue.repeat)
+	if ((queue.single == SingleMode::ON
+	     || queue.single == SingleMode::ONE_SHOT)
+	    && queue.repeat)
 		return queue.OrderToPosition(current);
 	else if (queue.IsValidOrder(current + 1))
 		return queue.OrderToPosition(current + 1);

--- a/src/queue/Playlist.hxx
+++ b/src/queue/Playlist.hxx
@@ -138,7 +138,7 @@ struct playlist {
 	 * This is the "BORDER_PAUSE" event handler.  It is invoked by
 	 * the player thread whenever playback goes into border pause.
 	 */
-	void BorderPause();
+	void BorderPause(PlayerControl &pc);
 
 protected:
 	/**

--- a/src/queue/Playlist.hxx
+++ b/src/queue/Playlist.hxx
@@ -20,6 +20,7 @@
 #ifndef MPD_PLAYLIST_HXX
 #define MPD_PLAYLIST_HXX
 
+#include "SingleMode.hxx"
 #include "queue/Queue.hxx"
 
 enum TagType : uint8_t;
@@ -132,6 +133,12 @@ struct playlist {
 	 * when it exits.
 	 */
 	void SyncWithPlayer(PlayerControl &pc);
+
+	/**
+	 * This is the "BORDER_PAUSE" event handler.  It is invoked by
+	 * the player thread whenever playback goes into border pause.
+	 */
+	void BorderPause();
 
 protected:
 	/**
@@ -347,11 +354,11 @@ public:
 
 	void SetRandom(PlayerControl &pc, bool new_value);
 
-	bool GetSingle() const {
+	SingleMode GetSingle() const {
 		return queue.single;
 	}
 
-	void SetSingle(PlayerControl &pc, bool new_value);
+	void SetSingle(PlayerControl &pc, SingleMode new_value);
 
 	bool GetConsume() const {
 		return queue.consume;

--- a/src/queue/PlaylistState.cxx
+++ b/src/queue/PlaylistState.cxx
@@ -154,7 +154,7 @@ playlist_state_restore(const char *line, TextFile &file,
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_REPEAT))) {
 			playlist.SetRepeat(pc, StringIsEqual(p, "1"));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_SINGLE))) {
-			playlist.SetSingle(pc, (SingleMode)atoi(p));
+			playlist.SetSingle(pc, SingleFromString(p));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_CONSUME))) {
 			playlist.SetConsume(StringIsEqual(p, "1"));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_CROSSFADE))) {
@@ -234,9 +234,10 @@ playlist_state_get_hash(const playlist &playlist,
 		 : 0) ^
 		((int)pc.GetCrossFade() << 20) ^
 		(unsigned(player_status.state) << 24) ^
+		/* note that this takes 2 bits */
+		((int)playlist.queue.single << 25) ^
 		(playlist.queue.random << 27) ^
 		(playlist.queue.repeat << 28) ^
-		((playlist.queue.single != SingleMode::OFF) << 29) ^
 		(playlist.queue.consume << 30) ^
 		(playlist.queue.random << 31);
 }

--- a/src/queue/PlaylistState.cxx
+++ b/src/queue/PlaylistState.cxx
@@ -89,7 +89,7 @@ playlist_state_save(BufferedOutputStream &os, const struct playlist &playlist,
 	os.Format(PLAYLIST_STATE_FILE_RANDOM "%i\n", playlist.queue.random);
 	os.Format(PLAYLIST_STATE_FILE_REPEAT "%i\n", playlist.queue.repeat);
 	os.Format(PLAYLIST_STATE_FILE_SINGLE "%i\n",
-			  (int)playlist.queue.single); // FIXME?
+			  (int)playlist.queue.single);
 	os.Format(PLAYLIST_STATE_FILE_CONSUME "%i\n", playlist.queue.consume);
 	os.Format(PLAYLIST_STATE_FILE_CROSSFADE "%i\n",
 		  (int)pc.GetCrossFade());
@@ -154,7 +154,6 @@ playlist_state_restore(const char *line, TextFile &file,
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_REPEAT))) {
 			playlist.SetRepeat(pc, StringIsEqual(p, "1"));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_SINGLE))) {
-			// playlist.SetSingle(pc, StringIsEqual(p, "1"));
 			playlist.SetSingle(pc, (SingleMode)atoi(p));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_CONSUME))) {
 			playlist.SetConsume(StringIsEqual(p, "1"));
@@ -237,7 +236,7 @@ playlist_state_get_hash(const playlist &playlist,
 		(unsigned(player_status.state) << 24) ^
 		(playlist.queue.random << 27) ^
 		(playlist.queue.repeat << 28) ^
-		(((int)playlist.queue.single > 0) << 29) ^ // XXX will work?
+		((playlist.queue.single != SingleMode::OFF) << 29) ^
 		(playlist.queue.consume << 30) ^
 		(playlist.queue.random << 31);
 }

--- a/src/queue/PlaylistState.cxx
+++ b/src/queue/PlaylistState.cxx
@@ -26,6 +26,7 @@
 #include "PlaylistState.hxx"
 #include "PlaylistError.hxx"
 #include "Playlist.hxx"
+#include "SingleMode.hxx"
 #include "queue/QueueSave.hxx"
 #include "fs/io/TextFile.hxx"
 #include "fs/io/BufferedOutputStream.hxx"
@@ -87,7 +88,8 @@ playlist_state_save(BufferedOutputStream &os, const struct playlist &playlist,
 
 	os.Format(PLAYLIST_STATE_FILE_RANDOM "%i\n", playlist.queue.random);
 	os.Format(PLAYLIST_STATE_FILE_REPEAT "%i\n", playlist.queue.repeat);
-	os.Format(PLAYLIST_STATE_FILE_SINGLE "%i\n", playlist.queue.single);
+	os.Format(PLAYLIST_STATE_FILE_SINGLE "%i\n",
+			  (int)playlist.queue.single); // FIXME?
 	os.Format(PLAYLIST_STATE_FILE_CONSUME "%i\n", playlist.queue.consume);
 	os.Format(PLAYLIST_STATE_FILE_CROSSFADE "%i\n",
 		  (int)pc.GetCrossFade());
@@ -152,7 +154,8 @@ playlist_state_restore(const char *line, TextFile &file,
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_REPEAT))) {
 			playlist.SetRepeat(pc, StringIsEqual(p, "1"));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_SINGLE))) {
-			playlist.SetSingle(pc, StringIsEqual(p, "1"));
+			// playlist.SetSingle(pc, StringIsEqual(p, "1"));
+			playlist.SetSingle(pc, (SingleMode)atoi(p));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_CONSUME))) {
 			playlist.SetConsume(StringIsEqual(p, "1"));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_CROSSFADE))) {
@@ -234,7 +237,7 @@ playlist_state_get_hash(const playlist &playlist,
 		(unsigned(player_status.state) << 24) ^
 		(playlist.queue.random << 27) ^
 		(playlist.queue.repeat << 28) ^
-		(playlist.queue.single << 29) ^
+		(((int)playlist.queue.single > 0) << 29) ^ // XXX will work?
 		(playlist.queue.consume << 30) ^
 		(playlist.queue.random << 31);
 }

--- a/src/queue/Queue.cxx
+++ b/src/queue/Queue.cxx
@@ -19,6 +19,7 @@
 
 #include "config.h"
 #include "Queue.hxx"
+#include "SingleMode.hxx"
 #include "DetachedSong.hxx"
 
 Queue::Queue(unsigned _max_length) noexcept
@@ -42,7 +43,7 @@ Queue::GetNextOrder(unsigned _order) const noexcept
 {
 	assert(_order < length);
 
-	if (single && repeat && !consume)
+	if (single != SingleMode::OFF && repeat && !consume)
 		return _order;
 	else if (_order + 1 < length)
 		return _order + 1;

--- a/src/queue/Queue.cxx
+++ b/src/queue/Queue.cxx
@@ -19,7 +19,6 @@
 
 #include "config.h"
 #include "Queue.hxx"
-#include "SingleMode.hxx"
 #include "DetachedSong.hxx"
 
 Queue::Queue(unsigned _max_length) noexcept

--- a/src/queue/Queue.hxx
+++ b/src/queue/Queue.hxx
@@ -22,6 +22,7 @@
 
 #include "Compiler.h"
 #include "IdTable.hxx"
+#include "SingleMode.hxx"
 #include "util/LazyRandomEngine.hxx"
 
 #include <algorithm>
@@ -92,7 +93,8 @@ struct Queue {
 	bool repeat = false;
 
 	/** play only current song. */
-	bool single = false;
+	// bool single = false;
+	SingleMode single = SingleMode::OFF;
 
 	/** remove each played files. */
 	bool consume = false;

--- a/src/queue/Queue.hxx
+++ b/src/queue/Queue.hxx
@@ -93,7 +93,6 @@ struct Queue {
 	bool repeat = false;
 
 	/** play only current song. */
-	// bool single = false;
 	SingleMode single = SingleMode::OFF;
 
 	/** remove each played files. */


### PR DESCRIPTION
Extends single mode.

If you enable one-shot single mode the music will be paused after current song and the single mode will be disabled. Useful if you don't like leaving playlist paused in the middle of a song and want to be able to resume it afterwards without disabling single mode manually.

I guess you could say this saves you one (or rather two) keystroke every time you want to leave playlist paused not in the middle of a song.