### PR TITLE
output/httpd: reject some well-known request paths

### DIFF
--- a/src/output/plugins/httpd/HttpdClient.cxx
+++ b/src/output/plugins/httpd/HttpdClient.cxx
@@ -71,10 +71,10 @@ HttpdClient::HandleLine(const char *line) noexcept
 	assert(state != State::RESPONSE);
 
 	if (state == State::REQUEST) {
-		if (memcmp(line, "HEAD /", 6) == 0) {
+		if (strncmp(line, "HEAD /", 6) == 0) {
 			line += 6;
 			head_method = true;
-		} else if (memcmp(line, "GET /", 5) == 0) {
+		} else if (strncmp(line, "GET /", 5) == 0) {
 			line += 5;
 		} else {
 			/* only GET is supported */
@@ -83,8 +83,20 @@ HttpdClient::HandleLine(const char *line) noexcept
 			return false;
 		}
 
+		/* blacklist some well-known request paths */
+		if ((strncmp(line, "favicon.ico", 11) == 0 &&
+				(line[11] == '\0' || line[11] == ' ')) ||
+			(strncmp(line, "robots.txt", 10) == 0 &&
+				(line[10] == '\0' || line[10] == ' ')) ||
+			(strncmp(line, "sitemap.xml", 11) == 0 &&
+				(line[11] == '\0' || line[11] == ' ')) ||
+			(strncmp(line, ".well-known/", 12) == 0))
+		{
+			should_reject = true;
+		}
+
 		line = strchr(line, ' ');
-		if (line == nullptr || memcmp(line + 1, "HTTP/", 5) != 0) {
+		if (line == nullptr || strncmp(line + 1, "HTTP/", 5) != 0) {
 			/* HTTP/0.9 without request headers */
 
 			if (head_method)
@@ -129,14 +141,21 @@ HttpdClient::SendResponse() noexcept
 
 	assert(state == State::RESPONSE);
 
-	if (metadata_requested) {
+	if (should_reject) {
+		response =
+			"HTTP/1.1 404 not found\r\n"
+			"Content-Type: text/plain\r\n"
+			"Connection: close\r\n"
+			"\r\n"
+			"404 not found";
+	} else if (metadata_requested) {
 		allocated =
 			icy_server_metadata_header(httpd.name, httpd.genre,
 						   httpd.website,
 						   httpd.content_type,
 						   metaint);
 		response = allocated.c_str();
-       } else { /* revert to a normal HTTP request */
+	} else { /* revert to a normal HTTP request */
 		snprintf(buffer, sizeof(buffer),
 			 "HTTP/1.1 200 OK\r\n"
 			 "Content-Type: %s\r\n"
@@ -415,7 +434,7 @@ HttpdClient::OnSocketInput(void *data, size_t length) noexcept
 		if (!SendResponse())
 			return InputResult::CLOSED;
 
-		if (head_method) {
+		if (head_method || should_reject) {
 			LockClose();
 			return InputResult::CLOSED;
 		}

--- a/src/output/plugins/httpd/HttpdClient.hxx
+++ b/src/output/plugins/httpd/HttpdClient.hxx
@@ -83,6 +83,11 @@ class HttpdClient final
 	 */
 	bool head_method = false;
 
+	/**
+	 * Should we reject this request?
+	 */
+	bool should_reject = false;
+
 	/* ICY */
 
 	/**


### PR DESCRIPTION
Return `404 not found` for some common well-known paths, as clients requesting them usually do that automatically and don't expect endless audio stram.
Also use strncmp instead of memcmp, as memcmp use may result in out of bounds access.