### PR TITLE
Make ffmpeg input plugin handle http/s sources if curl is disabled

### DIFF
--- a/src/input/plugins/FfmpegInputPlugin.cxx
+++ b/src/input/plugins/FfmpegInputPlugin.cxx
@@ -27,6 +27,7 @@
 #include "../InputStream.hxx"
 #include "../InputPlugin.hxx"
 #include "PluginUnavailable.hxx"
+#include "config.h"
 
 class FfmpegInputStream final : public InputStream {
 	Ffmpeg::IOContext io;
@@ -118,8 +119,10 @@ static constexpr const char *ffmpeg_prefixes[] = {
 	"rtmp://",
 	"rtmpt://",
 	"rtmps://",
+#ifndef ENABLE_CURL
 	"http://",
 	"https://",
+#endif
 	nullptr
 };
 

--- a/src/input/plugins/FfmpegInputPlugin.cxx
+++ b/src/input/plugins/FfmpegInputPlugin.cxx
@@ -118,6 +118,8 @@ static constexpr const char *ffmpeg_prefixes[] = {
 	"rtmp://",
 	"rtmpt://",
 	"rtmps://",
+	"http://",
+	"https://",
 	nullptr
 };
 


### PR DESCRIPTION
ffmpeg is capable of reading http and https sources, however MPD doesn't allow to use HTTP(S) sources unless MPD is compiled with libcurl as a dependency. This removes the need to compile MPD with libcurl if ffmpeg is enabled.