### PR TITLE
Add support for unix socket to HttpdOutputPlugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1023,6 +1023,7 @@ libconf_a_SOURCES = \
 	src/config/Migrate.cxx src/config/Migrate.hxx \
 	src/config/Templates.cxx src/config/Templates.hxx \
 	src/config/Domain.cxx src/config/Domain.hxx \
+	src/config/Net.cxx src/config/Net.hxx \
 	src/config/Option.hxx
 
 # the Song library

--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,7 @@ ver 0.21 (not yet released)
   - shout: support the Shine encoder plugin
   - sndio: remove support for the broken RoarAudio sndio emulation
   - osx: initial support for DSD over PCM
+  - httpd_output: support for unix sockets
 * mixer
   - sndio: new mixer plugin
 * encoder

--- a/doc/user.rst
+++ b/doc/user.rst
@@ -1705,7 +1705,7 @@ It is highly recommended to configure a fixed format, because a stream cannot sw
    * - **port P**
      - Binds the HTTP server to the specified port.
    * - **bind_to_address ADDR**
-     - Binds the HTTP server to the specified address (IPv4 or IPv6). Multiple addresses in parallel are not supported.
+     - Binds the HTTP server to the specified address (IPv4, IPv6 or UNIX socket). Multiple addresses in parallel are not supported.
    * - **encoder NAME**
      - Chooses an encoder plugin. A list of encoder plugins can be found in the encoder plugin reference :ref:`encoder_plugins`.
    * - **max_clients MC**

--- a/src/Listen.cxx
+++ b/src/Listen.cxx
@@ -23,6 +23,7 @@
 #include "config/Param.hxx"
 #include "config/Data.hxx"
 #include "config/Option.hxx"
+#include "config/Net.hxx"
 #include "system/Error.hxx"
 #include "util/RuntimeError.hxx"
 #include "fs/AllocatedPath.hxx"
@@ -48,13 +49,7 @@ listen_add_config_param(ClientListener &listener,
 {
 	assert(param != nullptr);
 
-	if (0 == strcmp(param->value.c_str(), "any")) {
-		listener.AddPort(port);
-	} else if (param->value[0] == '/' || param->value[0] == '~') {
-		listener.AddPath(param->GetPath());
-	} else {
-		listener.AddHost(param->value.c_str(), port);
-	}
+	ServerSocketAddGeneric(listener, param->value.c_str(), port);
 }
 
 #ifdef ENABLE_SYSTEMD_DAEMON

--- a/src/config/Net.cxx
+++ b/src/config/Net.cxx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2003-2017 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "config.h"
+#include "Net.hxx"
+#include "event/ServerSocket.hxx"
+#include "Path.hxx"
+#include "fs/AllocatedPath.hxx"
+
+void
+ServerSocketAddGeneric(ServerSocket &server_socket, const char *address, unsigned int port)
+{
+	if (address == nullptr || 0 == strcmp(address, "any")) {
+		server_socket.AddPort(port);
+	} else if (address[0] == '/' || address[0] == '~') {
+		server_socket.AddPath(ParsePath(address));
+	} else {
+		server_socket.AddHost(address, port);
+	}
+}

--- a/src/config/Net.hxx
+++ b/src/config/Net.hxx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2003-2017 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef MPD_CONFIG_NET_HXX
+#define MPD_CONFIG_NET_HXX
+
+class ServerSocket;
+
+/**
+ * Sets the address or unix socket of a ServerSocket instance
+ * There are three possible ways
+ * 1) Set address to a valid ip address and specify port.
+ *    server_socket will listen on this address/port tuple.
+ * 2) Set address to null and specify port.
+ *    server_socket will listen on ANY address on that port.
+ * 3) Set address to a path of a unix socket. port is ignored.
+ *    server_socket will listen on this unix socket.
+ *
+ * Throws #std::runtime_error on error.
+ *
+ * @param server_socket the instance to modify
+ * @param address the address to listen on
+ * @param port the port to listen on
+ */
+void
+ServerSocketAddGeneric(ServerSocket &server_socket, const char *address, unsigned int port);
+
+#endif

--- a/src/output/plugins/httpd/HttpdOutputPlugin.cxx
+++ b/src/output/plugins/httpd/HttpdOutputPlugin.cxx
@@ -33,6 +33,7 @@
 #include "util/Domain.hxx"
 #include "util/DeleteDisposer.hxx"
 #include "Log.hxx"
+#include "config/Net.hxx"
 
 #include <assert.h>
 
@@ -58,17 +59,11 @@ HttpdOutput::HttpdOutput(EventLoop &_loop, const ConfigBlock &block)
 	genre = block.GetBlockValue("genre", "Set genre in config");
 	website = block.GetBlockValue("website", "Set website in config");
 
-	unsigned port = block.GetBlockValue("port", 8000u);
-
 	clients_max = block.GetBlockValue("max_clients", 0u);
 
 	/* set up bind_to_address */
 
-	const char *bind_to_address = block.GetBlockValue("bind_to_address");
-	if (bind_to_address != nullptr && strcmp(bind_to_address, "any") != 0)
-		AddHost(bind_to_address, port);
-	else
-		AddPort(port);
+	ServerSocketAddGeneric(*this, block.GetBlockValue("bind_to_address"), block.GetBlockValue("port", 8000u));
 
 	/* determine content type */
 	content_type = prepared_encoder->GetMimeType();


### PR DESCRIPTION
Just a quick patch to enable unix sockets.
I did no checking for HAVE_UN since this is already done in AddPath.
"Works fine for me".
For now socket permissions are hardcoded to 0666 but I will create a PR tomorrow (or so) for adding support to set socket permissions in mpd.conf...
