### PR TITLE
decoder/sidplay: fix typo to avoid meson linker error (libsidplayfp)

### DIFF
--- a/src/decoder/plugins/SidplayDecoderPlugin.cxx
+++ b/src/decoder/plugins/SidplayDecoderPlugin.cxx
@@ -26,7 +26,7 @@
 #include "fs/Path.hxx"
 #include "fs/AllocatedPath.hxx"
 #ifdef HAVE_SIDPLAYFP
-#include "fs/io/FileReader.cxx"
+#include "fs/io/FileReader.hxx"
 #include "util/RuntimeError.hxx"
 #endif
 #include "util/Macros.hxx"


### PR DESCRIPTION
D'oh. My bad.