### PR TITLE
AlsaMixerPlugin.cxx: prevent alsa assertion failure

### DIFF
--- a/src/mixer/plugins/AlsaMixerPlugin.cxx
+++ b/src/mixer/plugins/AlsaMixerPlugin.cxx
@@ -146,6 +146,7 @@ alsa_mixer_elem_callback(snd_mixer_elem_t *elem, unsigned mask)
 		snd_mixer_elem_get_callback_private(elem);
 
 	if (mask & SND_CTL_EVENT_MASK_REMOVE) {
+		mixer.open = false;
 		return -ENODEV;
 	}
 

--- a/src/mixer/plugins/AlsaMixerPlugin.cxx
+++ b/src/mixer/plugins/AlsaMixerPlugin.cxx
@@ -145,6 +145,10 @@ alsa_mixer_elem_callback(snd_mixer_elem_t *elem, unsigned mask)
 	AlsaMixer &mixer = *(AlsaMixer *)
 		snd_mixer_elem_get_callback_private(elem);
 
+	if (mask & SND_CTL_EVENT_MASK_REMOVE) {
+		return -ENODEV;
+	}
+
 	if (mask & SND_CTL_EVENT_MASK_VALUE) {
 		try {
 			int volume = mixer.GetVolume();


### PR DESCRIPTION
When a hot-pluggable mixer is removed, the mixer handle becomes invalid: this commit handles the SND_CTL_EVENT_MASK_REMOVE event to prevent MPD from using that invalid handle