### PR TITLE
Ensure SEEK_SET is defined.

### DIFF
--- a/src/lib/cdio/Paranoia.hxx
+++ b/src/lib/cdio/Paranoia.hxx
@@ -43,6 +43,8 @@
 #include <stdexcept>
 #include <utility>
 
+#include <cstdio>
+
 class CdromDrive {
 	cdrom_drive_t *drv = nullptr;
 


### PR DESCRIPTION
Ensure SEEK_SET is set on systems where stdio.h is not pulled in by accident.