### PR TITLE
remove non-block call

### DIFF
--- a/src/system/EventPipe.cxx
+++ b/src/system/EventPipe.cxx
@@ -102,7 +102,7 @@ PoorSocketPair(int fd[2])
 	assert (fd != nullptr);
 
 	UniqueSocketDescriptor listen_socket;
-	if (!listen_socket.CreateNonBlock(AF_INET, SOCK_STREAM, IPPROTO_TCP))
+	if (!listen_socket.Create(AF_INET, SOCK_STREAM, IPPROTO_TCP))
 		throw MakeSocketError("Failed to create socket");
 
 	if (!listen_socket.Bind(IPv4Address(IPv4Address::Loopback(), 0)))


### PR DESCRIPTION
This is similar to https://github.com/MusicPlayerDaemon/MPD/commit/b177bffa6a5f1b69639b6cd759dcb16fdd76e5e2, in that it fixes the Windows issue of connecting to the open socket. Also, the `listen_socket` is set to `AcceptNonBlock` [after the connection](https://github.com/MusicPlayerDaemon/MPD/blob/98f92d828a72d5ce984d2d4ae2193a4533b280e5/src/system/EventPipe.cxx#L123) anyways.

This seems to fix #343 