### PR TITLE
Fix meson.build to work properly with '-Ddatabase=false'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -378,6 +378,9 @@ basic_dep = declare_dependency(
 if enable_database
   subdir('src/storage')
   subdir('src/db')
+else
+  db_glue_dep = dependency('', required: false)
+  storage_glue_dep = dependency('', required: false)
 endif
 
 if neighbor_glue_dep.found()


### PR DESCRIPTION
Currently, if you run meson with the '-Ddatabase=false' option set, meson errors out with the message "Unknown variable db_glue_dep" and "Unknown variable storage_glue_dep".