### PR TITLE
shout output plugin: add support for TLS

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -974,6 +974,8 @@ You must set a format.
      - Set the timeout for the shout connection in seconds. Defaults to 2 seconds.
    * - **protocol icecast2|icecast1|shoutcast**
      - Specifies the protocol that wil be used to connect to the server. The default is "icecast2".
+   * - **tls disabled|auto|auto_no_plain|rfc2818|rfc2817**
+     - Specifies what kind of TLS to use. The default is "disabled" (no TLS).
    * - **mount URI**
      - Mounts the :program:`MPD` stream in the specified URI.
    * - **user USERNAME**

--- a/src/output/plugins/ShoutOutputPlugin.cxx
+++ b/src/output/plugins/ShoutOutputPlugin.cxx
@@ -141,6 +141,25 @@ ShoutOutput::ShoutOutput(const ConfigBlock &block)
 		protocol = SHOUT_PROTOCOL_HTTP;
 	}
 
+	unsigned tls;
+	value = block.GetBlockValue("tls");
+	if (value != nullptr) {
+		if (0 == strcmp(value, "disabled"))
+			tls = SHOUT_TLS_DISABLED;
+		else if(0 == strcmp(value, "auto"))
+			tls = SHOUT_TLS_AUTO;
+		else if(0 == strcmp(value, "auto_no_plain"))
+			tls = SHOUT_TLS_AUTO_NO_PLAIN;
+		else if(0 == strcmp(value, "rfc2818"))
+			tls = SHOUT_TLS_RFC2818;
+		else if(0 == strcmp(value, "rfc2817"))
+			tls = SHOUT_TLS_RFC2817;
+		else
+			throw FormatRuntimeError("invalid shout TLS option \"%s\"", value);
+	} else {
+		tls = SHOUT_TLS_DISABLED;
+	}
+
 	if (shout_set_host(shout_conn, host) != SHOUTERR_SUCCESS ||
 	    shout_set_port(shout_conn, port) != SHOUTERR_SUCCESS ||
 	    shout_set_password(shout_conn, passwd) != SHOUTERR_SUCCESS ||
@@ -151,6 +170,7 @@ ShoutOutput::ShoutOutput(const ConfigBlock &block)
 	    shout_set_format(shout_conn, shout_format)
 	    != SHOUTERR_SUCCESS ||
 	    shout_set_protocol(shout_conn, protocol) != SHOUTERR_SUCCESS ||
+	    shout_set_tls(shout_conn, tls) != SHOUTERR_SUCCESS ||
 	    shout_set_agent(shout_conn, "MPD") != SHOUTERR_SUCCESS)
 		throw std::runtime_error(shout_get_error(shout_conn));
 


### PR DESCRIPTION
Adds an optional config option for the "shout" output to support use of libshout's `shout_set_tls` functionality. Defaults to "disabled", which is the same as the behavior before this patch: no attempt at TLS will be made.

To use with icecast, set `<ssl>1</ssl>` on a listen socket in the icecast configuration. When testing, I was successful in getting it to work using "auto", "auto_no_plain" and "rfc2818" modes with the [icecast 2.5 beta](https://ftp.osuosl.org/pub/xiph/releases/icecast/icecast-2.5-beta2.tar.gz). I also tested with icecast 2.4.3 with the same config but couldn't get any of the TLS modes to work.

[This Xiph wiki page](https://wiki.xiph.org/Icecast_Server/known_https_restrictions) seems to claim that TLS should work since icecast 2.4.1 but also that icecast 2.5 contains a bunch of TLS-related fixes, FWIW.

For testing with a self-signed cert I used OpenSSL's SSL_CERT_FILE environment variable. libshout has functions `shout_set_ca_directory` and `shout_set_ca_file` which could be used for the same purpose, but this patch doesn't support them. It appears that libshout can also support client certificate authentication through `shout_set_client_certificate` but I haven't tested it and it's not supported by this patch.