### PR TITLE
Fix DoP hiccups on Mac OS X

### DIFF
--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -922,12 +922,14 @@ bool OSXOutput::Pause() {
 void
 OSXOutput::Cancel() noexcept
 {
-	AudioOutputUnitStop(au);
-	ring_buffer->reset();
 #ifdef ENABLE_DSD
-	pcm_export->Reset();
+        pcm_export->Reset();
+        if (!dop_enabled) {
+                ring_buffer->reset();
+        }
+#else
+        ring_buffer->reset();
 #endif
-	AudioOutputUnitStart(au);
 }
 
 int

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -923,13 +923,15 @@ void
 OSXOutput::Cancel() noexcept
 {
 #ifdef ENABLE_DSD
-        pcm_export->Reset();
-        if (!dop_enabled) {
-                ring_buffer->reset();
-        }
-#else
-        ring_buffer->reset();
+        if (dop_enabled) 
+                return;
 #endif
+        AudioOutputUnitStop(au);
+        ring_buffer->reset();
+#ifdef ENABLE_DSD
+        pcm_export->Reset();
+#endif  
+        AudioOutputUnitStart(au);
 }
 
 int


### PR DESCRIPTION
see https://github.com/MusicPlayerDaemon/MPD/issues/578
Here're a few findings:

whenever AudioOutputUnitStop and AudioOutputUnitStart is called, DACs will reset their state. This will surely cause hiccups for DoP, no matter we reset the buffers or not. 

I test the following Cancel 

```
void OSXOutput::Cancel() noexcept {
  AudioOutputUnitStop(au);
  AudioOutputUnitStart(au);
}
```

And that's already suffient to make the problem occur on various DACs (either AKM or ESS based chip. either XMOS or custom USB interface). 

In this [post](https://www.forum.rme-audio.de/viewtopic.php?pid=142008#p142008), Matthias Carstens from RME believes "a player that stops sending DSD during seek operation is flawed", when I told him many players "go through stop, empty the buffer, fill the buffer with new data, start" during seek. 

I understand the reasoning behind using Start/Stop in Cancel() --- we don't have assurance that OS will consume multiple of complete frames, so without start/stop, we have no idea how many packet are left. If OS is not consuming multiple of frame packets (in DoP's case it's 4 complete frame packets), the audio stream will be broken. So I have a reply [here](https://www.forum.rme-audio.de/viewtopic.php?pid=142026#p142026) . 

At current stage, because most DACs will change mode and produce noise when AudioOutputUnitStop/AudioOutputUnitStart is called, they should not be used in DoP's case. When no Start/Stop is used, it is then impossible to count how many packets are left and drop maximum of multiples of 4 complete frames, because it has to be an atomic operation. 

So in this case, we can do nothing about it. I would rather have the 0.1s latency here rather than a corrupted stream. 

