### PR TITLE
decoder/sidplay: support basic and kernal rom (libsidplayfp)

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -1328,6 +1328,10 @@ C64 SID decoder based on `libsidplayfp <https://sourceforge.net/projects/sidplay
      - This is the default playing time in seconds for songs not in the songlength database, or in case you're not using a database. A value of 0 means play indefinitely.
    * - **filter yes|no**
      - Turns the SID filter emulation on or off.
+   * - **kernal**
+     - Only libsidplayfp. Roms are not embedded in libsidplayfp - please note https://sourceforge.net/p/sidplay-residfp/news/2013/01/released-libsidplayfp-100beta1/ But some SID tunes require rom images to play. Make C64 rom dumps from your own vintage gear or use rom files from Frodo or VICE emulation software tarballs. Absolute path to kernal rom image file.
+   * - **basic**
+     - Only libsidplayfp. Absolute path to basic rom image file.
 
 sndfile
 ~~~~~~~

--- a/src/decoder/plugins/SidplayDecoderPlugin.cxx
+++ b/src/decoder/plugins/SidplayDecoderPlugin.cxx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2017 The Music Player Daemon Project
+ * Copyright 2003-2018 The Music Player Daemon Project
  * http://www.musicpd.org
  *
  * This program is free software; you can redistribute it and/or modify
@@ -25,6 +25,10 @@
 #include "DetachedSong.hxx"
 #include "fs/Path.hxx"
 #include "fs/AllocatedPath.hxx"
+#ifdef HAVE_SIDPLAYFP
+#include "fs/io/FileReader.cxx"
+#include "util/RuntimeError.hxx"
+#endif
 #include "util/Macros.hxx"
 #include "util/StringFormat.hxx"
 #include "util/Domain.hxx"
@@ -65,6 +69,21 @@ static unsigned default_songlength;
 
 static bool filter_setting;
 
+#ifdef HAVE_SIDPLAYFP
+static constexpr unsigned rom_size = 8192;
+static uint8_t *kernal, *basic = nullptr;
+
+static void loadRom(const Path rom_path, uint8_t *dump)
+{
+	FileReader romDump(rom_path);
+	if (romDump.Read(dump, rom_size) != rom_size)
+	{
+		throw FormatRuntimeError
+			("Could not load rom dump '%s'", rom_path.c_str());
+	}
+}
+#endif
+
 static SidDatabase *
 sidplay_load_songlength_db(const Path path)
 {
@@ -100,6 +119,24 @@ sidplay_init(const ConfigBlock &block)
 
 	filter_setting = block.GetBlockValue("filter", true);
 
+#ifdef HAVE_SIDPLAYFP
+	/* read kernal rom dump file */
+	const auto kernal_path = block.GetPath("kernal");
+	if (!kernal_path.IsNull())
+	{
+		kernal = new uint8_t[rom_size];
+		loadRom(kernal_path, kernal);
+	}
+
+	/* read basic rom dump file */
+	const auto basic_path = block.GetPath("basic");
+	if (!basic_path.IsNull())
+	{
+		basic = new uint8_t[rom_size];
+		loadRom(basic_path, basic);
+	}
+#endif
+
 	return true;
 }
 
@@ -107,6 +144,11 @@ static void
 sidplay_finish() noexcept
 {
 	delete songlength_database;
+
+#ifdef HAVE_SIDPLAYFP
+	delete[] basic;
+	delete[] kernal;
+#endif
 }
 
 struct SidplayContainerPath {
@@ -202,6 +244,8 @@ sidplay_file_decode(DecoderClient &client, Path path_fs)
 
 #ifdef HAVE_SIDPLAYFP
 	sidplayfp player;
+
+	player.setRoms(kernal, basic, nullptr);
 #else
 	sidplay2 player;
 #endif


### PR DESCRIPTION
Some SID tunes - eg Commodore Basic Demos from HVSC - require basic and/or kernal rom to play but dumps are not embedded in libsidplayfp - please note https://sourceforge.net/p/sidplay-residfp/news/2013/01/released-libsidplayfp-100beta1/ 

Patch adds kernal and basic configuration parameters to load corresponding rom dumps.