### PR TITLE
Add APE mapping for album artist.

### DIFF
--- a/src/tag/ApeTag.cxx
+++ b/src/tag/ApeTag.cxx
@@ -29,6 +29,7 @@
 #include <string.h>
 
 static constexpr struct tag_table ape_tags[] = {
+        { "album artist", TAG_ALBUM_ARTIST },
 	{ "year", TAG_DATE },
 	{ nullptr, TAG_NUM_OF_ITEM_TYPES }
 };


### PR DESCRIPTION
"De-facto" field mappings are available at http://wiki.hydrogenaud.io/index.php?title=Tag_Mapping.