### PR TITLE
Use fchmod instead of chmod for unix sockets to prevent TOCTTOU

### DIFF
--- a/src/event/ServerSocket.cxx
+++ b/src/event/ServerSocket.cxx
@@ -39,7 +39,6 @@
 #include <string>
 #include <algorithm>
 
-#include <sys/stat.h>
 #include <string.h>
 #include <unistd.h>
 #include <assert.h>
@@ -183,13 +182,6 @@ OneServerSocket::Open()
 	auto _fd = socket_bind_listen(address.GetFamily(),
 				      SOCK_STREAM, 0,
 				      address, 5);
-
-#ifdef HAVE_UN
-	/* allow everybody to connect */
-
-	if (!path.IsNull())
-		fchmod(_fd.Get(), 0666);
-#endif
 
 	/* register in the EventLoop */	
 

--- a/src/event/ServerSocket.cxx
+++ b/src/event/ServerSocket.cxx
@@ -188,10 +188,10 @@ OneServerSocket::Open()
 	/* allow everybody to connect */
 
 	if (!path.IsNull())
-		chmod(path.c_str(), 0666);
+		fchmod(_fd.Get(), 0666);
 #endif
 
-	/* register in the EventLoop */
+	/* register in the EventLoop */	
 
 	SetFD(_fd.Release());
 }

--- a/src/net/SocketUtil.cxx
+++ b/src/net/SocketUtil.cxx
@@ -23,6 +23,8 @@
 #include "SocketError.hxx"
 #include "UniqueSocketDescriptor.hxx"
 
+#include <sys/stat.h>
+
 UniqueSocketDescriptor
 socket_bind_listen(int domain, int type, int protocol,
 		   SocketAddress address,
@@ -31,6 +33,14 @@ socket_bind_listen(int domain, int type, int protocol,
 	UniqueSocketDescriptor fd;
 	if (!fd.CreateNonBlock(domain, type, protocol))
 		throw MakeSocketError("Failed to create socket");
+
+
+#ifdef HAVE_UN
+	if (domain == AF_UNIX) {
+		/* allow everybody to connect */
+		fchmod(fd.Get(), 0666);
+	}
+#endif
 
 	if (!fd.SetReuseAddress())
 		throw MakeSocketError("setsockopt() failed");


### PR DESCRIPTION
Quick fix to use fchmod for unix sockets to prevent TOCTTOU (TimeOfCheckToTimeOfUse).
Its better to set permissions before the socket is finally created.

Also it would be good to let the user decide which permissions to apply instead of hardcoding 0666.
Have this working on a local branch, maybe worth another PR?

Btw:
How about calling unlink() for a (maybe existing) socket in socket_bind_listen() or SocketDescriptor::Bind(), instead of ServerSocket::AddPath()?
So we would have creation and deletion together. No disadvantage in the current approach, its just a feeling.