### PR TITLE
Clang: only use [[fallthrough]] in C++ files

### DIFF
--- a/src/util/Compiler.h
+++ b/src/util/Compiler.h
@@ -145,7 +145,7 @@
 
 #if GCC_CHECK_VERSION(7,0)
 #define gcc_fallthrough __attribute__((fallthrough))
-#elif CLANG_CHECK_VERSION(10,0)
+#elif CLANG_CHECK_VERSION(10,0) && defined(__cplusplus)
 #define gcc_fallthrough [[fallthrough]]
 #else
 #define gcc_fallthrough


### PR DESCRIPTION
It appears that [[fallthrough]] is valid in C++ but not in C. And
in some Clang versions (e.g. Clang 11 on macOS), Clang is pedantic
about this and considers it an error to use [[fallthrough]] in a
.c file such as src/util/format.c.

This changes makes gcc_fallthrough a no-op under Clang in C files.

Fixes #698