### PR TITLE
Revert change from chmod() to fchmod() for unix socket.

### DIFF
--- a/src/event/ServerSocket.cxx
+++ b/src/event/ServerSocket.cxx
@@ -184,6 +184,13 @@ OneServerSocket::Open()
 				      SOCK_STREAM, 0,
 				      address, 5);
 
+	#ifdef HAVE_UN
+		/* allow everybody to connect */
+
+		if (!path.IsNull())
+			chmod(path.c_str(), 0666);
+	#endif
+
 	/* register in the EventLoop */	
 
 	SetFD(_fd.Release());

--- a/src/net/SocketUtil.cxx
+++ b/src/net/SocketUtil.cxx
@@ -34,14 +34,6 @@ socket_bind_listen(int domain, int type, int protocol,
 	if (!fd.CreateNonBlock(domain, type, protocol))
 		throw MakeSocketError("Failed to create socket");
 
-
-#ifdef HAVE_UN
-	if (domain == AF_UNIX) {
-		/* allow everybody to connect */
-		fchmod(fd.Get(), 0666);
-	}
-#endif
-
 	if (!fd.SetReuseAddress())
 		throw MakeSocketError("setsockopt() failed");
 


### PR DESCRIPTION
Related to issue #337 
In case you prefer to not rollback a commit.
Otherwise please close this PR.

This does nothing but revert previous changes to use fchmod() on unix sockets.

Thanks