### PR TITLE
Unix Sockets audio output

### DIFF
--- a/src/output/Registry.cxx
+++ b/src/output/Registry.cxx
@@ -23,6 +23,7 @@
 #include "plugins/AlsaOutputPlugin.hxx"
 #include "plugins/AoOutputPlugin.hxx"
 #include "plugins/FifoOutputPlugin.hxx"
+#include "plugins/SockOutputPlugin.hxx"
 #include "plugins/SndioOutputPlugin.hxx"
 #include "plugins/httpd/HttpdOutputPlugin.hxx"
 #include "plugins/HaikuOutputPlugin.hxx"
@@ -51,6 +52,9 @@ const AudioOutputPlugin *const audio_output_plugins[] = {
 #endif
 #ifdef HAVE_FIFO
 	&fifo_output_plugin,
+#endif
+#ifdef HAVE_SOCK
+  &sock_output_plugin,
 #endif
 #ifdef ENABLE_SNDIO
 	&sndio_output_plugin,

--- a/src/output/plugins/SockOutputPlugin.cxx
+++ b/src/output/plugins/SockOutputPlugin.cxx
@@ -1,0 +1,187 @@
+#include "SockOutputPlugin.hxx"
+#include "../OutputAPI.hxx"
+#include "../Timer.hxx"
+#include "fs/AllocatedPath.hxx"
+#include "fs/FileSystem.hxx"
+#include "fs/FileInfo.hxx"
+#include "util/Domain.hxx"
+#include "util/RuntimeError.hxx"
+#include "Log.hxx"
+#include "open.h"
+
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <errno.h>
+#include <unistd.h>
+
+class SockOutput final : AudioOutput {
+  const AllocatedPath path;
+  std::string path_utf8;
+
+  int fd = -1;
+  bool created = false;
+  Timer *timer;
+
+public:
+  SockOutput(const ConfigBlock &block);
+
+  ~SockOutput() {
+    CloseSock();
+  }
+
+  static AudioOutput *Create(EventLoop &,
+            const ConfigBlock &block) {
+    return new SockOutput(block);
+  }
+
+private:
+  void Create();
+  void Check();
+  void Delete();
+
+  void OpenSock();
+  void CloseSock();
+
+  void Open(AudioFormat &audio_format) override;
+  void Close() noexcept override;
+
+  std::chrono::steady_clock::duration Delay() const noexcept override;
+  size_t Play(const void *chunk, size_t size) override;
+  void Cancel() noexcept override;
+};
+
+static constexpr Domain sock_output_domain("sock_output");
+
+SockOutput::SockOutput(const ConfigBlock &block)
+  :AudioOutput(0),
+   path(block.GetPath("path"))
+{
+  if (path.IsNull())
+    throw std::runtime_error("No \"path\" parameter specified");
+
+  path_utf8 = path.ToUTF8();
+
+  OpenSock();
+}
+
+inline void
+SockOutput::Delete()
+{
+  FormatDebug(sock_output_domain,
+        "Removing Unix Socket \"%s\"", path_utf8.c_str());
+
+  try {
+    RemoveFile(path);
+  } catch (...) {
+    LogError(std::current_exception(), "Could not remove Unix Socket");
+    return;
+  }
+
+  created = false;
+}
+
+void
+SockOutput::CloseSock()
+{
+  close(fd);
+}
+
+inline void
+SockOutput::Create()
+{
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+
+  if (path.length + 1 > sizeof(addr.sun_path))
+    throw FormatRuntimeError("Cannot create Unix Socket, path is too long: \"%s\"",
+          path_utf8.c_str());
+
+  // TODO Check errors
+
+  fd = socket(AF_UNIX, SOCK_STREAM, 0);
+
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path)-1);
+  bind(fd, (struct sockaddr *) &addr, sizeof(addr));
+
+  created = true;
+}
+
+inline void
+SockOutput::Check()
+{
+  struct stat st;
+  if (!StatFile(path, st)) {
+    if (errno == ENOENT) {
+      /* Path doesn't exist */
+      Create();
+      return;
+    }
+
+    throw FormatErrno("Failed to stat Unix Socket \"%s\"",
+          path_utf8.c_str());
+  }
+
+  if (!S_ISSOCK(st.st_mode))
+    throw FormatRuntimeError("\"%s\" already exists, but is not a Unix Socket",
+          path_utf8.c_str());
+}
+
+inline void
+SockOutput::OpenSock()
+try {
+	Check();
+
+  // TODO Input and output
+} catch (...) {
+	CloseSock();
+	throw;
+}
+
+void
+SockOutput::Open(AudioFormat &audio_format)
+{
+  timer = new Timer(audio_format);
+}
+
+void
+SockOutput::Close() noexcept
+{
+  delete timer;
+}
+
+void
+SockOutput::Cancel() noexcept
+{
+  timer->Reset();
+
+  // TODO Flush socket
+}
+
+std::chrono::steady_clock::duration
+SockOutput::Delay() const noexcept
+{
+	return timer->IsStarted()
+		? timer->GetDelay()
+		: std::chrono::steady_clock::duration::zero();
+}
+
+size_t
+SockOutput::Play(const void *chunk, size_t size)
+{
+	if (!timer->IsStarted())
+		timer->Start();
+	timer->Add(size);
+
+	while (true) {
+		// TODO Write to all outputs
+	}
+}
+
+const struct AudioOutputPlugin sock_output_plugin = {
+	"sock",
+	nullptr,
+	&SockOutput::Create,
+	nullptr,
+};

--- a/src/output/plugins/SockOutputPlugin.hxx
+++ b/src/output/plugins/SockOutputPlugin.hxx
@@ -1,0 +1,6 @@
+#ifndef MPD_SOCK_OUTPUT_PLUGIN_HXX
+#define MPD_SOCK_OUTPUT_PLUGIN_HXX
+
+extern const struct AudioOutputPlugin sock_output_plugin;
+
+#endif

--- a/src/output/plugins/meson.build
+++ b/src/output/plugins/meson.build
@@ -26,6 +26,12 @@ if enable_fifo_output
   output_plugins_sources += 'FifoOutputPlugin.cxx'
 endif
 
+enable_sock_output = get_option('sock') and not is_windows
+conf.set('HAVE_SOCK', enable_sock_output)
+if enable_sock_output
+  output_plugins_sources += 'SockOutputPlugin.cxx'
+endif
+
 if is_haiku
   output_plugins_sources += 'HaikuOutputPlugin.cxx'
 endif


### PR DESCRIPTION
__WIP, don't review/merge__

 * Adds a new audio output plugin (`sock`)
 * Will be available on BSDs, Linux and macOS
 * Like, `fifo` but supports multiple clients

### Motivation

Most MPD visualizers work with the `fifo` audio output right now.
Imo, `fifo` has some limitations
 * Only one visualizer per named pipe
 * No way to transmit sample rate/stream config

Unix Sockets would fix those limitations and are fairly easy to implement.
Of course, client-side support will be needed.
I'm working on client-side support for `sock` on as many visualizers I can find.

### Features

This PR is based on `src/output/plugins/FifoOutputPlugin.cxx` and will aim to implement these features
 - [x] New audio output plugin (Name  `sock`/`SockOutputPlugin`)
 - [x] `SOCK_STREAM` socket in file system
 - [ ] Deletion of old/existing sockets on start
 - [ ] Raw audio stream to every connected client
 - [ ] Buffer overrun handling (Client reads too slow)
 - [ ] Buffer underrun handling? (Lag/Server misses a write)
 - [ ] Implement stream encoding

For maximum platform compatibility, the actual streaming is done over `write/O_NONBLOCK` by iterating over all FDs in a single thread. (As opposed to `epoll/kqueue`, or multithreading).
The stream is read-only. No `read` calls are made.