### PR TITLE
fix compilation errors on Debian GNU/Hurd

### DIFF
--- a/src/thread/PosixCond.hxx
+++ b/src/thread/PosixCond.hxx
@@ -43,7 +43,7 @@ class PosixCond {
 	pthread_cond_t cond;
 
 public:
-#ifdef __GLIBC__
+#if defined(__GLIBC__) && !defined(__gnu_hurd__)
 	/* optimized constexpr constructor for pthread implementations
 	   that support it */
 	constexpr PosixCond() noexcept:cond(PTHREAD_COND_INITIALIZER) {}

--- a/src/thread/PosixMutex.hxx
+++ b/src/thread/PosixMutex.hxx
@@ -41,7 +41,7 @@ class PosixMutex {
 	pthread_mutex_t mutex;
 
 public:
-#ifdef __GLIBC__
+#if defined(__GLIBC__) && !defined(__gnu_hurd__)
 	/* optimized constexpr constructor for pthread implementations
 	   that support it */
 	constexpr PosixMutex():mutex(PTHREAD_MUTEX_INITIALIZER) {}


### PR DESCRIPTION
Apparently on hurd-i386 __GLIBC__ is defined, but the pthread
implementation is special and cannot be used with constexpr. Hence
exclude __gnu_hurd__.