### PR TITLE
decoder/sidplay: Add "default_genre" option

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -485,6 +485,8 @@ C64 SID decoder based on `libsidplayfp <https://sourceforge.net/projects/sidplay
      - Location of your songlengths file, as distributed with the HVSC. The sidplay plugin checks this for matching MD5 fingerprints. See http://www.hvsc.c64.org/download/C64Music/DOCUMENTS/Songlengths.faq.
    * - **default_songlength SECONDS**
      - This is the default playing time in seconds for songs not in the songlength database, or in case you're not using a database. A value of 0 means play indefinitely.
+   * - **default_genre GENRE**
+     - Optional default genre for SID songs.
    * - **filter yes|no**
      - Turns the SID filter emulation on or off.
    * - **kernal**

--- a/src/decoder/plugins/SidplayDecoderPlugin.cxx
+++ b/src/decoder/plugins/SidplayDecoderPlugin.cxx
@@ -68,6 +68,7 @@ static SidDatabase *songlength_database;
 
 static bool all_files_are_containers;
 static unsigned default_songlength;
+static std::string default_genre;
 
 static bool filter_setting;
 
@@ -115,6 +116,8 @@ sidplay_init(const ConfigBlock &block)
 		songlength_database = sidplay_load_songlength_db(database_path);
 
 	default_songlength = block.GetPositiveValue("default_songlength", 0u);
+
+	default_genre = block.GetBlockValue("default_genre", "");
 
 	all_files_are_containers =
 		block.GetBlockValue("all_files_are_containers", true);
@@ -470,6 +473,10 @@ ScanSidTuneInfo(const SidTuneInfo &info, unsigned track, unsigned n_tracks,
 	const char *artist = GetInfoString(info, 1);
 	if (artist != nullptr)
 		handler.OnTag(TAG_ARTIST, artist);
+
+	/* genre */
+	if (!default_genre.empty())
+		handler.OnTag(TAG_GENRE, default_genre.c_str());
 
 	/* date */
 	const char *date = GetInfoString(info, 2);


### PR DESCRIPTION
Genres are not part of the SID format, so SID files are genreless. This
"default_genre" option may be used to assign a default genre to all SID
music, for example "SID", "C64", "Chiptune", etc.