### PR TITLE
Fix for bogus output of the albumart command on 32bit platforms

### DIFF
--- a/src/command/FileCommands.cxx
+++ b/src/command/FileCommands.cxx
@@ -282,7 +282,7 @@ read_stream_art(Response &r, const char *uri, size_t offset)
 		return CommandResult::ERROR;
 	}
 
-	const size_t art_file_size = is->GetSize();
+	const offset_type art_file_size = is->GetSize();
 
 	constexpr size_t CHUNK_SIZE = 8192;
 	uint8_t buffer[CHUNK_SIZE];
@@ -291,7 +291,7 @@ read_stream_art(Response &r, const char *uri, size_t offset)
 	is->Seek(offset);
 	read_size = is->Read(&buffer, CHUNK_SIZE);
 
-	r.Format("size: %" PRIu64 "\n"
+	r.Format("size: %" PRIoffset "\n"
 			 "binary: %u\n",
 			 art_file_size,
 			 read_size


### PR DESCRIPTION
read_stream_art uses PRIu64 unconditionally with the Format method of a Respone instance to output a size_t typed value. If size_t is 32bit the output is garbeled. This patch uses offset_type and PRIoffset to make sure the format string and the type of the output value always match.