### PR TITLE
test/meson.build: run_storage depends on event lib

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -239,6 +239,7 @@ if enable_database
     '../src/LogBackend.cxx',
     include_directories: inc,
     dependencies: [
+      event_dep,
       storage_glue_dep,
     ],
   )


### PR DESCRIPTION
test/run_storage.cxx depends on EventThread/EventLoop from libevent.a.
Depend on it explicitly. This addresses build failure with
-Dtest=true -Dcurl=disabled -Ddbus=disabled