### PR TITLE
Runtime schema enumeration support

### DIFF
--- a/src/input/plugins/AlsaInputPlugin.cxx
+++ b/src/input/plugins/AlsaInputPlugin.cxx
@@ -486,4 +486,5 @@ const struct InputPlugin input_plugin_alsa = {
 	alsa_input_init,
 	nullptr,
 	alsa_input_open,
+	nullptr
 };

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -357,4 +357,5 @@ const InputPlugin input_plugin_cdio_paranoia = {
 	input_cdio_init,
 	nullptr,
 	input_cdio_open,
+	nullptr
 };

--- a/src/input/plugins/CurlInputPlugin.cxx
+++ b/src/input/plugins/CurlInputPlugin.cxx
@@ -471,16 +471,25 @@ input_curl_open(const char *url, Mutex &mutex)
 	return CurlInputStream::Open(url, {}, mutex);
 }
 
-static constexpr const char *curl_prefixes[] = {
-	"http://",
-	"https://",
-	nullptr
-};
+static std::set<std::string>
+input_curl_protocols() {
+	std::set<std::string> protocols;
+	auto version_info = curl_version_info(CURLVERSION_FIRST);
+	for (auto proto_ptr = version_info->protocols; *proto_ptr != nullptr; proto_ptr++) {
+		if (protocol_is_whitelisted(*proto_ptr)) {
+			std::string schema(*proto_ptr);
+			schema.append("://");
+			protocols.emplace(schema);
+		}
+	}
+	return protocols;
+}
 
 const struct InputPlugin input_plugin_curl = {
 	"curl",
-	curl_prefixes,
+	nullptr,
 	input_curl_init,
 	input_curl_finish,
 	input_curl_open,
+	input_curl_protocols
 };

--- a/src/input/plugins/FfmpegInputPlugin.cxx
+++ b/src/input/plugins/FfmpegInputPlugin.cxx
@@ -25,8 +25,13 @@
 #include "lib/ffmpeg/Init.hxx"
 #include "lib/ffmpeg/Error.hxx"
 #include "../InputStream.hxx"
-#include "../InputPlugin.hxx"
 #include "PluginUnavailable.hxx"
+#include "util/StringAPI.hxx"
+#include "../InputPlugin.hxx"
+#include <iostream>
+#include <exception>
+#include <typeinfo>
+#include <stdexcept>
 
 class FfmpegInputStream final : public InputStream {
 	Ffmpeg::IOContext io;
@@ -71,6 +76,22 @@ input_ffmpeg_init(EventLoop &, const ConfigBlock &)
 		throw PluginUnavailable("No protocol");
 }
 
+static std::set<std::string>
+input_ffmpeg_protocols() {
+	void *opaque = nullptr;
+	const char* protocol;
+	std::set<std::string> protocols;
+	while ((protocol = avio_enum_protocols(&opaque, 0))) {
+		if (protocol_is_whitelisted(protocol)) {
+			std::string schema(protocol);
+			schema.append("://");
+			protocols.emplace(schema);
+		}
+	}
+	
+	return protocols;
+}
+
 static InputStreamPtr
 input_ffmpeg_open(const char *uri,
 		  Mutex &mutex)
@@ -111,20 +132,11 @@ FfmpegInputStream::Seek(offset_type new_offset)
 	offset = result;
 }
 
-static constexpr const char *ffmpeg_prefixes[] = {
-	"gopher://",
-	"rtp://",
-	"rtsp://",
-	"rtmp://",
-	"rtmpt://",
-	"rtmps://",
-	nullptr
-};
-
 const InputPlugin input_plugin_ffmpeg = {
 	"ffmpeg",
-	ffmpeg_prefixes,
+	nullptr,
 	input_ffmpeg_init,
 	nullptr,
 	input_ffmpeg_open,
+	input_ffmpeg_protocols
 };

--- a/src/input/plugins/MmsInputPlugin.cxx
+++ b/src/input/plugins/MmsInputPlugin.cxx
@@ -110,4 +110,5 @@ const InputPlugin input_plugin_mms = {
 	nullptr,
 	nullptr,
 	input_mms_open,
+	nullptr
 };

--- a/src/input/plugins/NfsInputPlugin.cxx
+++ b/src/input/plugins/NfsInputPlugin.cxx
@@ -232,4 +232,5 @@ const InputPlugin input_plugin_nfs = {
 	input_nfs_init,
 	input_nfs_finish,
 	input_nfs_open,
+	nullptr
 };

--- a/src/input/plugins/QobuzInputPlugin.cxx
+++ b/src/input/plugins/QobuzInputPlugin.cxx
@@ -219,5 +219,6 @@ const InputPlugin qobuz_input_plugin = {
 	InitQobuzInput,
 	FinishQobuzInput,
 	OpenQobuzInput,
+	nullptr,
 	ScanQobuzTags,
 };

--- a/src/input/plugins/SmbclientInputPlugin.cxx
+++ b/src/input/plugins/SmbclientInputPlugin.cxx
@@ -162,4 +162,5 @@ const InputPlugin input_plugin_smbclient = {
 	input_smbclient_init,
 	nullptr,
 	input_smbclient_open,
+	nullptr
 };

--- a/src/input/plugins/TidalInputPlugin.cxx
+++ b/src/input/plugins/TidalInputPlugin.cxx
@@ -249,5 +249,6 @@ const InputPlugin tidal_input_plugin = {
 	InitTidalInput,
 	FinishTidalInput,
 	OpenTidalInput,
+	nullptr,
 	ScanTidalTags,
 };

--- a/src/ls.cxx
+++ b/src/ls.cxx
@@ -22,28 +22,41 @@
 #include "input/Registry.hxx"
 #include "input/InputPlugin.hxx"
 #include "client/Response.hxx"
-#include "util/ASCII.hxx"
 #include "util/UriUtil.hxx"
 
 #include <assert.h>
+
+#include <string>
 
 void print_supported_uri_schemes_to_fp(FILE *fp)
 {
 #ifdef HAVE_UN
 	fprintf(fp, " file://");
 #endif
+	std::set<std::string> protocols;
 	input_plugins_for_each(plugin)
-		for (auto i = plugin->prefixes; *i != nullptr; ++i)
-			fprintf(fp, " %s", *i);
+		plugin->ForeachSupportedUri([&](const char* uri) {
+			protocols.emplace(uri);
+		});
+	
+	for (auto protocol : protocols) {
+		fprintf(fp, " %s", protocol.c_str());
+	}
 	fprintf(fp,"\n");
 }
 
 void
 print_supported_uri_schemes(Response &r)
 {
+	std::set<std::string> protocols;
 	input_plugins_for_each_enabled(plugin)
-		for (auto i = plugin->prefixes; *i != nullptr; ++i)
-			r.Format("handler: %s\n", *i);
+		plugin->ForeachSupportedUri([&](const char* uri) {
+			protocols.emplace(uri);
+		});
+
+	for (auto protocol : protocols) {
+		r.Format("handler: %s\n", protocol.c_str());
+	}
 }
 
 bool
@@ -52,9 +65,7 @@ uri_supported_scheme(const char *uri) noexcept
 	assert(uri_has_scheme(uri));
 
 	input_plugins_for_each_enabled(plugin)
-		for (auto i = plugin->prefixes; *i != nullptr; ++i)
-			if (StringStartsWithCaseASCII(uri, *i))
-				return true;
+		return plugin->SupportsUri(uri);
 
 	return false;
 }


### PR DESCRIPTION
This PR adds support for enumerating input schemas at runtime. Basically, this is needed because FFMPEG libraries can be compiled with different flags and thus may or may not support gopher or rtmp, depending on the user's choice. It's a better solution, IMHO, than hardcoding supported protocols into MPD.