### PR TITLE
fixed setting unix socket permissions

### DIFF
--- a/src/event/ServerSocket.cxx
+++ b/src/event/ServerSocket.cxx
@@ -184,6 +184,13 @@ OneServerSocket::Open()
 				      SOCK_STREAM, 0,
 				      address, 5);
 
+#ifdef HAVE_UN
+	/* allow everybody to connect */
+
+	if (!path.IsNull())
+		chmod(path.c_str(), 0666);
+#endif
+
 	/* register in the EventLoop */	
 
 	SetFD(_fd.Release());

--- a/src/net/SocketUtil.cxx
+++ b/src/net/SocketUtil.cxx
@@ -34,11 +34,10 @@ socket_bind_listen(int domain, int type, int protocol,
 	if (!fd.CreateNonBlock(domain, type, protocol))
 		throw MakeSocketError("Failed to create socket");
 
-
 #ifdef HAVE_UN
 	if (domain == AF_UNIX) {
-		/* allow everybody to connect */
-		fchmod(fd.Get(), 0666);
+		/* Prevent access until right permissions are set */
+		fchmod(fd.Get(), 0);
 	}
 #endif
 

--- a/src/net/SocketUtil.hxx
+++ b/src/net/SocketUtil.hxx
@@ -32,6 +32,10 @@ class SocketAddress;
 /**
  * Creates a socket listening on the specified address.  This is a
  * shortcut for socket(), bind() and listen().
+ * When a unix socket is created (domain == AF_UNIX), its
+ * permissions will be stripped down to prevent unauthorized
+ * access. The caller is responsible to apply proper permissions
+ * at a later point.
  *
  * Throws #std::system_error on error.
  *


### PR DESCRIPTION
Call fchmod() first to prevent TOCTTOU.
Then apply permissions using hmod().

This is related to issue #337 
