### PR TITLE
Build documentation with sphinx_rtd_theme

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,7 @@ ver 0.22 (not yet released)
 * lower the real-time priority from 50 to 40
 * switch to C++17
   - GCC 7 or clang 4 (or newer) recommended
+* doc: require sphinx_rtd_theme python module
 
 ver 0.21.16 (2019/10/16)
 * queue

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,6 +1,11 @@
 install_man(['mpd.1', 'mpd.conf.5'])
 
 sphinx = find_program('sphinx-build')
+py = import('python').find_installation()
+if run_command(py, '-c', 'import sphinx_rtd_theme').returncode() != 0
+  error('python module "sphinx_rtd_theme" not found')
+endif
+
 sphinx_output = custom_target(
   'HTML documentation',
   output: 'html',
@@ -10,7 +15,7 @@ sphinx_output = custom_target(
     'protocol.rst',
     'conf.py',
   ],
-  command: [sphinx, '-q', '-b', 'html', '-d', '@OUTDIR@/doctrees', meson.current_source_dir(), '@OUTPUT@'],
+  command: [sphinx, '-q', '-b', 'html', '-d', '@OUTDIR@/doctrees', meson.current_source_dir(), '@OUTPUT@', '-D',  'html_theme=sphinx_rtd_theme'],
   build_by_default: true,
   install: true,
   install_dir: join_paths(get_option('datadir'), 'doc', meson.project_name()),


### PR DESCRIPTION
With latter version of meson (>= 0.51.0) it could be more elegant using
something like:

    import('python').find_installation(modules : ['sphinx_rtd_theme'])

https://mesonbuild.com/Python-module.html