### PR TITLE
Add missing meson dependencies (fixes MacPorts build)

### DIFF
--- a/src/filter/plugins/meson.build
+++ b/src/filter/plugins/meson.build
@@ -23,6 +23,9 @@ filter_plugins = static_library(
   'VolumeFilterPlugin.cxx',
   filter_plugins_sources,
   include_directories: inc,
+  dependencies: [
+    filter_plugins_deps,
+  ],
 )
 
 filter_plugins_dep = declare_dependency(

--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -40,6 +40,9 @@ input_glue = static_library(
   'cache/Item.cxx',
   'cache/Stream.cxx',
   include_directories: inc,
+  dependencies: [
+    boost_dep,
+  ],
 )
 
 input_glue_dep = declare_dependency(

--- a/src/lib/xiph/meson.build
+++ b/src/lib/xiph/meson.build
@@ -52,6 +52,9 @@ xiph = static_library(
   'VorbisPicture.cxx',
   'XiphTags.cxx',
   include_directories: inc,
+  dependencies: [
+    libvorbis_dep,
+  ],
 )
 
 xiph_dep = declare_dependency(


### PR DESCRIPTION
I'm not sure why it keeps happening to me, but on my macOS / MacPorts machine, Meson is finnicky about dependencies. Without these changes I get "header not found" errors.