### PR TITLE
Fix meson.build to work properly with '-Ddatabase=false'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -375,9 +375,11 @@ basic_dep = declare_dependency(
   link_with: basic,
 )
 
+subdir('src/db')
 if enable_database
   subdir('src/storage')
-  subdir('src/db')
+else
+  storage_glue_dep = dependency('', required: false)
 endif
 
 if neighbor_glue_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -375,12 +375,12 @@ basic_dep = declare_dependency(
   link_with: basic,
 )
 
-subdir('src/db')
 if enable_database
   subdir('src/storage')
 else
   storage_glue_dep = dependency('', required: false)
 endif
+subdir('src/db')
 
 if neighbor_glue_dep.found()
   sources += 'src/command/NeighborCommands.cxx'

--- a/src/db/meson.build
+++ b/src/db/meson.build
@@ -9,6 +9,11 @@ db_api_dep = declare_dependency(
   link_with: db_api,
 )
 
+if not enable_database
+  db_glue_dep = db_api_dep
+  subdir_done()
+endif
+
 subdir('plugins')
 
 db_glue_sources = [


### PR DESCRIPTION
Currently building with '-Ddatabase=false' fails. This fix rectifies that.