### PR TITLE
output/plugins/OSXOutputPlugin: add boost meson dependency

### DIFF
--- a/src/output/plugins/meson.build
+++ b/src/output/plugins/meson.build
@@ -76,7 +76,10 @@ if is_darwin
   audiounit_dep = declare_dependency(
     link_args: [
       '-framework', 'AudioUnit', '-framework', 'CoreAudio', '-framework', 'CoreServices',
-    ]
+    ],
+    dependencies: [
+      boost_dep,
+    ],
   )
 else
   audiounit_dep = dependency('', required: false)


### PR DESCRIPTION
Fixes compilation error:

```
[259/516] Compiling C++ object 'src/output/plugins/0f714b4@@output_plugins@sta/OSXOutputPlugin.cxx.o'.
FAILED: src/output/plugins/0f714b4@@output_plugins@sta/OSXOutputPlugin.cxx.o 
c++ -Isrc/output/plugins/0f714b4@@output_plugins@sta -Isrc/output/plugins -I../src/output/plugins -Isrc -I../src -I. -I../ -Xclang -fcolor-diagnostics -pipe -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++14 -g -Wall -Wextra -fvisibility=hidden -ffast-math -ftree-vectorize -fno-threadsafe-statics -fmerge-all-constants -Wmissing-declarations -Wshadow -Wpointer-arith -Wcast-qual -Wwrite-strings -Wsign-compare -Wno-non-virtual-dtor -Wno-noexcept-type -funwind-tables -D_GNU_SOURCE  -MD -MQ 'src/output/plugins/0f714b4@@output_plugins@sta/OSXOutputPlugin.cxx.o' -MF 'src/output/plugins/0f714b4@@output_plugins@sta/OSXOutputPlugin.cxx.o.d' -o 'src/output/plugins/0f714b4@@output_plugins@sta/OSXOutputPlugin.cxx.o' -c ../src/output/plugins/OSXOutputPlugin.cxx
../src/output/plugins/OSXOutputPlugin.cxx:41:10: fatal error: 'boost/lockfree/spsc_queue.hpp' file not found
#include <boost/lockfree/spsc_queue.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```

I don't know why this didn't come up around the time I submitted https://github.com/MusicPlayerDaemon/MPD/pull/435; it looks like the same type of problem.