### PR TITLE
meson: qobuz plugin needs gpg-error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ ver 0.21.6 (not yet released)
 * input
   - cdio_paranoia: fix build failure due to missing #include
 * support abstract sockets on Linux
+* require Meson 0.49.0 for native libgcrypt-config support
 
 ver 0.21.5 (2019/02/22)
 * protocol

--- a/doc/user.rst
+++ b/doc/user.rst
@@ -54,7 +54,7 @@ Download the source tarball from the `MPD home page <https://musicpd.org>`_ and 
 In any case, you need:
 
 * a C++14 compiler (e.g. gcc 6.0 or clang 3.9)
-* `Meson 0.47.2 <http://mesonbuild.com/>`__ and `Ninja
+* `Meson 0.49.0 <http://mesonbuild.com/>`__ and `Ninja
   <https://ninja-build.org/>`__
 * Boost 1.58
 * pkg-config 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'mpd',
   ['c', 'cpp'],
   version: '0.21.6',
-  meson_version: '>= 0.47.2',
+  meson_version: '>= 0.49.0',
   default_options: [
     'c_std=c99',
     'cpp_std=c++14'

--- a/src/lib/gcrypt/meson.build
+++ b/src/lib/gcrypt/meson.build
@@ -1,4 +1,17 @@
+# Since version 0.49.0 Meson has native libgcrypt dependency support, which has
+# the advantage over find_library() as it uses libgcrypt-config to query the
+# required linker flags.
+# However, we still need to use find_library() first, to prevent Meson
+# falsly assuming a target libgcrypt is available in case there is no
+# libgcrypt-config entry in the cross file and libgcrypt is installed on the
+# host. In this case, Meson will falsly use the native libgcrypt-config and
+# will falsly assume it has found the gcrypt library for the target.
+#
+# See: https://github.com/MusicPlayerDaemon/MPD/pull/495
 gcrypt_dep = c_compiler.find_library('gcrypt', required: get_option('qobuz'))
+if gcrypt_dep.found()
+	gcrypt_dep = dependency('libgcrypt')
+endif
 if not gcrypt_dep.found()
   subdir_done()
 endif


### PR DESCRIPTION
Latest version 1.8.4 of libgcrypt [requires](https://github.com/gpg/libgcrypt/blob/libgcrypt-1.8.4/configure.ac#L699) libgpg-error. When building mpd (version 0.21.5) statically with the Qobuz plugin enabled, the final linking fails because of the missing libgpg-error dependency, e.g.:

```
/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-visibility.o): In function `gcry_strerror':
visibility.c:(.text+0x14): undefined reference to `gpg_strerror'
```

<details><summary>Full build log (using the cross-compiling tool Buildroot):</summary>
<p>

```
buildroot ) make mpd-dirclean mpd
rm -Rf /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5
/usr/bin/make -j1 O=/home/joerg/Development/git/buildroot/output HOSTCC="/usr/bin/gcc" HOSTCXX="/usr/bin/g++" syncconfig
make[1]: Entering directory '/home/joerg/Development/git/buildroot'
make[1]: Leaving directory '/home/joerg/Development/git/buildroot'
mpd-0.21.5.tar.xz: OK (sha256: 2ea9f0eb3a7bdae5d705adf4e8ec45ef38b5b9ddf133f32b8926dd4e205b0ef9)
>>> mpd 0.21.5 Extracting
xzcat /home/joerg/Development/git/buildroot/dl/mpd/mpd-0.21.5.tar.xz | /home/joerg/Development/git/buildroot/output/host/bin/tar --strip-components=1 -C /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5   -xf -
>>> mpd 0.21.5 Patching
>>> mpd 0.21.5 Configuring
rm -rf /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5//build
mkdir -p /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5//build
sed -e "s%@TARGET_CROSS@%/home/joerg/Development/git/buildroot/output/host/bin/arm-linux-%g" -e "s%@TARGET_ARCH@%arm%g" -e "s%@TARGET_CPU@%arm926ej-s%g" -e "s%@TARGET_ENDIAN@%"little"%g" -e "s%@TARGET_CFLAGS@%`printf '"%s", ' -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -static`%g" -e "s%@TARGET_LDFLAGS@%`printf '"%s", '  -static`%g" -e "s%@TARGET_CXXFLAGS@%`printf '"%s", ' -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -static -static`%g" -e "s%@HOST_DIR@%/home/joerg/Development/git/buildroot/output/host%g" package/meson/cross-compilation.conf.in > /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5//build/cross-compilation.conf
PATH="/home/joerg/Development/git/buildroot/output/host/bin:/home/joerg/Development/git/buildroot/output/host/sbin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl"  PYTHONNOUSERSITE=y /home/joerg/Development/git/buildroot/output/host/bin/meson --prefix=/usr --libdir=lib --default-library=static --buildtype=release --cross-file=/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5//build/cross-compilation.conf -Dzeroconf=disabled -Dicu=disabled -Dalsa=disabled -Dao=disabled -Daudiofile=disabled -Dbzip2=disabled -Dcdio_paranoia=disabled -Dcurl=enabled -Ddsd=false -Dfaad=disabled -Dffmpeg=disabled -Dflac=disabled -Dhttpd=false -Djack=disabled -Dlame=disabled -Dlibmpdclient=disabled -Dmms=disabled -Dnfs=disabled -Dsmbclient=disabled -Dlibsamplerate=disabled -Dsndfile=disabled -Dsoxr=disabled -Dmad=disabled -Dmpg123=disabled -Dmpcdec=disabled -Dneighbor=false -Dopus=disabled -Doss=disabled -Dpulse=disabled -Dqobuz=enabled -Dshout=disabled -Dsoundcloud=disabled -Dsqlite=disabled -Dtcp=true -Dtidal=disabled -Dtremor=disabled -Dtwolame=disabled -Dupnp=disabled -Dvorbis=disabled -Dvorbisenc=disabled -Dwavpack=disabled /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/ /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5//build
The Meson build system
Version: 0.49.2
Source dir: /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5
Build dir: /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build
Build type: cross build
Project name: mpd
Project version: 0.21.5
Native C compiler: ccache cc (gcc 8.2.1 "cc (GCC) 8.2.1 20181127")
Cross C compiler: /home/joerg/Development/git/buildroot/output/host/bin/arm-linux-gcc (gcc 7.4.0)
Native C++ compiler: ccache c++ (gcc 8.2.1 "c++ (GCC) 8.2.1 20181127")
Cross C++ compiler: /home/joerg/Development/git/buildroot/output/host/bin/arm-linux-g++ (gcc 7.4.0)
Host machine cpu family: arm
Host machine cpu: arm926ej-s
Target machine cpu family: arm
Target machine cpu: arm926ej-s
Build machine cpu family: x86_64
Build machine cpu: x86_64
Found git repository at /home/joerg/Development/git/buildroot
Compiler for C++ supports arguments -Wall: YES
Compiler for C++ supports arguments -Wextra: YES
Compiler for C++ supports arguments -fvisibility=hidden: YES
Compiler for C++ supports arguments -ffast-math: YES
Compiler for C++ supports arguments -ftree-vectorize: YES
Compiler for C++ supports arguments -fno-threadsafe-statics: YES
Compiler for C++ supports arguments -fmerge-all-constants: YES
Compiler for C++ supports arguments -Wmissing-declarations: YES
Compiler for C++ supports arguments -Wshadow: YES
Compiler for C++ supports arguments -Wpointer-arith: YES
Compiler for C++ supports arguments -Wcast-qual: YES
Compiler for C++ supports arguments -Wwrite-strings: YES
Compiler for C++ supports arguments -Wsign-compare: YES
Compiler for C++ supports arguments -Wno-non-virtual-dtor -Wnon-virtual-dtor: YES
Compiler for C++ supports arguments -Wno-noexcept-type -Wnoexcept-type: YES
Compiler for C supports arguments -Wall: YES
Compiler for C supports arguments -Wextra: YES
Compiler for C supports arguments -fvisibility=hidden: YES
Compiler for C supports arguments -ffast-math: YES
Compiler for C supports arguments -ftree-vectorize: YES
Compiler for C supports arguments -Wmissing-prototypes: YES
Compiler for C supports arguments -Wshadow: YES
Compiler for C supports arguments -Wpointer-arith: YES
Compiler for C supports arguments -Wstrict-prototypes: YES
Compiler for C supports arguments -Wcast-qual: YES
Compiler for C supports arguments -Wwrite-strings: YES
Compiler for C supports arguments -pedantic: YES
Compiler for C supports arguments -ffunction-sections: YES
Compiler for C supports arguments -fdata-sections: YES
Compiler for C++ supports link arguments -Wl,--gc-sections: YES
Has header "locale.h" : YES
Checking for function "getpwnam_r" : YES
Checking for function "getpwuid_r" : YES
Checking for function "initgroups" : YES
Checking for function "fnmatch" : YES
Checking for function "strndup" : YES
Checking for function "strcasestr" : YES
Checking for function "syslog" : YES
Cross dependency Boost found: YES 1.69
Cross dependency threads found: YES 
Checking for function "pthread_setname_np" with dependency threads: YES
Cross dependency dbus-1 found: NO (tried pkgconfig and cmake)
Dependency icu-i18n skipped: feature icu disabled
Checking for function "iconv" : YES
Dependency smbclient skipped: feature smbclient disabled
Cross dependency zlib found: NO (tried pkgconfig and cmake)
Dependency alsa skipped: feature alsa disabled
Cross dependency libcurl found: YES 7.64.0
Cross dependency expat found: NO (tried pkgconfig and cmake)
Dependency libavformat skipped: feature ffmpeg disabled
Dependency libavcodec skipped: feature ffmpeg disabled
Dependency libavutil skipped: feature ffmpeg disabled
Library gcrypt found: YES
Dependency libnfs skipped: feature nfs disabled
Cross dependency libpcre found: NO (tried pkgconfig and cmake)
Dependency libpulse skipped: feature pulse disabled
Library sndio found: NO
Dependency sqlite3 skipped: feature sqlite disabled
Cross dependency libsystemd found: NO (tried pkgconfig and cmake)
Dependency libupnp skipped: feature upnp disabled
Cross dependency yajl found: YES 2.1.0
Header <sys/socket.h> has symbol "AF_INET6" : YES
Header <sys/socket.h> has symbol "struct ucred" : YES
Header <sys/socket.h> has symbol "SO_PEERCRED" : YES
Checking for function "getpeereid" : NO
Cross dependency id3tag found: NO (tried pkgconfig and cmake)
Cross dependency libchromaprint found: NO (tried pkgconfig and cmake)
Dependency samplerate skipped: feature libsamplerate disabled
Dependency soxr skipped: feature soxr disabled
Dependency libcdio_paranoia skipped: feature cdio_paranoia disabled
Dependency libmms skipped: feature mms disabled
Cross dependency libiso9660 found: NO (tried pkgconfig and cmake)
Library bz2 skipped: feature bzip2 disabled
Cross dependency zziplib found: NO (tried pkgconfig and cmake)
Dependency ao skipped: feature ao disabled
Dependency jack skipped: feature jack disabled
Cross dependency openal found: NO (tried pkgconfig and cmake)
Dependency shout skipped: feature shout disabled
Dependency flac skipped: feature flac disabled
Dependency opus skipped: feature opus disabled
Dependency vorbis skipped: feature vorbis disabled
Dependency vorbisidec skipped: feature tremor disabled
Cross dependency adplug found: NO (tried pkgconfig and cmake)
Cross dependency fluidsynth found: NO (tried pkgconfig and cmake)
Dependency audiofile skipped: feature audiofile disabled
Library faad skipped: feature faad disabled
Library gme found: NO
Library mad skipped: feature mad disabled
Cross dependency libmikmod found: NO (tried pkgconfig and cmake)
Cross dependency libmodplug found: NO (tried pkgconfig and cmake)
Library mpcdec skipped: feature mpcdec disabled
Dependency libmpg123 skipped: feature mpg123 disabled
Dependency sndfile skipped: feature sndfile disabled
Dependency wavpack skipped: feature wavpack disabled
Library WildMidi found: NO
Cross dependency libsidplayfp found: NO (tried pkgconfig and cmake)
Cross dependency libsidplay2 found: NO (tried pkgconfig and cmake)
Library mp3lame skipped: feature lame disabled
Dependency twolame skipped: feature twolame disabled
Cross dependency shine found: NO (tried pkgconfig and cmake)
Dependency libmpdclient skipped: feature libmpdclient disabled
Configuring config.h using configuration
Build targets in project: 44
Found ninja-1.9.0 at /home/joerg/Development/git/buildroot/output/host/bin/ninja
>>> mpd 0.21.5 Building
PATH="/home/joerg/Development/git/buildroot/output/host/bin:/home/joerg/Development/git/buildroot/output/host/sbin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl"  PYTHONNOUSERSITE=y /home/joerg/Development/git/buildroot/output/host/bin/ninja  -j9  -C /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5//build
ninja: Entering directory `/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5//build'
[74/439] Compiling C++ object 'src/event/e796227@@event@sta/Loop.cxx.o'.
In file included from /home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/boost/intrusive/rbtree.hpp:23:0,
                 from /home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/boost/intrusive/set.hpp:20,
                 from ../src/event/Loop.hxx:34,
                 from ../src/event/Loop.cxx:20:
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/boost/intrusive/bstree.hpp: In member function ‘boost::intrusive::bstree_impl<ValueTraits, VoidOrKeyOfValue, VoidOrKeyComp, SizeType, ConstantTimeSize, AlgoType, HeaderHolder>::iterator boost::intrusive::bstree_impl<ValueTraits, VoidOrKeyOfValue, VoidOrKeyComp, SizeType, ConstantTimeSize, AlgoType, HeaderHolder>::erase(boost::intrusive::bstree_impl<ValueTraits, VoidOrKeyOfValue, VoidOrKeyComp, SizeType, ConstantTimeSize, AlgoType, HeaderHolder>::const_iterator) [with ValueTraits = boost::intrusive::mhtraits<TimerEvent, boost::intrusive::set_member_hook<>, &TimerEvent::timer_set_hook>; VoidOrKeyOfValue = void; VoidOrKeyComp = EventLoop::TimerCompare; SizeType = unsigned int; bool ConstantTimeSize = false; boost::intrusive::algo_types AlgoType = (boost::intrusive::algo_types)5; HeaderHolder = void]’:
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/boost/intrusive/bstree.hpp:1419:13: note: parameter passing for argument of type ‘boost::intrusive::bstree_impl<boost::intrusive::mhtraits<TimerEvent, boost::intrusive::set_member_hook<>, &TimerEvent::timer_set_hook>, void, EventLoop::TimerCompare, unsigned int, false, (boost::intrusive::algo_types)5, void>::const_iterator {aka boost::intrusive::tree_iterator<boost::intrusive::mhtraits<TimerEvent, boost::intrusive::set_member_hook<>, &TimerEvent::timer_set_hook>, true>}’ changed in GCC 7.1
    iterator erase(const_iterator i)
             ^~~~~
[317/439] Compiling C++ object 'src/db/plugins/b742f49@@db_plugins@sta/.._VHelper.cxx.o'.
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/char_traits.h:39:0,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/string:40,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/stdexcept:39,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/array:39,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/tuple:39,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/functional:54,
                 from ../src/db/Visitor.hxx:23,
                 from ../src/db/VHelper.hxx:23,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algobase.h: In function ‘_ForwardIterator std::__lower_bound(_ForwardIterator, _ForwardIterator, const _Tp&, _Compare) [with _ForwardIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Tp = DetachedSong; _Compare = __gnu_cxx::__ops::_Iter_comp_val<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algobase.h:946:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __lower_bound(_ForwardIterator __first, _ForwardIterator __last,
     ^~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algobase.h:946:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/algorithm:62:0,
                 from ../src/tag/Tag.hxx:28,
                 from ../src/song/DetachedSong.hxx:23,
                 from ../src/db/VHelper.hxx:25,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘_ForwardIterator std::__upper_bound(_ForwardIterator, _ForwardIterator, const _Tp&, _Compare) [with _ForwardIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Tp = DetachedSong; _Compare = __gnu_cxx::__ops::_Val_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2039:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __upper_bound(_ForwardIterator __first, _ForwardIterator __last,
     ^~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2039:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/char_traits.h:39:0,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/string:40,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/stdexcept:39,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/array:39,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/tuple:39,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/functional:54,
                 from ../src/db/Visitor.hxx:23,
                 from ../src/db/VHelper.hxx:23,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algobase.h: In function ‘_ForwardIterator std::__lower_bound(_ForwardIterator, _ForwardIterator, const _Tp&, _Compare) [with _ForwardIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Tp = DetachedSong; _Compare = __gnu_cxx::__ops::_Iter_comp_val<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algobase.h:946:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __lower_bound(_ForwardIterator __first, _ForwardIterator __last,
     ^~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algobase.h:946:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/algorithm:62:0,
                 from ../src/tag/Tag.hxx:28,
                 from ../src/song/DetachedSong.hxx:23,
                 from ../src/db/VHelper.hxx:25,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘_ForwardIterator std::__upper_bound(_ForwardIterator, _ForwardIterator, const _Tp&, _Compare) [with _ForwardIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Tp = DetachedSong; _Compare = __gnu_cxx::__ops::_Val_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2039:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __upper_bound(_ForwardIterator __first, _ForwardIterator __last,
     ^~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2039:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/vector:69:0,
                 from ../src/db/VHelper.hxx:27,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/vector.tcc: In member function ‘void std::vector<_Tp, _Alloc>::_M_realloc_insert(std::vector<_Tp, _Alloc>::iterator, _Args&& ...) [with _Args = {const LightSong&}; _Tp = DetachedSong; _Alloc = std::allocator<DetachedSong>]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/vector.tcc:394:7: note: parameter passing for argument of type ‘std::vector<DetachedSong>::iterator {aka __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >}’ changed in GCC 7.1
       vector<_Tp, _Alloc>::
       ^~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/vector.tcc: In static member function ‘static void std::_Function_handler<void(_ArgTypes ...), _Functor>::_M_invoke(const std::_Any_data&, _ArgTypes&& ...) [with _Functor = DatabaseVisitorHelper::DatabaseVisitorHelper(const DatabaseSelection&, VisitSong&)::<lambda(const auto:1&)>; _ArgTypes = {const LightSong&}]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/vector.tcc:105:21: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    _M_realloc_insert(end(), std::forward<_Args>(__args)...);
    ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:62:0,
                 from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/algorithm:62,
                 from ../src/tag/Tag.hxx:28,
                 from ../src/song/DetachedSong.hxx:23,
                 from ../src/db/VHelper.hxx:25,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_tempbuf.h: In constructor ‘std::_Temporary_buffer<_ForwardIterator, _Tp>::_Temporary_buffer(_ForwardIterator, _ForwardIterator) [with _ForwardIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Tp = DetachedSong]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_tempbuf.h:243:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     _Temporary_buffer<_ForwardIterator, _Tp>::
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_tempbuf.h:243:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/algorithm:62:0,
                 from ../src/tag/Tag.hxx:28,
                 from ../src/song/DetachedSong.hxx:23,
                 from ../src/db/VHelper.hxx:25,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘_RandomAccessIterator std::_V2::__rotate(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, std::random_access_iterator_tag) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1328:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __rotate(_RandomAccessIterator __first,
     ^~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1328:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1328:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__merge_without_buffer(_BidirectionalIterator, _BidirectionalIterator, _BidirectionalIterator, _Distance, _Distance, _Compare) [with _BidirectionalIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Distance = int; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2476:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __merge_without_buffer(_BidirectionalIterator __first,
     ^~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2476:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2476:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2500:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    __second_cut
    ^~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2509:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    __first_cut
    ^~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1444:40: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__iterator_category(__first));
                                        ^
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2518:34: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__merge_without_buffer(__first, __first_cut, __new_middle,
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __len11, __len22, __comp);
       ~~~~~~~~~~~~~~~~~~~~~~~~~   
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2520:34: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__merge_without_buffer(__new_middle, __second_cut, __last,
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __len1 - __len11, __len2 - __len22, __comp);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__merge_without_buffer(_BidirectionalIterator, _BidirectionalIterator, _BidirectionalIterator, _Distance, _Distance, _Compare) [with _BidirectionalIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Distance = int; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2476:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __merge_without_buffer(_BidirectionalIterator __first,
     ^~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2476:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2476:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2500:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    __second_cut
    ^~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2509:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    __first_cut
    ^~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1444:40: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__iterator_category(__first));
                                        ^
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2518:34: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__merge_without_buffer(__first, __first_cut, __new_middle,
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __len11, __len22, __comp);
       ~~~~~~~~~~~~~~~~~~~~~~~~~   
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2520:34: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__merge_without_buffer(__new_middle, __second_cut, __last,
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __len1 - __len11, __len2 - __len22, __comp);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘_OutputIterator std::__move_merge(_InputIterator, _InputIterator, _InputIterator, _InputIterator, _OutputIterator, _Compare) [with _InputIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _OutputIterator = DetachedSong*; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __move_merge(_InputIterator __first1, _InputIterator __last1,
     ^~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘_OutputIterator std::__move_merge(_InputIterator, _InputIterator, _InputIterator, _InputIterator, _OutputIterator, _Compare) [with _InputIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _OutputIterator = DetachedSong*; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘_OutputIterator std::__move_merge(_InputIterator, _InputIterator, _InputIterator, _InputIterator, _OutputIterator, _Compare) [with _InputIterator = DetachedSong*; _OutputIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘_OutputIterator std::__move_merge(_InputIterator, _InputIterator, _InputIterator, _InputIterator, _OutputIterator, _Compare) [with _InputIterator = DetachedSong*; _OutputIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2639:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/vector:69:0,
                 from ../src/db/VHelper.hxx:27,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/vector.tcc: In member function ‘std::vector<_Tp, _Alloc>::iterator std::vector<_Tp, _Alloc>::_M_erase(std::vector<_Tp, _Alloc>::iterator, std::vector<_Tp, _Alloc>::iterator) [with _Tp = DetachedSong; _Alloc = std::allocator<DetachedSong>]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/vector.tcc:165:5: note: parameter passing for argument of type ‘std::vector<DetachedSong>::iterator {aka __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >}’ changed in GCC 7.1
     vector<_Tp, _Alloc>::
     ^~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/vector.tcc:165:5: note: parameter passing for argument of type ‘std::vector<DetachedSong>::iterator {aka __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >}’ changed in GCC 7.1
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/algorithm:62:0,
                 from ../src/tag/Tag.hxx:28,
                 from ../src/song/DetachedSong.hxx:23,
                 from ../src/db/VHelper.hxx:25,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘_BidirectionalIterator1 std::__rotate_adaptive(_BidirectionalIterator1, _BidirectionalIterator1, _BidirectionalIterator1, _Distance, _Distance, _BidirectionalIterator2, _Distance) [with _BidirectionalIterator1 = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _BidirectionalIterator2 = DetachedSong*; _Distance = int]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2373:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __rotate_adaptive(_BidirectionalIterator1 __first,
     ^~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2373:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2373:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1444:40: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__iterator_category(__first));
                                        ^
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1840:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __insertion_sort(_RandomAccessIterator __first,
     ^~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1840:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__inplace_stable_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2761:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __inplace_stable_sort(_RandomAccessIterator __first,
     ^~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2761:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2766:25: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__insertion_sort(__first, __last, __comp);
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2770:33: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__inplace_stable_sort(__first, __middle, __comp);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2771:33: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__inplace_stable_sort(__middle, __last, __comp);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2772:34: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__merge_without_buffer(__first, __middle, __last,
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
       __middle - __first,
       ~~~~~~~~~~~~~~~~~~~         
       __last - __middle,
       ~~~~~~~~~~~~~~~~~~          
       __comp);
       ~~~~~~~                     
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__merge_sort_with_buffer(_RandomAccessIterator, _RandomAccessIterator, _Pointer, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Pointer = DetachedSong*; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2705:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __merge_sort_with_buffer(_RandomAccessIterator __first,
     ^~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2705:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2695:25: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__insertion_sort(__first, __first + __chunk_size, __comp);
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2698:28: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__insertion_sort(__first, __last, __comp);
       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2674:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    __result = std::__move_merge(__first, __first + __step_size,
    ^~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2674:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2682:24: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__move_merge(__first, __first + __step_size,
       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    __first + __step_size, __last, __result, __comp);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2682:24: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2674:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    __result = std::__move_merge(__first, __first + __step_size,
    ^~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2682:24: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__move_merge(__first, __first + __step_size,
       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    __first + __step_size, __last, __result, __comp);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1840:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __insertion_sort(_RandomAccessIterator __first,
     ^~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:1840:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__inplace_stable_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2761:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __inplace_stable_sort(_RandomAccessIterator __first,
     ^~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2761:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2766:25: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__insertion_sort(__first, __last, __comp);
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2770:33: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__inplace_stable_sort(__first, __middle, __comp);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2771:33: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__inplace_stable_sort(__middle, __last, __comp);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2772:34: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__merge_without_buffer(__first, __middle, __last,
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
       __middle - __first,
       ~~~~~~~~~~~~~~~~~~~         
       __last - __middle,
       ~~~~~~~~~~~~~~~~~~          
       __comp);
       ~~~~~~~                     
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__merge_sort_with_buffer(_RandomAccessIterator, _RandomAccessIterator, _Pointer, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Pointer = DetachedSong*; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2705:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __merge_sort_with_buffer(_RandomAccessIterator __first,
     ^~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2705:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2695:25: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__insertion_sort(__first, __first + __chunk_size, __comp);
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2698:28: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__insertion_sort(__first, __last, __comp);
       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2674:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    __result = std::__move_merge(__first, __first + __step_size,
    ^~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2674:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2682:24: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__move_merge(__first, __first + __step_size,
       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    __first + __step_size, __last, __result, __comp);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2682:24: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2674:4: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    __result = std::__move_merge(__first, __first + __step_size,
    ^~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2682:24: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__move_merge(__first, __first + __step_size,
       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    __first + __step_size, __last, __result, __comp);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__merge_adaptive(_BidirectionalIterator, _BidirectionalIterator, _BidirectionalIterator, _Distance, _Distance, _Pointer, _Distance, _Compare) [with _BidirectionalIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Distance = int; _Pointer = DetachedSong*; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2415:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __merge_adaptive(_BidirectionalIterator __first,
     ^~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2415:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2415:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2444:8: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
        __second_cut
        ^~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2453:8: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
        __first_cut
        ^~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2459:27: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    _BidirectionalIterator __new_middle
                           ^~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2463:25: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__merge_adaptive(__first, __first_cut, __new_middle, __len11,
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     __len22, __buffer, __buffer_size, __comp);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2465:25: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__merge_adaptive(__new_middle, __second_cut, __last,
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     __len1 - __len11,
     ~~~~~~~~~~~~~~~~~    
     __len2 - __len22, __buffer,
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     __buffer_size, __comp);
     ~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__stable_sort_adaptive(_RandomAccessIterator, _RandomAccessIterator, _Pointer, _Distance, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Pointer = DetachedSong*; _Distance = int; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2732:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __stable_sort_adaptive(_RandomAccessIterator __first,
     ^~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2732:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2732:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2741:31: note: parameter passing for argument of type ‘const __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__stable_sort_adaptive(__first, __middle, __buffer,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           __buffer_size, __comp);
           ~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2743:31: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__stable_sort_adaptive(__middle, __last, __buffer,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
           __buffer_size, __comp);
           ~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2748:33: note: parameter passing for argument of type ‘const __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__merge_sort_with_buffer(__first, __middle, __buffer, __comp);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2749:33: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__merge_sort_with_buffer(__middle, __last, __buffer, __comp);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2751:28: note: parameter passing for argument of type ‘const __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__merge_adaptive(__first, __middle, __last,
       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
        _Distance(__middle - __first),
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        _Distance(__last - __middle),
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __buffer, __buffer_size,
        ~~~~~~~~~~~~~~~~~~~~~~~~
        __comp);
        ~~~~~~~              
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__merge_adaptive(_BidirectionalIterator, _BidirectionalIterator, _BidirectionalIterator, _Distance, _Distance, _Pointer, _Distance, _Compare) [with _BidirectionalIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Distance = int; _Pointer = DetachedSong*; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2415:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __merge_adaptive(_BidirectionalIterator __first,
     ^~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2415:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2415:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2444:8: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
        __second_cut
        ^~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2453:8: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
        __first_cut
        ^~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2459:27: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    _BidirectionalIterator __new_middle
                           ^~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2463:25: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__merge_adaptive(__first, __first_cut, __new_middle, __len11,
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     __len22, __buffer, __buffer_size, __comp);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2465:25: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__merge_adaptive(__new_middle, __second_cut, __last,
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     __len1 - __len11,
     ~~~~~~~~~~~~~~~~~    
     __len2 - __len22, __buffer,
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     __buffer_size, __comp);
     ~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In function ‘void std::__stable_sort_adaptive(_RandomAccessIterator, _RandomAccessIterator, _Pointer, _Distance, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >; _Pointer = DetachedSong*; _Distance = int; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<DatabaseVisitorHelper::Commit()::<lambda(const DetachedSong&, const DetachedSong&)> >]’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2732:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
     __stable_sort_adaptive(_RandomAccessIterator __first,
     ^~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2732:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2732:5: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2741:31: note: parameter passing for argument of type ‘const __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__stable_sort_adaptive(__first, __middle, __buffer,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           __buffer_size, __comp);
           ~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2743:31: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__stable_sort_adaptive(__middle, __last, __buffer,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
           __buffer_size, __comp);
           ~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2748:33: note: parameter passing for argument of type ‘const __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__merge_sort_with_buffer(__first, __middle, __buffer, __comp);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2749:33: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
    std::__merge_sort_with_buffer(__middle, __last, __buffer, __comp);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:2751:28: note: parameter passing for argument of type ‘const __gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       std::__merge_adaptive(__first, __middle, __last,
       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
        _Distance(__middle - __first),
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        _Distance(__last - __middle),
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __buffer, __buffer_size,
        ~~~~~~~~~~~~~~~~~~~~~~~~
        __comp);
        ~~~~~~~              
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h: In member function ‘void DatabaseVisitorHelper::Commit()’:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:5003:15: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       _TmpBuf __buf(__first, __last);
               ^~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:5006:28: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
  std::__inplace_stable_sort(__first, __last, __comp);
  ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:5008:29: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
  std::__stable_sort_adaptive(__first, __last, __buf.begin(),
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         _DistanceType(__buf.size()), __comp);
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:5003:15: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
       _TmpBuf __buf(__first, __last);
               ^~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:5006:28: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
  std::__inplace_stable_sort(__first, __last, __comp);
  ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_algo.h:5008:29: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
  std::__stable_sort_adaptive(__first, __last, __buf.begin(),
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         _DistanceType(__buf.size()), __comp);
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/vector:64:0,
                 from ../src/db/VHelper.hxx:27,
                 from ../src/db/VHelper.cxx:20:
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_vector.h:1210:71: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
  return _M_erase(__beg + (__first - __cbeg), __beg + (__last - __cbeg));
                                                                       ^
/home/joerg/Development/git/buildroot/output/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/7.4.0/bits/stl_vector.h:1210:71: note: parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<DetachedSong*, std::vector<DetachedSong> >’ changed in GCC 7.1
  return _M_erase(__beg + (__first - __cbeg), __beg + (__last - __cbeg));
                                                                       ^
[439/439] Linking target mpd.
FAILED: mpd 
/home/joerg/Development/git/buildroot/output/host/bin/arm-linux-g++  -o mpd 'mpd@exe/meson-generated_.._GitVersion.cxx.o' 'mpd@exe/src_Main.cxx.o' 'mpd@exe/src_protocol_Ack.cxx.o' 'mpd@exe/src_protocol_ArgParser.cxx.o' 'mpd@exe/src_protocol_Result.cxx.o' 'mpd@exe/src_command_CommandError.cxx.o' 'mpd@exe/src_command_AllCommands.cxx.o' 'mpd@exe/src_command_QueueCommands.cxx.o' 'mpd@exe/src_command_TagCommands.cxx.o' 'mpd@exe/src_command_PlayerCommands.cxx.o' 'mpd@exe/src_command_PlaylistCommands.cxx.o' 'mpd@exe/src_command_FileCommands.cxx.o' 'mpd@exe/src_command_OutputCommands.cxx.o' 'mpd@exe/src_command_MessageCommands.cxx.o' 'mpd@exe/src_command_ClientCommands.cxx.o' 'mpd@exe/src_command_PartitionCommands.cxx.o' 'mpd@exe/src_command_OtherCommands.cxx.o' 'mpd@exe/src_command_CommandListBuilder.cxx.o' 'mpd@exe/src_Idle.cxx.o' 'mpd@exe/src_IdleFlags.cxx.o' 'mpd@exe/src_decoder_Domain.cxx.o' 'mpd@exe/src_decoder_Thread.cxx.o' 'mpd@exe/src_decoder_Control.cxx.o' 'mpd@exe/src_decoder_Bridge.cxx.o' 'mpd@exe/src_decoder_DecoderPrint.cxx.o' 'mpd@exe/src_client_Listener.cxx.o' 'mpd@exe/src_client_Client.cxx.o' 'mpd@exe/src_client_ClientEvent.cxx.o' 'mpd@exe/src_client_ClientExpire.cxx.o' 'mpd@exe/src_client_ClientGlobal.cxx.o' 'mpd@exe/src_client_ClientIdle.cxx.o' 'mpd@exe/src_client_ClientList.cxx.o' 'mpd@exe/src_client_ClientNew.cxx.o' 'mpd@exe/src_client_ClientProcess.cxx.o' 'mpd@exe/src_client_ClientRead.cxx.o' 'mpd@exe/src_client_ClientWrite.cxx.o' 'mpd@exe/src_client_ClientMessage.cxx.o' 'mpd@exe/src_client_ClientSubscribe.cxx.o' 'mpd@exe/src_client_ClientFile.cxx.o' 'mpd@exe/src_client_Response.cxx.o' 'mpd@exe/src_Listen.cxx.o' 'mpd@exe/src_LogInit.cxx.o' 'mpd@exe/src_LogBackend.cxx.o' 'mpd@exe/src_Log.cxx.o' 'mpd@exe/src_ls.cxx.o' 'mpd@exe/src_Instance.cxx.o' 'mpd@exe/src_win32_Win32Main.cxx.o' 'mpd@exe/src_MusicBuffer.cxx.o' 'mpd@exe/src_MusicPipe.cxx.o' 'mpd@exe/src_MusicChunk.cxx.o' 'mpd@exe/src_MusicChunkPtr.cxx.o' 'mpd@exe/src_Mapper.cxx.o' 'mpd@exe/src_Partition.cxx.o' 'mpd@exe/src_Permission.cxx.o' 'mpd@exe/src_player_CrossFade.cxx.o' 'mpd@exe/src_player_Thread.cxx.o' 'mpd@exe/src_player_Control.cxx.o' 'mpd@exe/src_PlaylistError.cxx.o' 'mpd@exe/src_PlaylistPrint.cxx.o' 'mpd@exe/src_PlaylistSave.cxx.o' 'mpd@exe/src_playlist_PlaylistStream.cxx.o' 'mpd@exe/src_playlist_PlaylistMapper.cxx.o' 'mpd@exe/src_playlist_PlaylistAny.cxx.o' 'mpd@exe/src_playlist_PlaylistSong.cxx.o' 'mpd@exe/src_playlist_PlaylistQueue.cxx.o' 'mpd@exe/src_playlist_Print.cxx.o' 'mpd@exe/src_db_PlaylistVector.cxx.o' 'mpd@exe/src_queue_Queue.cxx.o' 'mpd@exe/src_queue_QueuePrint.cxx.o' 'mpd@exe/src_queue_QueueSave.cxx.o' 'mpd@exe/src_queue_Playlist.cxx.o' 'mpd@exe/src_queue_PlaylistControl.cxx.o' 'mpd@exe/src_queue_PlaylistEdit.cxx.o' 'mpd@exe/src_queue_PlaylistTag.cxx.o' 'mpd@exe/src_queue_PlaylistState.cxx.o' 'mpd@exe/src_ReplayGainGlobal.cxx.o' 'mpd@exe/src_LocateUri.cxx.o' 'mpd@exe/src_SongUpdate.cxx.o' 'mpd@exe/src_SongLoader.cxx.o' 'mpd@exe/src_SongPrint.cxx.o' 'mpd@exe/src_SongSave.cxx.o' 'mpd@exe/src_StateFile.cxx.o' 'mpd@exe/src_StateFileConfig.cxx.o' 'mpd@exe/src_Stats.cxx.o' 'mpd@exe/src_TagPrint.cxx.o' 'mpd@exe/src_TagSave.cxx.o' 'mpd@exe/src_TagFile.cxx.o' 'mpd@exe/src_TagStream.cxx.o' 'mpd@exe/src_TimePrint.cxx.o' 'mpd@exe/src_mixer_Volume.cxx.o' 'mpd@exe/src_PlaylistFile.cxx.o' 'mpd@exe/src_CommandLine.cxx.o' 'mpd@exe/src_unix_SignalHandlers.cxx.o' 'mpd@exe/src_unix_Daemon.cxx.o' 'mpd@exe/src_queue_PlaylistUpdate.cxx.o' 'mpd@exe/src_command_StorageCommands.cxx.o' 'mpd@exe/src_command_DatabaseCommands.cxx.o' 'mpd@exe/src_RemoteTagCache.cxx.o' -Wl,--no-undefined -Wl,--as-needed -Wl,-O1 -Wl,--gc-sections -Wl,--start-group libbasic.a src/config/libfs.a src/fs/libfs.a src/system/libsystem.a src/lib/icu/libicu.a src/util/libutil.a src/net/libnet.a src/event/libevent.a src/thread/libthread.a src/input/libinput_glue.a src/input/plugins/libinput_plugins.a src/lib/curl/libcurl.a src/lib/yajl/libyajl.a src/lib/gcrypt/libgcrypt.a src/input/libinput_api.a src/pcm/libpcm.a src/tag/libtag.a src/output/liboutput_glue.a src/filter/libfilter_glue.a src/filter/plugins/libfilter_plugins.a src/filter/libfilter_api.a src/mixer/plugins/libmixer_plugins.a src/output/plugins/liboutput_plugins.a src/output/liboutput_api.a src/mixer/libmixer_glue.a src/decoder/libdecoder_glue.a src/decoder/plugins/libdecoder_plugins.a src/decoder/libdecoder_api.a src/encoder/libencoder_glue.a src/encoder/plugins/libencoder_plugins.a src/playlist/libplaylist_glue.a src/playlist/plugins/libplaylist_plugins.a src/playlist/libplaylist_api.a src/db/libdb_glue.a src/db/plugins/libdb_plugins.a src/db/libdb_api.a src/storage/libstorage_api.a src/storage/libstorage_glue.a src/storage/plugins/libstorage_plugins.a src/song/libsong.a /home/joerg/Development/git/buildroot/output/host/usr/bin/../arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libcurl.a /home/joerg/Development/git/buildroot/output/host/usr/bin/../arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libyajl.a -lgcrypt -lgcrypt -Wl,--end-group -pthread '-Wl,-rpath,$ORIGIN/:$ORIGIN/src/config:$ORIGIN/src/fs:$ORIGIN/src/system:$ORIGIN/src/lib/icu:$ORIGIN/src/util:$ORIGIN/src/net:$ORIGIN/src/event:$ORIGIN/src/thread:$ORIGIN/src/input:$ORIGIN/src/input/plugins:$ORIGIN/src/lib/curl:$ORIGIN/src/lib/yajl:$ORIGIN/src/lib/gcrypt:$ORIGIN/src/pcm:$ORIGIN/src/tag:$ORIGIN/src/output:$ORIGIN/src/filter:$ORIGIN/src/filter/plugins:$ORIGIN/src/mixer/plugins:$ORIGIN/src/output/plugins:$ORIGIN/src/mixer:$ORIGIN/src/decoder:$ORIGIN/src/decoder/plugins:$ORIGIN/src/encoder:$ORIGIN/src/encoder/plugins:$ORIGIN/src/playlist:$ORIGIN/src/playlist/plugins:$ORIGIN/src/db:$ORIGIN/src/db/plugins:$ORIGIN/src/storage:$ORIGIN/src/storage/plugins:$ORIGIN/src/song' -Wl,-rpath-link,/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/config:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/fs:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/system:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/lib/icu:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/util:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/net:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/event:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/thread:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/input:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/input/plugins:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/lib/curl:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/lib/yajl:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/lib/gcrypt:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/pcm:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/tag:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/output:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/filter:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/filter/plugins:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/mixer/plugins:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/output/plugins:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/mixer:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/decoder:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/decoder/plugins:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/encoder:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/encoder/plugins:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/playlist:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/playlist/plugins:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/db:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/db/plugins:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/storage:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/storage/plugins:/home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/build/src/song -static 
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-visibility.o): In function `gcry_strerror':
visibility.c:(.text+0x14): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-visibility.o): In function `gcry_strsource':
visibility.c:(.text+0x18): undefined reference to `gpg_strsource'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-visibility.o): In function `gcry_err_code_from_errno':
visibility.c:(.text+0x1c): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-visibility.o): In function `gcry_err_code_to_errno':
visibility.c:(.text+0x20): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-visibility.o): In function `gcry_err_make_from_errno':
visibility.c:(.text+0x30): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-visibility.o): In function `gcry_error_from_errno':
visibility.c:(.text+0x54): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-misc.o): In function `_gcry_fatal_error':
misc.c:(.text+0x6c): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-misc.o): In function `_gcry_strtokenize':
misc.c:(.text+0x86c): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-misc.o): In function `_gcry_divide_by_zero':
misc.c:(.text+0xa94): undefined reference to `gpg_err_set_errno'
misc.c:(.text+0xaa0): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `global_init':
global.c:(.text+0x108): undefined reference to `gpgrt_get_syscall_clamp'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `do_malloc':
global.c:(.text+0x214): undefined reference to `gpg_err_set_errno'
global.c:(.text+0x220): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_get_config':
global.c:(.text+0x368): undefined reference to `gpgrt_fopenmem'
global.c:(.text+0x45c): undefined reference to `gpgrt_ferror'
global.c:(.text+0x474): undefined reference to `gpgrt_fclose'
global.c:(.text+0x47c): undefined reference to `gpg_err_set_errno'
global.c:(.text+0x4ac): undefined reference to `gpgrt_fprintf'
global.c:(.text+0x4c8): undefined reference to `gpgrt_fprintf'
global.c:(.text+0x4e0): undefined reference to `gpgrt_fprintf'
global.c:(.text+0x4f8): undefined reference to `gpgrt_fprintf'
global.c:(.text+0x510): undefined reference to `gpgrt_fprintf'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o):global.c:(.text+0x524): more undefined references to `gpgrt_fprintf' follow
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_get_config':
global.c:(.text+0x66c): undefined reference to `gpgrt_rewind'
global.c:(.text+0x67c): undefined reference to `gpgrt_fclose_snatch'
global.c:(.text+0x694): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_free':
global.c:(.text+0x95c): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_vcontrol':
global.c:(.text+0xdbc): undefined reference to `gpgrt_lock_init'
global.c:(.text+0xdc8): undefined reference to `gpgrt_lock_lock'
global.c:(.text+0xdd4): undefined reference to `gpgrt_lock_unlock'
global.c:(.text+0xde0): undefined reference to `gpgrt_lock_destroy'
global.c:(.text+0xef0): undefined reference to `gpgrt_get_syscall_clamp'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_realloc_core':
global.c:(.text+0xf90): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_calloc':
global.c:(.text+0xfd4): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_calloc_secure':
global.c:(.text+0x102c): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_xmalloc':
global.c:(.text+0x1094): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_xrealloc':
global.c:(.text+0x1104): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_xmalloc_secure':
global.c:(.text+0x119c): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_xcalloc':
global.c:(.text+0x1210): undefined reference to `gpg_err_set_errno'
global.c:(.text+0x121c): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_xcalloc_secure':
global.c:(.text+0x1268): undefined reference to `gpg_err_set_errno'
global.c:(.text+0x1274): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-global.o): In function `_gcry_xstrdup':
global.c:(.text+0x12ec): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-sexp.o): In function `make_space':
sexp.c:(.text+0x350): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-sexp.o): In function `do_vsexp_sscan':
sexp.c:(.text+0x708): undefined reference to `gpg_err_code_from_errno'
sexp.c:(.text+0x1030): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-stdmem.o): In function `_gcry_private_malloc':
stdmem.c:(.text+0x24): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-stdmem.o): In function `_gcry_private_malloc_secure':
stdmem.c:(.text+0x9c): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `mb_get_new':
secmem.c:(.text+0x110): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `_gcry_secmem_malloc_internal':
secmem.c:(.text+0x728): undefined reference to `gpg_err_set_errno'
secmem.c:(.text+0x75c): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `_gcry_secmem_set_auto_expand':
secmem.c:(.text+0x920): undefined reference to `gpgrt_lock_lock'
secmem.c:(.text+0x940): undefined reference to `gpgrt_lock_unlock'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `_gcry_secmem_set_flags':
secmem.c:(.text+0x958): undefined reference to `gpgrt_lock_lock'
secmem.c:(.text+0x9bc): undefined reference to `gpgrt_lock_unlock'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `_gcry_secmem_get_flags':
secmem.c:(.text+0x9d0): undefined reference to `gpgrt_lock_lock'
secmem.c:(.text+0xa38): undefined reference to `gpgrt_lock_unlock'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `_gcry_secmem_init':
secmem.c:(.text+0xa5c): undefined reference to `gpgrt_lock_lock'
secmem.c:(.text+0xa70): undefined reference to `gpgrt_lock_unlock'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `_gcry_secmem_malloc':
secmem.c:(.text+0xa94): undefined reference to `gpgrt_lock_lock'
secmem.c:(.text+0xaac): undefined reference to `gpgrt_lock_unlock'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `_gcry_secmem_free':
secmem.c:(.text+0xad0): undefined reference to `gpgrt_lock_lock'
secmem.c:(.text+0xae4): undefined reference to `gpgrt_lock_unlock'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `_gcry_secmem_realloc':
secmem.c:(.text+0xb08): undefined reference to `gpgrt_lock_lock'
secmem.c:(.text+0xb58): undefined reference to `gpgrt_lock_unlock'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-secmem.o): In function `_gcry_secmem_dump_stats':
secmem.c:(.text+0xe40): undefined reference to `gpgrt_lock_lock'
secmem.c:(.text+0xeac): undefined reference to `gpgrt_lock_unlock'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-fips.o): In function `lock_fsm':
fips.c:(.text+0x8): undefined reference to `gpgrt_lock_lock'
fips.c:(.text+0x14): undefined reference to `gpg_strerror'
fips.c:(.text+0x28): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-fips.o): In function `unlock_fsm':
fips.c:(.text+0x54): undefined reference to `gpgrt_lock_unlock'
fips.c:(.text+0x60): undefined reference to `gpg_strerror'
fips.c:(.text+0x74): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-fips.o): In function `_gcry_fips_run_selftests':
fips.c:(.text+0x4e4): undefined reference to `gpg_strerror'
fips.c:(.text+0x55c): undefined reference to `gpg_strerror'
fips.c:(.text+0x5c0): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-fips.o):fips.c:(.text+0x600): more undefined references to `gpg_strerror' follow
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-fips.o): In function `_gcry_initialize_fips_mode':
fips.c:(.text+0x908): undefined reference to `gpgrt_lock_init'
fips.c:(.text+0x914): undefined reference to `gpg_strerror'
fips.c:(.text+0x928): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(cipher.o): In function `_gcry_cipher_open_internal':
cipher.c:(.text+0x3b8): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(dsa.o): In function `run_selftests':
dsa.c:(.text+0x90): undefined reference to `gpg_strerror'
dsa.c:(.text+0xe0): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(dsa.o): In function `dsa_check_secret_key':
dsa.c:(.text+0x4f8): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(dsa.o): In function `dsa_sign':
dsa.c:(.text+0x8bc): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(dsa.o): In function `dsa_verify':
dsa.c:(.text+0xcec): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(dsa.o): In function `dsa_generate':
dsa.c:(.text+0x1b48): undefined reference to `gpg_err_code_from_syserror'
dsa.c:(.text+0x1c30): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-curves.o): In function `scanval':
ecc-curves.c:(.text+0x24): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-curves.o): In function `point_from_keyparam':
ecc-curves.c:(.text+0x180): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-curves.o): In function `_gcry_ecc_update_curve_param':
ecc-curves.c:(.text+0x660): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-curves.o): In function `_gcry_mpi_ec_new':
ecc-curves.c:(.text+0xccc): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-eddsa.o): In function `eddsa_encode_x_y':
ecc-eddsa.c:(.text+0x5c): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-eddsa.o): In function `scanval':
ecc-eddsa.c:(.text+0xec): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-eddsa.o): In function `_gcry_ecc_eddsa_ensure_compact':
ecc-eddsa.c:(.text+0x320): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-eddsa.o): In function `_gcry_ecc_eddsa_decodepoint':
ecc-eddsa.c:(.text+0x718): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-eddsa.o): In function `_gcry_ecc_eddsa_compute_h_d':
ecc-eddsa.c:(.text+0x83c): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-eddsa.o): In function `_gcry_ecc_eddsa_genkey':
ecc-eddsa.c:(.text+0x98c): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-eddsa.o): In function `_gcry_ecc_eddsa_sign':
ecc-eddsa.c:(.text+0xed4): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-misc.o): In function `_gcry_ecc_ec2os':
ecc-misc.c:(.text+0x1c8): undefined reference to `gpg_strerror'
ecc-misc.c:(.text+0x280): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc-misc.o): In function `_gcry_ecc_mont_decodepoint':
ecc-misc.c:(.text+0x658): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(elgamal.o): In function `elg_check_secret_key':
elgamal.c:(.text+0x1a4): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(elgamal.o): In function `elg_sign':
elgamal.c:(.text+0x668): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(elgamal.o): In function `elg_encrypt':
elgamal.c:(.text+0x8b0): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(elgamal.o): In function `elg_decrypt':
elgamal.c:(.text+0xc30): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(elgamal.o): In function `elg_verify':
elgamal.c:(.text+0xfc4): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(elgamal.o): In function `elg_generate':
elgamal.c:(.text+0x16e4): undefined reference to `gpg_err_code_from_syserror'
elgamal.c:(.text+0x1708): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(kdf.o): In function `_gcry_kdf_pkdf2':
kdf.c:(.text+0xa0): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(mac.o): In function `_gcry_mac_open':
mac.c:(.text+0x178): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(md.o): In function `md_enable.isra.1':
md.c:(.text+0x36c): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(md.o): In function `md_open':
md.c:(.text+0x44c): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(md.o): In function `md_final':
md.c:(.text+0x6c4): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(md.o): In function `_gcry_md_copy':
md.c:(.text+0x970): undefined reference to `gpg_err_code_from_syserror'
md.c:(.text+0xa4c): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(md.o): In function `_gcry_md_hash_buffer':
md.c:(.text+0xd78): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(md.o): In function `_gcry_md_setkey':
md.c:(.text+0xebc): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(primegen.o): In function `prime_generate_internal':
primegen.c:(.text+0x910): undefined reference to `gpg_err_code_from_errno'
primegen.c:(.text+0x9e8): undefined reference to `gpg_err_code_from_errno'
primegen.c:(.text+0xab8): undefined reference to `gpg_err_code_from_errno'
primegen.c:(.text+0xad4): undefined reference to `gpg_err_code_from_errno'
primegen.c:(.text+0xb14): undefined reference to `gpgrt_lock_lock'
primegen.c:(.text+0xb40): undefined reference to `gpgrt_lock_unlock'
primegen.c:(.text+0xbc8): undefined reference to `gpgrt_lock_unlock'
primegen.c:(.text+0xc70): undefined reference to `gpgrt_lock_lock'
primegen.c:(.text+0xe58): undefined reference to `gpgrt_lock_unlock'
primegen.c:(.text+0xeb4): undefined reference to `gpgrt_lock_unlock'
primegen.c:(.text+0xec4): undefined reference to `gpgrt_lock_lock'
primegen.c:(.text+0xf10): undefined reference to `gpgrt_lock_unlock'
primegen.c:(.text+0x1168): undefined reference to `gpg_err_code_from_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(primegen.o): In function `_gcry_generate_fips186_2_prime':
primegen.c:(.text+0x1ca0): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(primegen.o): In function `_gcry_generate_fips186_3_prime':
primegen.c:(.text+0x2140): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(pubkey-util.o): In function `_gcry_pk_util_preparse_encval':
pubkey-util.c:(.text+0x890): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(pubkey-util.o): In function `_gcry_pk_util_data_to_mpi':
pubkey-util.c:(.text+0xb9c): undefined reference to `gpg_err_code_from_syserror'
pubkey-util.c:(.text+0xd7c): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(pubkey-util.o):pubkey-util.c:(.text+0xfb0): more undefined references to `gpg_err_code_from_syserror' follow
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(rsa.o): In function `run_selftests':
rsa.c:(.text+0x250): undefined reference to `gpg_strerror'
rsa.c:(.text+0x2a0): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(rsa.o): In function `rsa_check_secret_key':
rsa.c:(.text+0x69c): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(rsa.o): In function `rsa_verify':
rsa.c:(.text+0x964): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(rsa.o): In function `rsa_encrypt':
rsa.c:(.text+0xb68): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(rsa.o):rsa.c:(.text+0x1168): more undefined references to `gpg_strerror' follow
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(scrypt.o): In function `_gcry_kdf_scrypt':
scrypt.c:(.text+0x47c): undefined reference to `gpg_err_code_from_syserror'
scrypt.c:(.text+0x4c4): undefined reference to `gpg_err_code_from_syserror'
scrypt.c:(.text+0x4e4): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-drbg.o): In function `drbg_lock':
random-drbg.c:(.text+0x144): undefined reference to `gpgrt_lock_lock'
random-drbg.c:(.text+0x150): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-drbg.o): In function `drbg_unlock':
random-drbg.c:(.text+0x740): undefined reference to `gpgrt_lock_unlock'
random-drbg.c:(.text+0x74c): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-drbg.o): In function `parse_flag_string':
random-drbg.c:(.text+0x7b0): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-drbg.o): In function `_drbg_init_internal':
random-drbg.c:(.text+0xd10): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-drbg.o): In function `_gcry_rngdrbg_cavs_test':
random-drbg.c:(.text+0x19a4): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-drbg.o): In function `_gcry_rngdrbg_selftest':
random-drbg.c:(.text+0x1c04): undefined reference to `gpg_err_code_from_syserror'
random-drbg.c:(.text+0x1c74): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random.o): In function `_gcry_create_nonce':
random.c:(.text+0x664): undefined reference to `gpgrt_lock_lock'
random.c:(.text+0x670): undefined reference to `gpg_strerror'
random.c:(.text+0x6fc): undefined reference to `gpgrt_lock_unlock'
random.c:(.text+0x708): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ec.o): In function `ec_p_init':
ec.c:(.text+0x12c): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ec.o): In function `_gcry_mpi_ec_p_new':
ec.c:(.text+0x84c): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(mpicoder.o): In function `_gcry_mpi_print':
mpicoder.c:(.text+0x990): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(mpicoder.o): In function `_gcry_mpi_aprint':
mpicoder.c:(.text+0xdc0): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(mpicoder.o): In function `_gcry_mpi_to_octet_string':
mpicoder.c:(.text+0xecc): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(libgcrypt_la-hmac256.o): In function `_gcry_hmac256_file':
hmac256.c:(.text+0x88c): undefined reference to `gpg_err_set_errno'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(dsa-common.o): In function `int2octets':
dsa-common.c:(.text+0x70): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(dsa-common.o): In function `_gcry_dsa_gen_rfc6979_k':
dsa-common.c:(.text+0x2cc): undefined reference to `gpg_err_code_from_syserror'
dsa-common.c:(.text+0x354): undefined reference to `gpg_err_code_from_syserror'
dsa-common.c:(.text+0x5b4): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc.o): In function `compute_keygrip':
ecc.c:(.text+0x300): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc.o): In function `ecc_verify':
ecc.c:(.text+0x9b0): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc.o): In function `ecc_sign':
ecc.c:(.text+0xe2c): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc.o): In function `ecc_decrypt_raw':
ecc.c:(.text+0x132c): undefined reference to `gpg_err_code_from_syserror'
ecc.c:(.text+0x1414): undefined reference to `gpg_strerror'
ecc.c:(.text+0x1474): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc.o): In function `ecc_encrypt_raw':
ecc.c:(.text+0x1744): undefined reference to `gpg_strerror'
ecc.c:(.text+0x1adc): undefined reference to `gpg_err_code_from_syserror'
ecc.c:(.text+0x1b44): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc.o): In function `ecc_check_secret_key':
ecc.c:(.text+0x21ac): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc.o): In function `run_selftests':
ecc.c:(.text+0x2380): undefined reference to `gpg_strerror'
ecc.c:(.text+0x23d0): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(ecc.o): In function `ecc_generate':
ecc.c:(.text+0x3178): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(mac-poly1305.o): In function `poly1305mac_open':
mac-poly1305.c:(.text+0x360): undefined reference to `gpg_err_code_from_syserror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-csprng.o): In function `lock_pool':
random-csprng.c:(.text+0x24): undefined reference to `gpgrt_lock_lock'
random-csprng.c:(.text+0x30): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-csprng.o): In function `unlock_pool':
random-csprng.c:(.text+0xbc): undefined reference to `gpgrt_lock_unlock'
random-csprng.c:(.text+0xc8): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-system.o): In function `lock_rng':
random-system.c:(.text+0x8): undefined reference to `gpgrt_lock_lock'
random-system.c:(.text+0x14): undefined reference to `gpg_strerror'
/home/joerg/Development/git/buildroot/output/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libgcrypt.a(random-system.o): In function `unlock_rng':
random-system.c:(.text+0x54): undefined reference to `gpgrt_lock_unlock'
random-system.c:(.text+0x60): undefined reference to `gpg_strerror'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
make: *** [package/pkg-generic.mk:241: /home/joerg/Development/git/buildroot/output/build/mpd-0.21.5/.stamp_built] Error 1
```

</p>
</details>