### PR TITLE
include hostname in zeroconf_name (fixes #387)

### DIFF
--- a/doc/mpd.conf.5
+++ b/doc/mpd.conf.5
@@ -99,7 +99,8 @@ information will be published with Zeroconf.  The default is yes.
 .B zeroconf_name <name>
 If Zeroconf is enabled, this is the service name to publish.  This name should
 be unique to your local network, but name collisions will be properly dealt
-with.  The default is "Music Player".
+with.  The default is "Music Player @ %h", where %h will be replaced with the
+hostname of the machine running MPD.
 .TP
 .B audio_output
 See \fBDESCRIPTION\fP and the various \fBAUDIO OUTPUT PARAMETERS\fP sections

--- a/doc/mpdconf.example
+++ b/doc/mpdconf.example
@@ -151,9 +151,9 @@
 #zeroconf_enabled		"yes"
 #
 # The argument to this setting will be the Zeroconf / Avahi unique name for
-# this MPD server on the network.
+# this MPD server on the network. %h will be replaced with the hostname.
 #
-#zeroconf_name			"Music Player"
+#zeroconf_name			"Music Player @ %h"
 #
 ###############################################################################
 

--- a/doc/user.rst
+++ b/doc/user.rst
@@ -673,7 +673,8 @@ settings control this feature:
    * - **zeroconf_enabled yes|no**
      - Enables or disables this feature. Default is yes.
    * - **zeroconf_name NAME**
-     - The service name to publish via Zeroconf. The default is "Music Player".
+     - The service name to publish via Zeroconf. The default is "Music Player @ %h".
+       %h will be replaced with the hostname of the machine running :program:`MPD`.
 
 Advanced configuration
 **********************

--- a/src/zeroconf/ZeroconfGlue.cxx
+++ b/src/zeroconf/ZeroconfGlue.cxx
@@ -27,13 +27,16 @@
 #include "util/Domain.hxx"
 #include "Log.hxx"
 #include "util/Compiler.h"
+#include <unistd.h>
+#include <limits.h>
+#include <regex>
 
 static constexpr Domain zeroconf_domain("zeroconf");
 
 /* The default service name to publish
  * (overridden by 'zeroconf_name' config parameter)
  */
-#define SERVICE_NAME		"Music Player"
+#define SERVICE_NAME		"Music Player @ %h"
 
 #define DEFAULT_ZEROCONF_ENABLED 1
 
@@ -58,6 +61,11 @@ ZeroconfInit(const ConfigData &config, gcc_unused EventLoop &loop)
 
 	serviceName = config.GetString(ConfigOption::ZEROCONF_NAME,
 				       SERVICE_NAME);
+
+	char hostname[HOST_NAME_MAX+1];
+	gethostname(hostname, HOST_NAME_MAX);
+	std::string sName = std::regex_replace(serviceName, std::regex("%h"), hostname);
+	serviceName = sName.c_str();
 
 #ifdef HAVE_AVAHI
 	AvahiInit(loop, serviceName);


### PR DESCRIPTION
expand %h to the system hostname and default to a zeroconf string that
contains %h