### PR TITLE
change HTTP Version to a valid version

### DIFF
--- a/src/output/plugins/httpd/IcyMetaDataServer.cxx
+++ b/src/output/plugins/httpd/IcyMetaDataServer.cxx
@@ -31,7 +31,7 @@ icy_server_metadata_header(const char *name,
 			   const char *genre, const char *url,
 			   const char *content_type, int metaint)
 {
-	return FormatString("ICY 200 OK\r\n"
+	return FormatString("HTTP/1.1 200 OK\r\n"
 			    "icy-notice1:<BR>This stream requires an audio player!<BR>\r\n" /* TODO */
 			    "icy-notice2:MPD - The music player daemon<BR>\r\n"
 			    "icy-name: %s\r\n"             /* TODO */


### PR DESCRIPTION
Currently, Safari on iOS will not play the httpd output because the HTTP Version is not a valid version. 

This changes it to a valid version; and although I'm not entirely sure which is the correct version, `HTTP 1.1` works fine.