### PR TITLE
Enable Curl plugin on win32

### DIFF
--- a/python/build/libs.py
+++ b/python/build/libs.py
@@ -364,6 +364,15 @@ curl = AutotoolsProject(
     patches='src/lib/curl/patches',
 )
 
+libexpat = AutotoolsProject(
+    'https://github.com/libexpat/libexpat/releases/download/R_2_2_6/expat-2.2.6.tar.bz2',
+    '17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2',
+    'lib/libexpat.a',
+    [
+        '--disable-shared', '--enable-static',
+    ],
+)
+
 libnfs = AutotoolsProject(
     'https://github.com/sahlberg/libnfs/archive/libnfs-3.0.0.tar.gz',
     '445d92c5fc55e4a5b115e358e60486cf8f87ee50e0103d46a02e7fb4618566a5',

--- a/win32/build.py
+++ b/win32/build.py
@@ -119,6 +119,8 @@ configure = [
 
     '--disable-icu',
 
+    'CXXFLAGS=-DCURL_STATICLIB',
+
 ] + configure_args
 
 from build.cmdline import concatenate_cmdline_variables

--- a/win32/build.py
+++ b/win32/build.py
@@ -86,6 +86,7 @@ thirdparty_libs = [
     liblame,
     ffmpeg,
     curl,
+    libexpat,
     libnfs,
     boost,
 ]


### PR DESCRIPTION
The Win32 instance of the Curl plugin had bit-rotted a bit when Expat became a requirement; this adds Expat to the Windows build, and fixes up a CFLAGS requirement when statically linking Curl.