### PR TITLE
Alsa input plugin

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -134,7 +134,7 @@ Allows :program:`MPD` on Linux to play audio directly from a soundcard using the
 
 .. code-block:: none
 
-    mpc add alsa:// plays audio from device hw:0,0
+    mpc add alsa:// plays audio from device default
 
 .. code-block:: none
 

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -130,7 +130,7 @@ Input plugins
 alsa
 ~~~~
 
-Allows :program:`MPD` on Linux to play audio directly from a soundcard using the scheme alsa://. Audio is formatted as 44.1 kHz 16-bit stereo (CD format). Examples:
+Allows :program:`MPD` on Linux to play audio directly from a soundcard using the scheme alsa://. Audio is by default formatted as 48 kHz 16-bit stereo, but this default can be overidden by a config file setting or by the URI. Examples:
 
 .. code-block:: none
 
@@ -138,7 +138,31 @@ Allows :program:`MPD` on Linux to play audio directly from a soundcard using the
 
 .. code-block:: none
 
-    mpc add alsa://hw:1,0 plays audio from device hw:1,0 cdio_paranoia
+    mpc add alsa://hw:1,0 plays audio from device hw:1,0
+
+.. code-block:: none
+
+    mpc add alsa://hw:1,0?format=44100:16:2 plays audio from device hw:1,0 sampling 16-bit stereo at 44.1kHz.
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Setting
+     - Description
+   * - **default_device NAME**
+     - The alsa device id to use to none is specified in the uri.
+   * - **default_format F**
+     - The sampling rate, size and channels to use. Wildcards are not allowed.
+
+       Example - "44100:16:2"
+
+   * - **auto_resample yes|no**
+     - If set to no, then libasound will not attempt to resample. In this case, the user is responsible for ensuring that the requested sample rate can be produced natively by the device, otherwise an error will occur.
+   * - **auto_channels yes|no**
+     - If set to no, then libasound will not attempt to convert between different channel numbers. The user must ensure that the device supports the requested channels when sampling.
+   * - **auto_format yes|no**
+     - If set to no, then libasound will not attempt to convert between different sample formats (16 bit, 24 bit, floating point, ...). Again the user must ensure that the requested format is available natively from the device.
 
 cdio_paranoia
 ~~~~~~~~~~~~~

--- a/src/decoder/plugins/PcmDecoderPlugin.cxx
+++ b/src/decoder/plugins/PcmDecoderPlugin.cxx
@@ -17,6 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "config.h"
+
 #include "PcmDecoderPlugin.hxx"
 #include "../DecoderAPI.hxx"
 #include "CheckAudioFormat.hxx"

--- a/src/decoder/plugins/PcmDecoderPlugin.cxx
+++ b/src/decoder/plugins/PcmDecoderPlugin.cxx
@@ -28,8 +28,11 @@
 #include "util/StaticFifoBuffer.hxx"
 #include "util/NumberParser.hxx"
 #include "util/MimeType.hxx"
-#include "AudioParser.hxx"
 #include "Log.hxx"
+
+#ifdef ENABLE_ALSA
+#include "AudioParser.hxx"
+#endif
 
 #include <exception>
 
@@ -135,6 +138,7 @@ pcm_stream_decode(DecoderClient &client, InputStream &is)
 			audio_format.channels = value;
 		}
 
+#ifdef ENABLE_ALSA
 		if (GetMimeTypeBase(mime) == "audio/x-mpd-alsa-pcm") {
 			i = mime_parameters.find("format");
 			if (i != mime_parameters.end()) {
@@ -148,6 +152,7 @@ pcm_stream_decode(DecoderClient &client, InputStream &is)
 				}
 			}
 		}
+#endif
 	}
 
 	if (audio_format.sample_rate == 0) {
@@ -236,8 +241,10 @@ static const char *const pcm_mime_types[] = {
 	/* same as above, but with reverse byte order */
 	"audio/x-mpd-cdda-pcm-reverse",
 
+#ifdef ENABLE_ALSA
 	/* for streams obtained by the alsa input plugin */
 	"audio/x-mpd-alsa-pcm",
+#endif
 
 	nullptr
 };

--- a/src/input/plugins/AlsaInputPlugin.cxx
+++ b/src/input/plugins/AlsaInputPlugin.cxx
@@ -52,8 +52,8 @@ static constexpr Domain alsa_input_domain("alsa");
 
 static constexpr auto ALSA_URI_PREFIX = "alsa://";
 
-static constexpr auto BUILTIN_DEFAULT_DEVICE = "hw:0,0";
-static constexpr auto BUILTIN_DEFAULT_FORMAT = "44100:16:2";
+static constexpr auto BUILTIN_DEFAULT_DEVICE = "default";
+static constexpr auto BUILTIN_DEFAULT_FORMAT = "48000:16:2";
 
 static constexpr auto DEFAULT_BUFFER_TIME = std::chrono::milliseconds(1000);
 static constexpr auto DEFAULT_RESUME_TIME = DEFAULT_BUFFER_TIME / 2;


### PR DESCRIPTION
Extend the alsa:// input scheme to allow users to select an audio format to use by specifying it in a query component on the URI.
Also allows admins to override the built-in defaults for device name and audio format using mpd.conf settings.