### PR TITLE
StringBuffer: Include cstddef for size_t

### DIFF
--- a/src/util/StringBuffer.hxx
+++ b/src/util/StringBuffer.hxx
@@ -31,6 +31,7 @@
 #define STRING_BUFFER_HXX
 
 #include <array>
+#include <cstddef>
 
 /**
  * A statically allocated string buffer.


### PR DESCRIPTION
Fixes
a.cpp:3:1: error: 'size_t' does not name a type
    3 | size_t s;
      | ^~~~~~
a.cpp:2:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?