### PR TITLE
util: do not use (C++) fallthrough in C file

### DIFF
--- a/src/util/format.c
+++ b/src/util/format.c
@@ -19,7 +19,6 @@
  */
 
 #include "format.h"
-#include "util/Compiler.h"
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -239,7 +238,6 @@ format_object2(const char *format, const char **last, const void *object,
 			}
 
 			/* fall through */
-			gcc_fallthrough;
 
 		default:
 			/* pass-through non-escaped portions of the format string */


### PR DESCRIPTION
Fixes https://github.com/MusicPlayerDaemon/MPD/issues/698

It appears `[[fallthrough]]` is specific to C++. In a1afe9afc6879960389491b6fb587f14ae1ae5df we added this attribute to `src/util/format.c`, which is not a C++ file. Clang 11 on macOS does not like this: it causes compilation to fail with:

```
../src/util/format.c:242:4: error: expected expression
                        gcc_fallthrough;
                        ^
../src/util/Compiler.h:149:25: note: expanded from macro 'gcc_fallthrough'
#define gcc_fallthrough [[fallthrough]]
```