### PR TITLE
playlist/PlaylistSong: also copy start and end time in merge_song_metadata

### DIFF
--- a/src/playlist/PlaylistSong.cxx
+++ b/src/playlist/PlaylistSong.cxx
@@ -40,6 +40,13 @@ merge_song_metadata(DetachedSong &add, const DetachedSong &base) noexcept
 	}
 
 	add.SetLastModified(base.GetLastModified());
+
+	if (add.GetStartTime().IsZero()) {
+		add.SetStartTime(base.GetStartTime());
+	}
+	if (add.GetEndTime().IsZero()) {
+		add.SetEndTime(base.GetEndTime());
+	}
 }
 
 static bool


### PR DESCRIPTION
This is needed to correctly load playlist entries that reference a song in a cuesheet that is treated as a folder.

Currently, if songs that are part of a cuesheet that is treated as a folder are stored in a playlist and the playlist is loaded the queue is populated with the individual songs according to their metadata but reference the whole audio file referenced by the cuesheet, instead of only the parts that actually belong to the individual songs.

This behavior is fixed with this PR by copying the start and end time over in merge_song_metadata.