### PR TITLE
[OSXOutputPlugin] Fix a bug that the stream sample rate is missing

### DIFF
--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -777,6 +777,7 @@ OSXOutput::Open(AudioFormat &audio_format)
 		asbd.mBitsPerChannel = audio_format.GetSampleSize() * 8;
 	}
 	asbd.mBytesPerPacket = audio_format.GetFrameSize();
+	asbd.mSampleRate = audio_format.sample_rate;
 
 #ifdef ENABLE_DSD
 	if (dop && audio_format.format == SampleFormat::DSD) {


### PR DESCRIPTION
the code here tried to guard DSD features behind ENABLE_DSD. However, the sample rate setting should be shared between two scenarios. 

https://github.com/MusicPlayerDaemon/MPD/commit/40a1ebee295c569521ea17ffdedc641d1aedd9cb#diff-ce7ecec9ea9ca3df90d9c290cb3ef9d4R795


The code runs fine if the dac supports the sample rate, as Mac OS  will use the device rate if stream rate is 0. 
However, when DAC is uncapable of processing the sample rate, a wrong rate (device rate) will be used for the stream rate.