### PR TITLE
Some improvements for OSX output plugin

### DIFF
--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -715,13 +715,13 @@ void
 OSXOutput::Open(AudioFormat &audio_format)
 {
 	char errormsg[1024];
-#ifdef ENABLE_DSD
-	bool dop = dop_setting;
-#endif
 	Float64 sample_rate = initial_sample_rate;
 	PcmExport::Params params;
 	params.alsa_channel_order = true;
+#ifdef ENABLE_DSD
+	bool dop = dop_setting;
 	params.dop = false;
+#endif
 
 	memset(&asbd, 0, sizeof(asbd));
 	asbd.mFormatID = kAudioFormatLinearPCM;

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -138,15 +138,25 @@ AudioOutput *
 OSXOutput::Create(EventLoop &, const ConfigBlock &block)
 {
 	OSXOutput *oo = new OSXOutput(block);
-
-	AudioObjectPropertyAddress aopa = {
-		kAudioHardwarePropertyDefaultOutputDevice,
-		kAudioObjectPropertyScopeOutput,
-		kAudioObjectPropertyElementMaster
-	};
-
+	AudioObjectPropertyAddress aopa;
 	AudioDeviceID dev_id = kAudioDeviceUnknown;
 	UInt32 dev_id_size = sizeof(dev_id);
+	
+	if (oo->component_subtype == kAudioUnitSubType_SystemOutput)
+		// get system output dev_id if configured
+		aopa = {
+			kAudioHardwarePropertyDefaultSystemOutputDevice,
+			kAudioObjectPropertyScopeOutput,
+			kAudioObjectPropertyElementMaster
+		};
+	else
+		// fallback to default device initially (can still be changed by osx_output_set_device)
+		aopa = {
+			kAudioHardwarePropertyDefaultOutputDevice,
+			kAudioObjectPropertyScopeOutput,
+			kAudioObjectPropertyElementMaster
+		};
+
 	AudioObjectGetPropertyData(kAudioObjectSystemObject,
 				   &aopa,
 				   0,


### PR DESCRIPTION
Includes the following:
- use system output device (the device used for notifications) in case configured in mpd.conf (before default device was used e.g. for sample rate synchronization if configured whereas system device was used for output)
- use AudioOutputUnitStop to implement Pause()
- fix sample rate synchronization for rates below the minimum rate available on the device (before maximum rate was used in these cases)
- Get initial sampling rate of the output device and reset it when we close the output
- Fix build with DSD disabled (this was introduced by the DoP implementation sent earlier)