### PR TITLE
output/Alsa: workaround 'next is not a member' (Boost 1.67)

### DIFF
--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -41,6 +41,12 @@
 
 #include <alsa/asoundlib.h>
 
+// workaround ‘next’ is not a member of ‘boost’ build error from Boost 1.67
+#include <boost/version.hpp>
+#if BOOST_VERSION == 106700
+#include <boost/next_prior.hpp>
+#endif
+
 #include <boost/lockfree/spsc_queue.hpp>
 
 #include <string>


### PR DESCRIPTION
MPD from git/master does not build on 18.10 *buntus. Workaround for build error ‘next’ is not a member of ‘boost’ build error related to Boost 1.67.