### PR TITLE
Fix typo in build instructions

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -89,7 +89,7 @@ Now configure the source tree:
 
 .. code-block:: none
 
- meson . output/release --buildtype=debugpotimized -Db_ndebug=true
+ meson . output/release --buildtype=debugoptimized -Db_ndebug=true
 
 The following command shows a list of compile-time options:
 


### PR DESCRIPTION
Fix typo in new build instructions.