### PR TITLE
Enable OSX to set both hardware sample rate and bit depth 

### DIFF
--- a/doc/user.xml
+++ b/doc/user.xml
@@ -4440,18 +4440,6 @@ run</programlisting>
                   output device it is playing through, and no other program can access it.
                 </entry>
               </row>
-              <row>
-                <entry>
-                  <varname>sync_sample_rate</varname>
-                  <parameter>yes|no</parameter>
-                </entry>
-                <entry>
-                  Synchronize the sample rate. It will try to set the output device sample
-                  rate to the corresponding sample rate of the file playing. If the output
-                  device does not support the sample rate the track has, it will try to 
-                  select the best possible for each file.
-                </entry>
-              </row>
 	      <row>
                 <entry>
                   <varname>dop</varname>

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -838,9 +838,9 @@ OSXOutput::Open(AudioFormat &audio_format)
 		throw FormatRuntimeError("Unable to set frame size: %s",
 					 errormsg);
 	}
-	pcm_export->Open(audio_format.format, audio_format.channels, params);
 
 #ifdef ENABLE_DSD
+	pcm_export->Open(audio_format.format, audio_format.channels, params);
 	size_t ring_buffer_size = std::max<size_t>(buffer_frame_size,
 						   MPD_OSX_BUFFER_TIME_MS * pcm_export->GetFrameSize(audio_format) * asbd.mSampleRate / 1000);
 #else

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -892,11 +892,7 @@ OSXOutput::Play(const void *chunk, size_t size)
 std::chrono::steady_clock::duration
 OSXOutput::Delay() const noexcept
 {
-	// Idle if paused
-	if(pause)
-		return std::chrono::seconds(1);
-	
-	return ring_buffer->write_available()
+	return ring_buffer->write_available() && !pause
 		? std::chrono::steady_clock::duration::zero()
 		: std::chrono::milliseconds(MPD_OSX_BUFFER_TIME_MS / 4);
 }

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -36,6 +36,7 @@
 
 #include <CoreAudio/CoreAudio.h>
 #include <AudioUnit/AudioUnit.h>
+#include <AudioToolbox/AudioToolbox.h>
 #include <CoreServices/CoreServices.h>
 #include <boost/lockfree/spsc_queue.hpp>
 
@@ -192,7 +193,7 @@ OSXOutput::GetVolume()
 {
 	Float32 vol;
 	AudioObjectPropertyAddress aopa = {
-		.mSelector	= kAudioDevicePropertyVolumeScalar,
+		.mSelector	= kAudioHardwareServiceDeviceProperty_VirtualMasterVolume,
 		.mScope		= kAudioObjectPropertyScopeOutput,
 		.mElement	= kAudioObjectPropertyElementMaster,
 	};
@@ -217,7 +218,7 @@ void
 OSXOutput::SetVolume(unsigned new_volume) {
 	Float32 vol = new_volume / 100.0;
 	AudioObjectPropertyAddress aopa = {
-		.mSelector	= kAudioDevicePropertyVolumeScalar,
+		.mSelector	= kAudioHardwareServiceDeviceProperty_VirtualMasterVolume,
 		.mScope		= kAudioObjectPropertyScopeOutput,
 		.mElement	= kAudioObjectPropertyElementMaster
 	};

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -845,7 +845,7 @@ OSXOutput::Open(AudioFormat &audio_format)
 						   MPD_OSX_BUFFER_TIME_MS * pcm_export->GetFrameSize(audio_format) * asbd.mSampleRate / 1000);
 #else
 	size_t ring_buffer_size = std::max<size_t>(buffer_frame_size,
--						   MPD_OSX_BUFFER_TIME_MS * audio_format.GetFrameSize() * audio_format.sample_rate / 1000);
+						   MPD_OSX_BUFFER_TIME_MS * audio_format.GetFrameSize() * audio_format.sample_rate / 1000);
 #endif
 	ring_buffer = new boost::lockfree::spsc_queue<uint8_t>(ring_buffer_size);
 


### PR DESCRIPTION
This PR will fix #271.

special thanks to @coroner21 who contributed a nice way to score hardware supported format in #292

Also, The DSD related code are all guarded with ENABLE_DSD  flag.