### PR TITLE
Fix debug build on macOS

### DIFF
--- a/src/CommandLine.cxx
+++ b/src/CommandLine.cxx
@@ -276,7 +276,8 @@ static void help(void)
 	       "Options:\n");
 
 	for (const auto &i : option_defs)
-		PrintOption(i);
+		if(i.HasDescription() == true) // hide hidden options from help print
+			PrintOption(i);
 
 	exit(EXIT_SUCCESS);
 }

--- a/src/Main.cxx
+++ b/src/Main.cxx
@@ -107,10 +107,6 @@
 #include <locale.h>
 #endif
 
-#ifdef __BLOCKS__
-#include <dispatch/dispatch.h>
-#endif
-
 #include <limits.h>
 
 static constexpr size_t KILOBYTE = 1024;
@@ -536,21 +532,8 @@ try {
 	daemonize_begin(options.daemon);
 #endif
 
-#ifdef __BLOCKS__
-	/* Runs the OS X native event loop in the main thread, and runs
-	   the rest of mpd_main on a new thread. This lets CoreAudio receive
-	   route change notifications (e.g. plugging or unplugging headphones).
-	   All hardware output on OS X ultimately uses CoreAudio internally.
-	   This must be run after forking; if dispatch is called before forking,
-	   the child process will have a broken internal dispatch state. */
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-		exit(mpd_main_after_fork(config));
-	});
-	dispatch_main();
-	return EXIT_FAILURE; // unreachable, because dispatch_main never returns
-#else
 	return mpd_main_after_fork(config);
-#endif
+
 } catch (const std::exception &e) {
 	LogError(e);
 	return EXIT_FAILURE;


### PR DESCRIPTION
With Grand Central Dispatch used in Main.cxx, debug builds on macOS crash as the IsInside() assertion gets triggered in the event loop. As a simple fix, usage of GCD is removed. Plugging and unplugging headphones or changes of the default output device was tested without issues. Whatever the original commit tried to fix by GCD probably does not need fixing anymore.