### PR TITLE
Support timed_wait in microseconds level

### DIFF
--- a/src/thread/PosixCond.hxx
+++ b/src/thread/PosixCond.hxx
@@ -75,13 +75,13 @@ public:
 	}
 
 private:
-	bool timed_wait(PosixMutex &mutex, unsigned timeout_ms) noexcept {
+	bool timed_wait(PosixMutex &mutex, long timeout_us) noexcept {
 		struct timeval now;
 		gettimeofday(&now, nullptr);
 
 		struct timespec ts;
-		ts.tv_sec = now.tv_sec + timeout_ms / 1000;
-		ts.tv_nsec = (now.tv_usec + (timeout_ms % 1000) * 1000) * 1000;
+		ts.tv_sec = now.tv_sec + timeout_us / 1000000;
+		ts.tv_nsec = (now.tv_usec + (timeout_us % 1000000)) * 1000;
 		// Keep tv_nsec < 1E9 to prevent return of EINVAL
 		if (ts.tv_nsec >= 1000000000) {
 			ts.tv_nsec -= 1000000000;
@@ -94,13 +94,13 @@ private:
 public:
 	bool timed_wait(PosixMutex &mutex,
 			std::chrono::steady_clock::duration timeout) noexcept {
-		auto timeout_ms = std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count();
-		if (timeout_ms < 0)
-			timeout_ms = 0;
-		else if (timeout_ms > std::numeric_limits<unsigned>::max())
-			timeout_ms = std::numeric_limits<unsigned>::max();
+		auto timeout_us = std::chrono::duration_cast<std::chrono::microseconds>(timeout).count();
+		if (timeout_us < 0)
+			timeout_us = 0;
+		else if (timeout_us > std::numeric_limits<long>::max())
+			timeout_us = std::numeric_limits<long>::max();
 
-		return timed_wait(mutex, timeout_ms);
+		return timed_wait(mutex, timeout_us);
 	}
 };
 

--- a/src/thread/PosixCond.hxx
+++ b/src/thread/PosixCond.hxx
@@ -75,7 +75,7 @@ public:
 	}
 
 private:
-	bool timed_wait(PosixMutex &mutex, long timeout_us) noexcept {
+	bool timed_wait(PosixMutex &mutex, uint_least32_t timeout_us) noexcept {
 		struct timeval now;
 		gettimeofday(&now, nullptr);
 
@@ -97,8 +97,8 @@ public:
 		auto timeout_us = std::chrono::duration_cast<std::chrono::microseconds>(timeout).count();
 		if (timeout_us < 0)
 			timeout_us = 0;
-		else if (timeout_us > std::numeric_limits<long>::max())
-			timeout_us = std::numeric_limits<long>::max();
+		else if (timeout_us > std::numeric_limits<uint_least32_t>::max())
+			timeout_us = std::numeric_limits<uint_least32_t>::max();
 
 		return timed_wait(mutex, timeout_us);
 	}


### PR DESCRIPTION
Some Audio plugin (such as ALSA, and soon CoreAudio) already support microsecond level buffer time. However, current interval less than 1000 microseconds will cause a bug that the code treated as 0 ms.