### PR TITLE
doc/protocol.rst: update information about volume since -1 is not sent anymore

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -395,7 +395,7 @@ Querying ``MPD``'s status
     - ``consume`` [#since_0_15]_: ``0`` or ``1``
     - ``playlist``: 31-bit unsigned integer, the playlist version number
     - ``playlistlength``: integer, the length of the playlist
-    - ``state``: ``play``, ``stop, or ``pause``
+    - ``state``: ``play``, ``stop``, or ``pause``
     - ``song``: playlist song number of the current song stopped on or playing
     - ``songid``: playlist songid of the current song stopped on or playing
     - ``nextsong`` [#since_0_15]_: playlist song number of the next song to be played

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -388,7 +388,7 @@ Querying ``MPD``'s status
     Reports the current status of the player and the volume
     level.
 
-    - ``volume``: ``0-100`` or ``-1`` if the volume cannot be determined
+    - ``volume``: ``0-100``
     - ``repeat``: ``0`` or ``1``
     - ``random``: ``0`` or ``1``
     - ``single`` [#since_0_15]_: ``0``, ``1``, or ``oneshot`` [#since_0_21]_


### PR DESCRIPTION
Since 9cc37bdea2a55ca022c92902f943443badb94bce, MPD's status command does not emit the value -1 for the volume if the player is stopped. Instead, volume information is completely absent from the response sent by MPD.

Also, two backticks were missing.