### PR TITLE
 decoder/sidplay: Fix date field to have year but not company or author

### DIFF
--- a/src/decoder/plugins/SidplayDecoderPlugin.cxx
+++ b/src/decoder/plugins/SidplayDecoderPlugin.cxx
@@ -481,6 +481,30 @@ GetInfoString(const SidTuneInfo &info, unsigned i)
 	return Windows1252ToUTF8(s);
 }
 
+gcc_pure
+static AllocatedString<char>
+GetDateString(const SidTuneInfo &info)
+{
+	/*
+	 * Field 2 is called <released>, previously used as <copyright>.
+	 * It is formatted <year><space><company or author or group>,
+	 * where <year> may be <YYYY>, <YYY?>, <YY??> or <YYYY-YY>, for
+	 * example "1987", "199?", "19??" or "1985-87". The <company or
+	 * author or group> may be for example Rob Hubbard. A full field
+	 * may be for example "1987 Rob Hubbard".
+	 */
+	AllocatedString<char> release = GetInfoString(info, 2);
+
+	/* Keep the <year> part only for the date. */
+	for (size_t i = 0; release[i] != AllocatedString<char>::SENTINEL; i++)
+		if (std::isspace(release[i])) {
+			release[i] = AllocatedString<char>::SENTINEL;
+			break;
+		}
+
+	return release;
+}
+
 static void
 ScanSidTuneInfo(const SidTuneInfo &info, unsigned track, unsigned n_tracks,
 		TagHandler &handler) noexcept
@@ -514,7 +538,7 @@ ScanSidTuneInfo(const SidTuneInfo &info, unsigned track, unsigned n_tracks,
 
 	try {
 		/* date */
-		AllocatedString<char> date = GetInfoString(info, 2);
+		AllocatedString<char> date = GetDateString(info);
 		if (!date.empty())
 			handler.OnTag(TAG_DATE, date.c_str());
 	} catch (...) { }

--- a/src/decoder/plugins/SidplayDecoderPlugin.cxx
+++ b/src/decoder/plugins/SidplayDecoderPlugin.cxx
@@ -486,17 +486,19 @@ ScanSidTuneInfo(const SidTuneInfo &info, unsigned track, unsigned n_tracks,
 		TagHandler &handler) noexcept
 {
 	try {
-		/* title */
-		AllocatedString<char> title = GetInfoString(info, 0);
+		/* album */
+		AllocatedString<char> album = GetInfoString(info, 0);
+
+		handler.OnTag(TAG_ALBUM, album.c_str());
 
 		if (n_tracks > 1) {
 			const auto tag_title =
 				StringFormat<1024>("%s (%u/%u)",
-						   title.c_str(),
+						   album.c_str(),
 						   track, n_tracks);
 			handler.OnTag(TAG_TITLE, tag_title.c_str());
 		} else
-			handler.OnTag(TAG_TITLE, title.c_str());
+			handler.OnTag(TAG_TITLE, album.c_str());
 	} catch (...) { }
 
 	try {

--- a/src/decoder/plugins/SidplayDecoderPlugin.cxx
+++ b/src/decoder/plugins/SidplayDecoderPlugin.cxx
@@ -25,6 +25,7 @@
 #include "song/DetachedSong.hxx"
 #include "fs/Path.hxx"
 #include "fs/AllocatedPath.hxx"
+#include "lib/icu/Converter.hxx"
 #ifdef HAVE_SIDPLAYFP
 #include "fs/io/FileReader.hxx"
 #include "util/RuntimeError.hxx"
@@ -33,6 +34,7 @@
 #include "util/StringView.hxx"
 #include "util/Domain.hxx"
 #include "util/ByteOrder.hxx"
+#include "util/AllocatedString.hxx"
 #include "Log.hxx"
 
 #ifdef HAVE_SIDPLAYFP
@@ -437,51 +439,83 @@ sidplay_file_decode(DecoderClient &client, Path path_fs)
 	} while (cmd != DecoderCommand::STOP);
 }
 
+static AllocatedString<char>
+Windows1252ToUTF8(const char *s)
+{
+#ifdef HAVE_ICU_CONVERTER
+	try {
+		std::unique_ptr<IcuConverter>
+			converter(IcuConverter::Create("windows-1252"));
+
+		return converter->ToUTF8(s);
+	} catch (...) { }
+#endif
+
+	/*
+	 * Fallback to not transcoding windows-1252 to utf-8, that may result
+	 * in invalid utf-8 unless nonprintable characters are replaced.
+	 */
+	AllocatedString<char> t = AllocatedString<char>::Duplicate(s);
+
+	for (size_t i = 0; t[i] != AllocatedString<char>::SENTINEL; i++)
+		if (!std::isprint(t[i]))
+			t[i] = '?';
+
+	return t;
+}
+
 gcc_pure
-static const char *
-GetInfoString(const SidTuneInfo &info, unsigned i) noexcept
+static AllocatedString<char>
+GetInfoString(const SidTuneInfo &info, unsigned i)
 {
 #ifdef HAVE_SIDPLAYFP
-	return info.numberOfInfoStrings() > i
+	const char *s = info.numberOfInfoStrings() > i
 		? info.infoString(i)
-		: nullptr;
+		: "";
 #else
-	return info.numberOfInfoStrings > i
+	const char *s = info.numberOfInfoStrings > i
 		? info.infoString[i]
-		: nullptr;
+		: "";
 #endif
+
+	return Windows1252ToUTF8(s);
 }
 
 static void
 ScanSidTuneInfo(const SidTuneInfo &info, unsigned track, unsigned n_tracks,
 		TagHandler &handler) noexcept
 {
-	/* title */
-	const char *title = GetInfoString(info, 0);
-	if (title == nullptr)
-		title = "";
+	try {
+		/* title */
+		AllocatedString<char> title = GetInfoString(info, 0);
 
-	if (n_tracks > 1) {
-		const auto tag_title =
-			StringFormat<1024>("%s (%u/%u)",
-					   title, track, n_tracks);
-		handler.OnTag(TAG_TITLE, tag_title.c_str());
-	} else
-		handler.OnTag(TAG_TITLE, title);
+		if (n_tracks > 1) {
+			const auto tag_title =
+				StringFormat<1024>("%s (%u/%u)",
+						   title.c_str(),
+						   track, n_tracks);
+			handler.OnTag(TAG_TITLE, tag_title.c_str());
+		} else
+			handler.OnTag(TAG_TITLE, title.c_str());
+	} catch (...) { }
 
-	/* artist */
-	const char *artist = GetInfoString(info, 1);
-	if (artist != nullptr)
-		handler.OnTag(TAG_ARTIST, artist);
+	try {
+		/* artist */
+		AllocatedString<char> artist = GetInfoString(info, 1);
+		if (!artist.empty())
+			handler.OnTag(TAG_ARTIST, artist.c_str());
+	} catch (...) { }
 
 	/* genre */
 	if (!default_genre.empty())
 		handler.OnTag(TAG_GENRE, default_genre.c_str());
 
-	/* date */
-	const char *date = GetInfoString(info, 2);
-	if (date != nullptr)
-		handler.OnTag(TAG_DATE, date);
+	try {
+		/* date */
+		AllocatedString<char> date = GetInfoString(info, 2);
+		if (!date.empty())
+			handler.OnTag(TAG_DATE, date.c_str());
+	} catch (...) { }
 
 	/* track */
 	handler.OnTag(TAG_TRACK, StringFormat<16>("%u", track).c_str());


### PR DESCRIPTION
```
Field 2 is called <released>, formerly used as <copyright>[1][2]. It is
formatted <year><space><company or author or group>, where <year> may be
<YYYY>, <YYY?>, <YY??> or <YYYY-YY>, for example "1987", "199?", "19??"
or "1985-87". The <company or author or group> may be for example Rob
Hubbard. A full field may be for example "1987 Rob Hubbard".

This change splits the <released> field at the first <space>, to retain
the <year> part.

The 51823 SID files in High Voltage SID Collection (HVSC) version 71
have the following distribution of dates:

    333 19??         11 1990-92       6 1995-99       2 2006-08
    827 198?         88 1990-93    2140 1996        530 2007
     32 1982         69 1990-94       9 1996-97      15 2007-08
      1 1982-83      49 1990-95       2 1996-98       2 2007-09
    255 1983       3467 1991          5 1996-99       1 2007-10
    677 1984         75 1991-92    1840 1997        430 2008
    775 1985         65 1991-93       4 1997-98      23 2008-09
      3 1985-86      10 1991-94    1276 1998          1 2008-12
     10 1985-87      35 1991-97       4 1998-99     631 2009
    943 1986       3320 1992        865 1999          1 2009-10
     12 1986-87      26 1992-93      24 200?        645 2010
      5 1986-89      59 1992-94     590 2000          1 2010-12
   2083 1987          1 1992-96       4 2000-01     538 2011
     31 1987-88    2996 1993        727 2001          1 2011-12
     44 1987-89      42 1993-94     875 2002        651 2012
   2510 1988         12 1993-95       2 2002-04     811 2013
    129 1988-89       2 1993-97     844 2003        790 2014
     91 1988-90    2737 1994          3 2003-05     740 2015
     58 1988-91      16 1994-95     842 2004        792 2016
   3466 1989         20 1994-96       2 2004-05     775 2017
     95 1989-90      17 1994-97     707 2005        638 2018
    150 1989-91    2271 1995          1 2005-06     284 2019
   1077 199?          2 1995-96       2 2005-07
   2834 1990          4 1995-97     785 2006
    119 1990-91       2 1995-98       6 2006-07

References:

[1] https://www.hvsc.c64.org/download/C64Music/DOCUMENTS/SID_file_format.txt
[2] https://hvsc.c64.org/info
```