### PR TITLE
tag: new tag Label

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -770,6 +770,7 @@ When scanning or playing a song, :program:`MPD` parses its metadata. The followi
 * **performer**: the artist who performed the song.
 * **comment**: a human-readable comment about this song. The exact meaning of this tag is not well-defined.
 * **disc**: the decimal disc number in a multi-disc album.
+* **label**: the name of the label or publisher.
 * **musicbrainz_artistid**: the artist id in the `MusicBrainz <https://picard.musicbrainz.org/docs/mappings/>`_ database.
 * **musicbrainz_albumid**: the album id in the `MusicBrainz <https://picard.musicbrainz.org/docs/mappings/>`_ database.
 * **musicbrainz_albumartistid**: the album artist id in the `MusicBrainz <https://picard.musicbrainz.org/docs/mappings/>`_ database.

--- a/src/tag/Id3Scan.cxx
+++ b/src/tag/Id3Scan.cxx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2017 The Music Player Daemon Project
+ * Copyright 2003-2018 The Music Player Daemon Project
  * http://www.musicpd.org
  *
  * This program is free software; you can redistribute it and/or modify
@@ -38,12 +38,13 @@
 #include <string.h>
 #include <stdlib.h>
 
-#  ifndef ID3_FRAME_COMPOSER
-#    define ID3_FRAME_COMPOSER "TCOM"
-#  endif
-#  ifndef ID3_FRAME_DISC
-#    define ID3_FRAME_DISC "TPOS"
-#  endif
+#ifndef ID3_FRAME_COMPOSER
+#define ID3_FRAME_COMPOSER "TCOM"
+#endif
+
+#ifndef ID3_FRAME_DISC
+#define ID3_FRAME_DISC "TPOS"
+#endif
 
 #ifndef ID3_FRAME_ARTIST_SORT
 #define ID3_FRAME_ARTIST_SORT "TSOP"
@@ -59,6 +60,10 @@
 
 #ifndef ID3_FRAME_ORIGINAL_RELEASE_DATE
 #define ID3_FRAME_ORIGINAL_RELEASE_DATE "TDOR"
+#endif
+
+#ifndef ID3_FRAME_LABEL
+#define ID3_FRAME_LABEL "TPUB"
 #endif
 
 gcc_pure
@@ -316,6 +321,8 @@ scan_id3_tag(struct id3_tag *tag, TagHandler &handler) noexcept
 	tag_id3_import_comment(tag, ID3_FRAME_COMMENT, TAG_COMMENT,
 			       handler);
 	tag_id3_import_text(tag, ID3_FRAME_DISC, TAG_DISC,
+			    handler);
+	tag_id3_import_text(tag, ID3_FRAME_LABEL, TAG_LABEL,
 			    handler);
 
 	tag_id3_import_musicbrainz(tag, handler);

--- a/src/tag/Names.c
+++ b/src/tag/Names.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2017 The Music Player Daemon Project
+ * Copyright 2003-2018 The Music Player Daemon Project
  * http://www.musicpd.org
  *
  * This program is free software; you can redistribute it and/or modify
@@ -37,6 +37,7 @@ const char *const tag_item_names[TAG_NUM_OF_ITEM_TYPES] = {
 	[TAG_PERFORMER] = "Performer",
 	[TAG_COMMENT] = "Comment",
 	[TAG_DISC] = "Disc",
+	[TAG_LABEL] = "Label",
 
 	/* MusicBrainz tags from http://musicbrainz.org/doc/MusicBrainzTag */
 	[TAG_MUSICBRAINZ_ARTISTID] = "MUSICBRAINZ_ARTISTID",

--- a/src/tag/Type.h
+++ b/src/tag/Type.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2017 The Music Player Daemon Project
+ * Copyright 2003-2018 The Music Player Daemon Project
  * http://www.musicpd.org
  *
  * This program is free software; you can redistribute it and/or modify
@@ -51,6 +51,7 @@ enum TagType
 	TAG_PERFORMER,
 	TAG_COMMENT,
 	TAG_DISC,
+	TAG_LABEL,
 
 	TAG_MUSICBRAINZ_ARTISTID,
 	TAG_MUSICBRAINZ_ALBUMID,


### PR DESCRIPTION
Maps ID3Tag TPUB to the new Music Player daemon tag Label. According to ID3.org, TPUB is used for label or publisher information. Basically, a label is a company that sells music. Not very exciting so far. But in the field of electronic music there are specialized labels, eg. Rephlex or Central Processing Unit with its own unique style. Furthermore, artists in the field of electronic (dance) music like to use dozens or even more pseudonyms, but often remain loyal to a few labels. The new tag label can therefore simplify the search for the desired music.