### PR TITLE
Allow local clients to load playlists in arbitrary absolute location

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -714,7 +714,9 @@ and without the `.m3u` suffix).
 Some of the commands described in this section can be used to
 run playlist plugins instead of the hard-coded simple
 `m3u` parser.  They can access playlists in
-the music directory (relative path including the suffix) or
+the music directory (relative path including the suffix),
+playlists in arbitrary location (absolute path including the suffix;
+allowed only for clients that are connected via UNIX domain socket), or
 remote playlists (absolute URI with a supported scheme).
 
 :command:`listplaylist {NAME}`

--- a/src/command/PlaylistCommands.cxx
+++ b/src/command/PlaylistCommands.cxx
@@ -38,6 +38,7 @@
 #include "util/UriUtil.hxx"
 #include "util/ConstBuffer.hxx"
 #include "util/ChronoUtil.hxx"
+#include "LocateUri.hxx"
 
 bool
 playlist_commands_available() noexcept
@@ -66,12 +67,17 @@ handle_save(Client &client, Request args, gcc_unused Response &r)
 CommandResult
 handle_load(Client &client, Request args, gcc_unused Response &r)
 {
+	const auto uri = LocateUri(args.front(), &client
+#ifdef ENABLE_DATABASE
+					   , nullptr
+#endif
+					   );
 	RangeArg range = args.ParseOptional(1, RangeArg::All());
 
 	const ScopeBulkEdit bulk_edit(client.GetPartition());
 
 	const SongLoader loader(client);
-	playlist_open_into_queue(args.front(),
+	playlist_open_into_queue(uri,
 				 range.start, range.end,
 				 client.GetPlaylist(),
 				 client.GetPlayerControl(), loader);
@@ -81,7 +87,11 @@ handle_load(Client &client, Request args, gcc_unused Response &r)
 CommandResult
 handle_listplaylist(Client &client, Request args, Response &r)
 {
-	const char *const name = args.front();
+	const auto name = LocateUri(args.front(), &client
+#ifdef ENABLE_DATABASE
+					   , nullptr
+#endif
+					   );
 
 	if (playlist_file_print(r, client.GetPartition(), SongLoader(client),
 				name, false))
@@ -93,7 +103,11 @@ handle_listplaylist(Client &client, Request args, Response &r)
 CommandResult
 handle_listplaylistinfo(Client &client, Request args, Response &r)
 {
-	const char *const name = args.front();
+	const auto name = LocateUri(args.front(), &client
+#ifdef ENABLE_DATABASE
+					   , nullptr
+#endif
+					   );
 
 	if (playlist_file_print(r, client.GetPartition(), SongLoader(client),
 				name, true))

--- a/src/playlist/PlaylistAny.cxx
+++ b/src/playlist/PlaylistAny.cxx
@@ -17,6 +17,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "LocateUri.hxx"
 #include "PlaylistAny.hxx"
 #include "PlaylistStream.hxx"
 #include "PlaylistMapper.hxx"
@@ -25,17 +26,26 @@
 #include "config.h"
 
 std::unique_ptr<SongEnumerator>
-playlist_open_any(const char *uri,
+playlist_open_any(const LocatedUri &located_uri,
 #ifdef ENABLE_DATABASE
 		  const Storage *storage,
 #endif
 		  Mutex &mutex)
 {
-	return uri_has_scheme(uri)
-		? playlist_open_remote(uri, mutex)
-		: playlist_mapper_open(uri,
+	switch (located_uri.type) {
+	case LocatedUri::Type::ABSOLUTE:
+		return playlist_open_remote(located_uri.canonical_uri, mutex);
+
+	case LocatedUri::Type::PATH:
+		return playlist_open_path(located_uri.path, mutex);
+
+	case LocatedUri::Type::RELATIVE:
+		return playlist_mapper_open(located_uri.canonical_uri,
 #ifdef ENABLE_DATABASE
 				       storage,
 #endif
 				       mutex);
+	}
+
+	gcc_unreachable();
 }

--- a/src/playlist/PlaylistAny.hxx
+++ b/src/playlist/PlaylistAny.hxx
@@ -34,7 +34,7 @@ class Storage;
  * music or playlist directory.
  */
 std::unique_ptr<SongEnumerator>
-playlist_open_any(const char *uri,
+playlist_open_any(const LocatedUri &located_uri,
 #ifdef ENABLE_DATABASE
 		  const Storage *storage,
 #endif

--- a/src/playlist/PlaylistQueue.cxx
+++ b/src/playlist/PlaylistQueue.cxx
@@ -18,6 +18,7 @@
  */
 
 #include "config.h"
+#include "LocateUri.hxx"
 #include "PlaylistQueue.hxx"
 #include "PlaylistAny.hxx"
 #include "PlaylistSong.hxx"
@@ -63,7 +64,7 @@ playlist_load_into_queue(const char *uri, SongEnumerator &e,
 }
 
 void
-playlist_open_into_queue(const char *uri,
+playlist_open_into_queue(const LocatedUri &uri,
 			 unsigned start_index, unsigned end_index,
 			 playlist &dest, PlayerControl &pc,
 			 const SongLoader &loader)
@@ -78,7 +79,7 @@ playlist_open_into_queue(const char *uri,
 	if (playlist == nullptr)
 		throw PlaylistError::NoSuchList();
 
-	playlist_load_into_queue(uri, *playlist,
+	playlist_load_into_queue(uri.canonical_uri, *playlist,
 				 start_index, end_index,
 				 dest, pc, loader);
 }

--- a/src/playlist/PlaylistQueue.hxx
+++ b/src/playlist/PlaylistQueue.hxx
@@ -49,7 +49,7 @@ playlist_load_into_queue(const char *uri, SongEnumerator &e,
  * play queue.
  */
 void
-playlist_open_into_queue(const char *uri,
+playlist_open_into_queue(const LocatedUri &uri,
 			 unsigned start_index, unsigned end_index,
 			 playlist &dest, PlayerControl &pc,
 			 const SongLoader &loader);

--- a/src/playlist/Print.cxx
+++ b/src/playlist/Print.cxx
@@ -18,6 +18,7 @@
  */
 
 #include "config.h"
+#include "LocateUri.hxx"
 #include "Print.hxx"
 #include "PlaylistAny.hxx"
 #include "PlaylistSong.hxx"
@@ -55,7 +56,7 @@ playlist_provider_print(Response &r,
 bool
 playlist_file_print(Response &r, Partition &partition,
 		    const SongLoader &loader,
-		    const char *uri, bool detail)
+		    const LocatedUri &uri, bool detail)
 {
 	Mutex mutex;
 
@@ -71,6 +72,6 @@ playlist_file_print(Response &r, Partition &partition,
 	if (playlist == nullptr)
 		return false;
 
-	playlist_provider_print(r, loader, uri, *playlist, detail);
+	playlist_provider_print(r, loader, uri.canonical_uri, *playlist, detail);
 	return true;
 }

--- a/src/playlist/Print.hxx
+++ b/src/playlist/Print.hxx
@@ -34,6 +34,6 @@ struct Partition;
 bool
 playlist_file_print(Response &r, Partition &partition,
 		    const SongLoader &loader,
-		    const char *uri, bool detail);
+		    const LocatedUri &uri, bool detail);
 
 #endif


### PR DESCRIPTION
Adresses #455.

Before this patch, 
```
load /foo/bar.m3u
```
always fails with `ACK [50@0] {load} No such playlist`

With this patch we have
- remote clients: always fails with `ACK [4@0] {} Access denied`
- local clients:
    - success `OK` if the files exists
    - otherwise fails `ACK [52@0] {} Failed to access /foo/bar.m3u: No such file or directory`.

Behaviour for relative paths and remote URI is not changed.
