### PR TITLE
Fix JACK plugin outputting mono input only to left channel

### DIFF
--- a/src/output/plugins/JackOutputPlugin.cxx
+++ b/src/output/plugins/JackOutputPlugin.cxx
@@ -539,7 +539,7 @@ JackOutput::Start()
 		std::fill(dports + num_dports, dports + audio_format.channels,
 			  dports[0]);
 	} else if (num_dports > audio_format.channels) {
-		if (audio_format.channels == 1 && num_dports > 2) {
+		if (audio_format.channels == 1 && num_dports >= 2) {
 			/* mono input file: connect the one source
 			   channel to the both destination channels */
 			duplicate_port = dports[1];


### PR DESCRIPTION
The JACK output plugin would not correctly upmix mono input files when exactly 2 output ports were configured. This fixes that.