### PR TITLE
[OSXOutput] Throw an error when device not found

### DIFF
--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -637,11 +637,8 @@ osx_output_set_device(OSXOutput *oo)
 		}
 	}
 	if (i == numdevices) {
-		FormatWarning(osx_output_domain,
-			      "Found no audio device with name '%s' "
-			      "(will use default audio device)",
+                throw FormatRuntimeError("Found no audio device with name '%s' ",
 			      oo->device_name);
-		return;
 	}
 
 	status = AudioUnitSetProperty(oo->au,


### PR DESCRIPTION
Currently it falls back to system default device (either internal speaker or headphone) when device not found. 
I believe it is a better to fail in this case, to make it better aligned with platforms (such as alsa).