### PR TITLE
Bump minimum required version of Boost to 1.54

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -465,7 +465,7 @@ dnl ---------------------------------------------------------------------------
 dnl Mandatory Libraries
 dnl ---------------------------------------------------------------------------
 
-AX_BOOST_BASE([1.46],, [AC_MSG_ERROR([Boost not found])])
+AX_BOOST_BASE([1.54],, [AC_MSG_ERROR([Boost not found])])
 
 AC_ARG_ENABLE(icu,
 	AS_HELP_STRING([--enable-icu],

--- a/doc/user.xml
+++ b/doc/user.xml
@@ -111,7 +111,7 @@ cd mpd-version</programlisting>
 
         <listitem>
           <para>
-            <ulink url="http://www.boost.org/">Boost 1.46</ulink>
+            <ulink url="http://www.boost.org/">Boost 1.54</ulink>
           </para>
         </listitem>
 


### PR DESCRIPTION
lockfree library used by ALSA output plugin is part of Boost from version 1.53,
so this can be theoretically the lowest required version, however
there are issues which are resolved from 1.54 onward.

corresponding issue: #249 