### PR TITLE
Fix pause for OSX output plugin (delay one second)

### DIFF
--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -867,6 +867,10 @@ OSXOutput::Play(const void *chunk, size_t size)
 std::chrono::steady_clock::duration
 OSXOutput::Delay() const noexcept
 {
+	// Idle if paused
+	if(pause)
+		return std::chrono::seconds(1);
+	
 	return ring_buffer->write_available()
 		? std::chrono::steady_clock::duration::zero()
 		: std::chrono::milliseconds(MPD_OSX_BUFFER_TIME_MS / 4);


### PR DESCRIPTION
While working on a new Mac OS output plugin I found that Pause() was not reflected in Delay() function causing high CPU load. Apologies for the oversight in the first place...