### PR TITLE
Fixed playlist filename zero-length bug

### DIFF
--- a/src/PlaylistFile.cxx
+++ b/src/PlaylistFile.cxx
@@ -149,6 +149,9 @@ LoadPlaylistFileInfo(PlaylistInfo &info,
 	} catch (...) {
 		return false;
 	}
+	
+	if (info.name.empty())
+		return false;
 
 	info.mtime = fi.GetModificationTime();
 	return true;


### PR DESCRIPTION
This is a fix for a bug which happens when returning playlists that are named '.m3u' via the `lsinfo` command.