### PR TITLE
Add the ability to specify media.role for pulse output plugin

### DIFF
--- a/doc/mpdconf.example
+++ b/doc/mpdconf.example
@@ -280,6 +280,7 @@ input {
 #	name		"My Pulse Output"
 ##	server		"remote_server"		# optional
 ##	sink		"remote_server_sink"	# optional
+##	media_role	"media_role"		#optional
 #}
 #
 # An example of a winmm output (Windows multimedia API).

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -998,6 +998,8 @@ The pulse plugin connects to a `PulseAudio <http://www.freedesktop.org/wiki/Soft
      - Sets the host name of the PulseAudio server. By default, :program:`MPD` connects to the local PulseAudio server.
    * - **sink NAME**
      - Specifies the name of the PulseAudio sink :program:`MPD` should play on.
+   * - **media_role ROLE**
+     - Specifies a custom media role that :program:`MPD` reports to PulseAudio. Default is "music". (optional).
    * - **scale_volume FACTOR**
      - Specifies a linear scaling coefficient (ranging from 0.5 to 5.0) to apply when adjusting volume through :program:`MPD`.  For example, chosing a factor equal to ``"0.7"`` means that setting the volume to 100 in :program:`MPD` will set the PulseAudio volume to 70%, and a factor equal to ``"3.5"`` means that volume 100 in :program:`MPD` corresponds to a 350% PulseAudio volume.
 

--- a/src/output/plugins/PulseOutputPlugin.cxx
+++ b/src/output/plugins/PulseOutputPlugin.cxx
@@ -45,6 +45,7 @@ class PulseOutput final : AudioOutput {
 	const char *name;
 	const char *server;
 	const char *sink;
+	const char *media_role;
 
 	PulseMixer *mixer = nullptr;
 
@@ -177,7 +178,8 @@ PulseOutput::PulseOutput(const ConfigBlock &block)
 	:AudioOutput(FLAG_ENABLE_DISABLE|FLAG_PAUSE),
 	 name(block.GetBlockValue("name", "mpd_pulse")),
 	 server(block.GetBlockValue("server")),
-	 sink(block.GetBlockValue("sink"))
+	 sink(block.GetBlockValue("sink")),
+	 media_role(block.GetBlockValue("media_role"))
 {
 	setenv("PULSE_PROP_media.role", "music", true);
 	setenv("PULSE_PROP_application.icon_name", "mpd", true);
@@ -393,8 +395,16 @@ PulseOutput::SetupContext()
 {
 	assert(mainloop != nullptr);
 
-	context = pa_context_new(pa_threaded_mainloop_get_api(mainloop),
-				 MPD_PULSE_NAME);
+	pa_proplist *proplist = pa_proplist_new();
+	if (media_role)
+		pa_proplist_sets(proplist, PA_PROP_MEDIA_ROLE, media_role);
+
+	context = pa_context_new_with_proplist(pa_threaded_mainloop_get_api(mainloop),
+											MPD_PULSE_NAME,
+											proplist);
+
+	pa_proplist_free(proplist);
+
 	if (context == nullptr)
 		throw std::runtime_error("pa_context_new() has failed");
 


### PR DESCRIPTION
This merge request provide the ability to specify a custom media.role for pulse output plugin.

This is useful in multiple mpd instances scenario, or multiple pulse outputs defined on the same mpd instance.
It actually a more flexible way to route flows than the "sink" parameter, letting the pulse routing do its job, but with the ability to isolate routing for each output.
If not specified, the role remains like before ("music")

In audio_output section, specify like this:

```
audio_output {
        type                    "pulse"
        name                    "Local"
        media_role               "mycustomrole"
}
```
Your streams associated with this output will appears like this in pulse:

Sink Input #14
        Driver: protocol-native.c
        Owner Module: 11
        Client: 24
        Sink: 2
        Sample Specification: s16le 2ch 44100Hz
        Channel Map: front-left,front-right
        Format: pcm, format.sample_format = "\"s16le\""  format.rate = "44100"  format.channels = "2"  format.channel_map = "\"front-left,front-right\""
        Corked: no
        Mute: no
        Volume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB
                balance 0.00
        Buffer Latency: 267664 usec
        Sink Latency: 178076 usec
        Resample method: n/a
        Properties:
                media.name = "Local"
                application.name = "Music Player Daemon"
                native-protocol.peer = "UNIX socket client"
                native-protocol.version = "32"
                **media.role = "mycustomrole"**
                application.icon_name = "mpd"
                application.process.id = "9117"
                application.process.user = "rodriguo"
                application.process.host = "myarch"
                application.process.binary = "mpd"
                application.language = "C"
                application.process.machine_id = "35a06a8c24ca4246a18a7a3170362d3f"
                application.process.session_id = "5"
                **module-stream-restore.id = "sink-input-by-media-role:mycustomrole"**

