### PR TITLE
add aac support 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,6 @@ src_mpd_LDADD = \
 	$(STORAGE_LIBS) \
 	$(PLAYLIST_LIBS) \
 	$(AVAHI_LIBS) \
-	$(DBUS_LIBS) \
 	$(LIBWRAP_LDFLAGS) \
 	$(SQLITE_LIBS) \
 	$(DECODER_LIBS) \
@@ -67,8 +66,6 @@ src_mpd_LDADD = \
 	$(ICU_LDADD) \
 	libutil.a \
 	$(SYSTEMD_DAEMON_LIBS)
-
-src_mpd_CPPFLAGS = $(AM_CPPFLAGS) $(DBUS_CFLAGS)
 
 src_mpd_SOURCES = \
 	src/Main.cxx src/Main.hxx
@@ -281,27 +278,6 @@ ALSA_SOURCES = \
 	src/lib/alsa/PeriodBuffer.hxx \
 	src/lib/alsa/NonBlock.cxx src/lib/alsa/NonBlock.hxx
 
-if ENABLE_DBUS
-noinst_LIBRARIES += libodbus.a
-libodbus_a_SOURCES = \
-	src/lib/dbus/AppendIter.hxx \
-	src/lib/dbus/AsyncRequest.hxx \
-	src/lib/dbus/Connection.cxx src/lib/dbus/Connection.hxx \
-	src/lib/dbus/Error.cxx src/lib/dbus/Error.hxx \
-	src/lib/dbus/Iter.hxx \
-	src/lib/dbus/Message.cxx src/lib/dbus/Message.hxx \
-	src/lib/dbus/PendingCall.hxx \
-	src/lib/dbus/ReadIter.hxx \
-	src/lib/dbus/ObjectManager.hxx \
-	src/lib/dbus/UDisks2.cxx src/lib/dbus/UDisks2.hxx \
-	src/lib/dbus/ScopeMatch.cxx src/lib/dbus/ScopeMatch.hxx \
-	src/lib/dbus/Types.hxx \
-	src/lib/dbus/Values.hxx \
-	src/lib/dbus/Glue.cxx src/lib/dbus/Glue.hxx \
-	src/lib/dbus/Watch.cxx src/lib/dbus/Watch.hxx
-libodbus_a_CPPFLAGS = $(AM_CPPFLAGS) $(DBUS_CFLAGS)
-endif
-
 #
 # Android native library
 #
@@ -512,7 +488,6 @@ libutil_a_SOURCES = \
 	src/util/FormatString.cxx src/util/FormatString.hxx \
 	src/util/Tokenizer.cxx src/util/Tokenizer.hxx \
 	src/util/TextFile.hxx \
-	src/util/TemplateString.hxx \
 	src/util/TimeParser.cxx src/util/TimeParser.hxx \
 	src/util/UriUtil.cxx src/util/UriUtil.hxx \
 	src/util/Manual.hxx \
@@ -792,7 +767,6 @@ libstorage_a_SOURCES = \
 	src/storage/FileInfo.hxx
 
 libstorage_a_CPPFLAGS = $(AM_CPPFLAGS) \
-	$(DBUS_CFLAGS) \
 	$(NFS_CFLAGS) \
 	$(SMBCLIENT_CFLAGS)
 
@@ -802,14 +776,6 @@ STORAGE_LIBS = \
 	$(EXPAT_LIBS) \
 	$(NFS_LIBS) \
 	$(SMBCLIENT_LIBS)
-
-if ENABLE_UDISKS
-libstorage_a_SOURCES += \
-	src/storage/plugins/UdisksStorage.cxx src/storage/plugins/UdisksStorage.hxx
-STORAGE_LIBS += \
-	$(DBUS_LIBS) \
-	libodbus.a
-endif
 
 if ENABLE_SMBCLIENT
 libstorage_a_SOURCES += \
@@ -850,7 +816,6 @@ libneighbor_a_SOURCES = \
 	src/neighbor/NeighborPlugin.hxx
 
 libneighbor_a_CPPFLAGS = $(AM_CPPFLAGS) \
-	$(DBUS_CFLAGS) \
 	$(UPNP_CFLAGS) \
 	$(SMBCLIENT_CFLAGS)
 
@@ -871,15 +836,6 @@ libneighbor_a_SOURCES += \
 NEIGHBOR_LIBS += \
 	$(EXPAT_LIBS) \
 	$(UPNP_LIBS)
-endif
-
-if ENABLE_UDISKS
-libneighbor_a_SOURCES += \
-	$(UDISKS_SOURCES) \
-	src/neighbor/plugins/UdisksNeighborPlugin.cxx src/neighbor/plugins/UdisksNeighborPlugin.hxx
-NEIGHBOR_LIBS += \
-	$(DBUS_LIBS) \
-	libodbus.a
 endif
 
 endif
@@ -1289,7 +1245,8 @@ ENCODER_LIBS = \
 	$(FLAC_LIBS) \
 	$(OPUS_LIBS) \
 	$(SHINE_LIBS) \
-	$(VORBISENC_LIBS)
+	$(VORBISENC_LIBS) \
+	$(FDKAAC_LIBS)
 
 libencoder_plugins_a_SOURCES = \
 	src/encoder/Configured.cxx src/encoder/Configured.hxx \
@@ -1346,6 +1303,12 @@ if ENABLE_SHINE
 libencoder_plugins_a_SOURCES += \
 	src/encoder/plugins/ShineEncoderPlugin.cxx \
 	src/encoder/plugins/ShineEncoderPlugin.hxx
+endif
+
+if ENABLE_FDKAAC
+libencoder_plugins_a_SOURCES += \
+	src/encoder/plugins/FdkaacEncoderPlugin.cxx \
+	src/encoder/plugins/FdkaacEncoderPlugin.hxx
 endif
 
 else
@@ -1976,7 +1939,6 @@ if ENABLE_NEIGHBOR_PLUGINS
 
 test_run_neighbor_explorer_SOURCES = \
 	src/Log.cxx src/LogBackend.cxx \
-	test/ShutdownHandler.cxx test/ShutdownHandler.hxx \
 	test/run_neighbor_explorer.cxx
 test_run_neighbor_explorer_LDADD = $(AM_LDADD) \
 	$(NEIGHBOR_LIBS) \

--- a/configure.ac
+++ b/configure.ac
@@ -627,21 +627,6 @@ if test x$enable_libwrap = xyes; then
 fi
 
 dnl ---------------------------------------------------------------------------
-dnl D-Bus
-dnl ---------------------------------------------------------------------------
-
-MPD_ENABLE_AUTO_PKG(dbus, DBUS, [dbus-1], [D-Bus support], [dbus-1 not found])
-
-AC_ARG_ENABLE(udisks,
-	AS_HELP_STRING([--enable-udisks],
-		[support for removable media via udisks2]),,
-	[enable_udisks=auto])
-
-MPD_DEPENDS([enable_udisks], [found_dbus], [support for removable media via udisks2], [dbus-1 not found])
-MPD_AUTO(udisks, [support for removable media via udisks2], [udisks not available], [found_udisks=yes])
-MPD_DEFINE_CONDITIONAL(enable_udisks, ENABLE_UDISKS, [support for removable media via udisks2])
-
-dnl ---------------------------------------------------------------------------
 dnl Metadata Plugins
 dnl ---------------------------------------------------------------------------
 
@@ -806,9 +791,6 @@ if test x$enable_neighbor_plugins = xauto; then
 		enable_neighbor_plugins=yes
 	fi
 	if test x$enable_upnp = xyes; then
-		enable_neighbor_plugins=yes
-	fi
-	if test x$enable_udisks = xyes; then
 		enable_neighbor_plugins=yes
 	fi
 fi
@@ -1113,6 +1095,7 @@ else
 	enable_shine_encoder=no
 	enable_wave_encoder=no
 	enable_flac_encoder=no
+	enable_fdkaac_encoder=no
 fi
 
 dnl ------------------------------- FLAC Encoder ------------------------------
@@ -1141,6 +1124,11 @@ dnl ------------------------------- WAVE Encoder ------------------------------
 MPD_DEFINE_CONDITIONAL(enable_wave_encoder, ENABLE_WAVE_ENCODER,
 	[PCM wave encoder plugin])
 
+dnl ------------------------------- FDK AAC Encoder ------------------------------
+MPD_ENABLE_AUTO_PKG(fdkaac_encoder, FDKAAC, [fdk-aac],
+	[FDK AAC encoder plugin], [libfdk-aac not found])
+
+
 dnl --------------------------- encoder plugins test --------------------------
 if test x$enable_vorbis_encoder != xno ||
 	test x$enable_opus != xno ||
@@ -1148,7 +1136,8 @@ if test x$enable_vorbis_encoder != xno ||
 	test x$enable_twolame_encoder != xno ||
 	test x$enable_flac_encoder != xno ||
 	test x$enable_shine_encoder != xno ||
-	test x$enable_wave_encoder != xno; then
+	test x$enable_wave_encoder != xno ||
+	test x$enable_fdkaac_encoder != xno; then
 	# at least one encoder plugin is enabled
 	enable_encoder=yes
 else
@@ -1519,8 +1508,6 @@ results(soxr, [libsoxr])
 results(libmpdclient, [libmpdclient])
 results(inotify, [inotify])
 results(sqlite, [SQLite])
-results(dbus, [DBUS])
-results(udisks, [UDISKS])
 
 printf '\nMetadata support:\n\t'
 results(id3,[ID3])
@@ -1558,6 +1545,7 @@ if
 		results(opus, [Opus])
 		results(twolame_encoder, [TwoLAME])
 		results(wave_encoder, [WAVE])
+		results(fdkaac_encoder, [FDKAAC])
 fi
 
 printf '\nStreaming support:\n\t'

--- a/src/encoder/EncoderList.cxx
+++ b/src/encoder/EncoderList.cxx
@@ -28,6 +28,7 @@
 #include "plugins/ShineEncoderPlugin.hxx"
 #include "plugins/LameEncoderPlugin.hxx"
 #include "plugins/TwolameEncoderPlugin.hxx"
+#include "plugins/FdkaacEncoderPlugin.hxx"
 
 #include <string.h>
 
@@ -53,6 +54,9 @@ const EncoderPlugin *const encoder_plugins[] = {
 #endif
 #ifdef ENABLE_SHINE
 	&shine_encoder_plugin,
+#endif
+#ifdef ENABLE_FDKAAC
+	&fdkaac_encoder_plugin,
 #endif
 	nullptr
 };

--- a/src/encoder/plugins/FdkaacEncoderPlugin.cxx
+++ b/src/encoder/plugins/FdkaacEncoderPlugin.cxx
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2003-2018 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "config.h"
+#include "FdkaacEncoderPlugin.hxx"
+#include "../EncoderAPI.hxx"
+#include "AudioFormat.hxx"
+#include "config/ConfigError.hxx"
+#include "util/NumberParser.hxx"
+#include "util/ReusableArray.hxx"
+#include "util/RuntimeError.hxx"
+
+#include <fdk-aac/aacenc_lib.h>
+
+#include <stdexcept>
+
+#include <assert.h>
+#include <string.h>
+
+class FdkaacEncoder final : public Encoder {
+	const AudioFormat audio_format;
+	HANDLE_AACENCODER *AacEncoder;
+	AACENC_InfoStruct *info;
+	int input_buffer_pos = 0;
+
+	ReusableArray<unsigned char, 32768> output_buffer;
+	ReusableArray<unsigned char, 32768> input_buffer;
+	unsigned char *output_begin = nullptr, *output_end = nullptr, *input_begin = nullptr;
+
+public:
+	FdkaacEncoder(const AudioFormat _audio_format,
+		    HANDLE_AACENCODER *_AacEncoder, AACENC_InfoStruct *_info)
+		:Encoder(false),audio_format(_audio_format),AacEncoder(_AacEncoder),info(_info) {}
+
+	~FdkaacEncoder() override;
+
+	/* virtual methods from class Encoder */
+	void Write(const void *data, size_t length) override;
+	size_t Read(void *dest, size_t length) override;
+};
+
+class PreparedFdkaacEncoder final : public PreparedEncoder {
+	HANDLE_AACENCODER *AacEncoder;
+	AUDIO_OBJECT_TYPE aot;
+	int bitrate;
+	int quality;
+	bool aacenc_afterburner;
+
+public:
+	PreparedFdkaacEncoder(const ConfigBlock &block);
+
+	/* virtual methods from class PreparedEncoder */
+	Encoder *Open(AudioFormat &audio_format) override;
+
+	const char *GetMimeType() const override {
+		fprintf(stderr, "GetMimeType\n");
+		return "audio/aac";
+	}
+};
+
+PreparedFdkaacEncoder::PreparedFdkaacEncoder(const ConfigBlock &block)
+{
+	const char *value;
+
+	value = block.GetBlockValue("aot", "lc");
+	if (value != nullptr) {
+		if(!strcmp(value, "lc")) {
+			aot=AOT_AAC_LC;
+		}else if(!strcmp(value, "he")) {
+			aot=AOT_SBR;
+		}else if(!strcmp(value, "hev2")) {
+			aot=AOT_PS;
+		}else if(!strcmp(value, "ld")) {
+			aot=AOT_ER_AAC_LD;
+		}else if(!strcmp(value, "eld")) {
+			aot=AOT_ER_AAC_ELD;
+		}else {
+			aot=AOT_AAC_LC;
+		}
+	}
+	aacenc_afterburner = block.GetBlockValue("aacenc_afterburner", true);
+	quality = block.GetBlockValue("quality", 0);
+	bitrate = block.GetBlockValue("bitrate", 128)*1000;
+}
+
+static PreparedEncoder *
+fdkaac_encoder_init(const ConfigBlock &block)
+{
+	return new PreparedFdkaacEncoder(block);
+}
+
+static void
+fdkaac_encoder_setup(HANDLE_AACENCODER *AacEncoder, AUDIO_OBJECT_TYPE aot, int bitrate,
+int quality, bool aacenc_afterburner, const AudioFormat &audio_format)
+{
+	if(aacEncoder_SetParam(*AacEncoder, AACENC_AOT, aot) != AACENC_OK) {
+		throw std::runtime_error("error setting fdkaac AOT");
+	}
+	if(aacEncoder_SetParam(*AacEncoder, AACENC_BITRATE, bitrate) != AACENC_OK) {
+		throw std::runtime_error("error setting fdkaac bitrate");
+	}
+	if(aacEncoder_SetParam(*AacEncoder, AACENC_BITRATEMODE, quality) != AACENC_OK) {
+		throw std::runtime_error("error setting fdkaac bitrate mode");
+	}
+	if(aacEncoder_SetParam(*AacEncoder, AACENC_SAMPLERATE, audio_format.sample_rate) != AACENC_OK) {
+		throw std::runtime_error("error setting fdkaac samplerate");
+	}
+	if(aacEncoder_SetParam(*AacEncoder, AACENC_CHANNELMODE, audio_format.channels) != AACENC_OK) {
+		throw std::runtime_error("error setting fdkaac channels");
+	}
+	if(aacEncoder_SetParam(*AacEncoder, AACENC_AFTERBURNER, aacenc_afterburner) != AACENC_OK) {
+		throw std::runtime_error("error setting fdkaac afterburner");
+	}
+	if (aacEncEncode(*AacEncoder, NULL, NULL, NULL, NULL) != AACENC_OK) {
+		throw std::runtime_error("Unable to initialize the encoder\n");
+	}
+}
+
+Encoder *
+PreparedFdkaacEncoder::Open(AudioFormat &audio_format)
+{
+	audio_format.format = SampleFormat::S16;
+	audio_format.channels = 2;
+	AACENC_InfoStruct *info = (AACENC_InfoStruct *)calloc(sizeof(AACENC_InfoStruct), 1);
+	AacEncoder = (HANDLE_AACENCODER*)calloc(sizeof(HANDLE_AACENCODER), 1);
+	AACENC_ERROR res = aacEncOpen ( AacEncoder, 0, 0);
+	if (res != AACENC_OK)
+		throw std::runtime_error("aacEncOpen failed");
+
+	try {
+		fdkaac_encoder_setup(AacEncoder, aot, bitrate, quality, aacenc_afterburner, audio_format);
+		if (aacEncInfo(*AacEncoder, info) != AACENC_OK) {
+			throw std::runtime_error("Unable to get the encoder info\n");
+		}
+	} catch (...) {
+		aacEncClose (AacEncoder);
+		free(AacEncoder);
+		free(info);
+		throw;
+	}
+
+	return new FdkaacEncoder(audio_format, AacEncoder, info);
+}
+
+FdkaacEncoder::~FdkaacEncoder()
+{
+	aacEncClose (AacEncoder);
+	free(AacEncoder);
+	free(info);
+}
+
+void
+FdkaacEncoder::Write(const void *data, size_t length)
+{
+	assert(output_begin == output_end);
+	const unsigned char *src = (const unsigned char *)data;
+
+	int frame_size = info->frameLength*audio_format.GetSampleSize()*audio_format.channels;	// bytes
+
+	int read_buffer_pos=0;
+	while(length) {
+
+		size_t bytes_to_copy = frame_size-input_buffer_pos;
+		if(bytes_to_copy > length) {
+			bytes_to_copy = length;	
+		}
+
+		const auto input_buf = input_buffer.Get(bytes_to_copy);
+		if(input_begin == nullptr) {
+			input_begin = input_buf;
+		}
+
+		memcpy(input_buf + input_buffer_pos, src, bytes_to_copy);
+
+		input_buffer_pos += bytes_to_copy;
+		read_buffer_pos += bytes_to_copy;
+		length -= bytes_to_copy;
+		src += bytes_to_copy;
+
+		if(input_buffer_pos == frame_size) {
+			const auto dest = output_buffer.Get(info->maxOutBufBytes);
+			int bytes_out = 0;
+
+			AACENC_BufDesc in_buf;
+			AACENC_BufDesc out_buf;
+			AACENC_InArgs in_args;
+			AACENC_OutArgs out_args;
+		
+			int in_identifier = IN_AUDIO_DATA;
+			int in_size = frame_size; 
+			int in_elem_size = 2;
+			void *in_ptr = input_begin; 
+			in_args.numInSamples = in_size / audio_format.GetSampleSize();
+			in_buf.numBufs = 1;
+			in_buf.bufs = &in_ptr;
+			in_buf.bufferIdentifiers = &in_identifier;
+			in_buf.bufSizes = &in_size;
+			in_buf.bufElSizes = &in_elem_size;
+
+			int out_identifier = OUT_BITSTREAM_DATA;
+			void *out_ptr = dest;
+			int out_size = info->maxOutBufBytes;
+			int out_elem_size = 1;
+			out_buf.numBufs = 1;
+			out_buf.bufs = &out_ptr;
+			out_buf.bufferIdentifiers = &out_identifier;
+			out_buf.bufSizes = &out_size;
+			out_buf.bufElSizes = &out_elem_size;
+
+			AACENC_ERROR res = aacEncEncode ( *AacEncoder, &in_buf, &out_buf, &in_args, &out_args );
+			if(res != AACENC_OK) {
+				if (res == AACENC_ENCODE_EOF) {
+					throw std::runtime_error("fdkaac encoder failed");
+				}
+			}
+			bytes_out = out_args.numOutBytes;
+
+			if(bytes_out) {
+				output_begin = dest;
+				output_end = dest + bytes_out;
+			}
+
+			input_begin = nullptr;
+			input_buffer_pos = 0;
+		}
+	}
+}
+
+size_t
+FdkaacEncoder::Read(void *dest, size_t length)
+{
+	const auto begin = output_begin;
+	assert(begin <= output_end);
+	const size_t remainning = output_end - begin;
+	if (length > remainning)
+		length = remainning;
+
+	memcpy(dest, begin, length);
+
+	output_begin = begin + length;
+	return length;
+}
+
+const EncoderPlugin fdkaac_encoder_plugin = {
+	"aac",
+	fdkaac_encoder_init,
+};

--- a/src/encoder/plugins/FdkaacEncoderPlugin.hxx
+++ b/src/encoder/plugins/FdkaacEncoderPlugin.hxx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2003-2018 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef MPD_ENCODER_FDKAAC_HXX
+#define MPD_ENCODER_FDKAAC_HXX
+
+extern const struct EncoderPlugin fdkaac_encoder_plugin;
+
+#endif

--- a/src/output/plugins/ShoutOutputPlugin.cxx
+++ b/src/output/plugins/ShoutOutputPlugin.cxx
@@ -118,6 +118,8 @@ ShoutOutput::ShoutOutput(const ConfigBlock &block)
 	unsigned shout_format;
 	if (StringIsEqual(mime_type, "audio/mpeg"))
 		shout_format = SHOUT_FORMAT_MP3;
+	else if (StringIsEqual(mime_type, "audio/aac"))
+		shout_format = SHOUT_FORMAT_AAC;
 	else
 		shout_format = SHOUT_FORMAT_OGG;
 


### PR DESCRIPTION
Requirements:
- Fraunhofer FDK AAC library 
- aac capable libshout from https://github.com/codders/libshout

New config parameters:
- aot: determines Audio Object Type (one of "lc", "he", "hev2"), default "lc"
- aacenc_afterburner: This parameter controls the use of the afterburner feature. The after- burner is a type of analysis by synthesis algorithm which increases the audio quality but also the required processing power (one of "no", "yes"), default "yes" 
- quality: Enables VBR (one of "0"..."8", depending on AOT), default 0 (CBR enabled)
- bitrate: Sets CBR, default "128"
