### PR TITLE
input/cache: use simpler intrusive::set API

### DIFF
--- a/src/input/cache/Manager.cxx
+++ b/src/input/cache/Manager.cxx
@@ -81,11 +81,9 @@ InputCacheManager::Get(const char *uri, bool create)
 	if (!PathTraitsUTF8::IsAbsolute(uri))
 		return {};
 
-	UriMap::insert_commit_data hint;
-	auto result = items_by_uri.insert_check(uri, items_by_uri.key_comp(),
-						hint);
-	if (!result.second) {
-		auto &item = *result.first;
+	auto iter = items_by_uri.find(uri, items_by_uri.key_comp());
+	if (iter != items_by_uri.end()) {
+		auto &item = *iter;
 
 		/* refresh */
 		items_by_time.erase(items_by_time.iterator_to(item));
@@ -112,7 +110,7 @@ InputCacheManager::Get(const char *uri, bool create)
 	while (total_size > max_total_size && EvictOldestUnused()) {}
 
 	auto *item = new InputCacheItem(std::move(is));
-	items_by_uri.insert_commit(*item, hint);
+	items_by_uri.insert(*item);
 	items_by_time.push_back(*item);
 
 	return InputCacheLease(*item);


### PR DESCRIPTION
This fixes https://github.com/MusicPlayerDaemon/MPD/issues/691

In that issue we found a bug in `InputCacheManager::Get` due to incorrect use of the Boost intrusive::set API. The pair of functions `insert_check`/`insert_commit` allow you to amortize the cost of a tree walk across two function calls. This performance gain comes at the cost of complexity: you may not modify the tree in between `insert_check` and `insert_commit`.

If you do modify the tree, you will get sporadic runtime assertion failures (i.e. crashes). This is the cause of #691.

My gut feeling is that `InputCacheManager::Get` is too complex to use `insert_check` / `insert_commit` correctly. I would have to add comments to remind myself of what is going on, and why things need to happen in just the right order. I also don't see a way to make the function simpler. So for the sake of readability and robustness, I think we shouldn't use `insert_check` / `insert_commit` here and just use `find` and `insert`.