### PR TITLE
Added always_on to streaming example in mpdconf.example

### DIFF
--- a/doc/mpdconf.example
+++ b/doc/mpdconf.example
@@ -249,6 +249,7 @@ input {
 ##	public		"no"			# optional
 ##	timeout		"2"			# optional
 ##	mixer_type      "software"		# optional
+##      always_on       "yes"                   # optional
 #}
 #
 # An example of a recorder output:


### PR DESCRIPTION
always_on yes|no 	
If set to yes, then MPD attempts to keep this audio output always open. This may be useful for streaming servers, when you don't want to disconnect all listeners even when playback is accidentally stopped.