### PR TITLE
SocketUtil: explicitly set V6ONLY socket option

### DIFF
--- a/src/net/SocketDescriptor.cxx
+++ b/src/net/SocketDescriptor.cxx
@@ -322,12 +322,6 @@ SocketDescriptor::SetTcpUserTimeout(const unsigned &milliseconds) noexcept
 }
 
 bool
-SocketDescriptor::SetV6Only(bool value) noexcept
-{
-	return SetBoolOption(IPPROTO_IPV6, IPV6_V6ONLY, value);
-}
-
-bool
 SocketDescriptor::SetBindToDevice(const char *name) noexcept
 {
 	return SetOption(SOL_SOCKET, SO_BINDTODEVICE, name, strlen(name));
@@ -377,6 +371,12 @@ SocketDescriptor::AddMembership(SocketAddress address) noexcept
 }
 
 #endif
+
+bool
+SocketDescriptor::SetV6Only(bool value) noexcept
+{
+	return SetBoolOption(IPPROTO_IPV6, IPV6_V6ONLY, value);
+}
 
 bool
 SocketDescriptor::Bind(SocketAddress address) noexcept

--- a/src/net/SocketDescriptor.hxx
+++ b/src/net/SocketDescriptor.hxx
@@ -195,8 +195,6 @@ public:
 	 */
 	bool SetTcpUserTimeout(const unsigned &milliseconds) noexcept;
 
-	bool SetV6Only(bool value) noexcept;
-
 	/**
 	 * Setter for SO_BINDTODEVICE.
 	 */
@@ -208,6 +206,8 @@ public:
 	bool AddMembership(const IPv6Address &address) noexcept;
 	bool AddMembership(SocketAddress address) noexcept;
 #endif
+
+	bool SetV6Only(bool value) noexcept;
 
 	bool Bind(SocketAddress address) noexcept;
 

--- a/src/net/SocketUtil.cxx
+++ b/src/net/SocketUtil.cxx
@@ -41,8 +41,11 @@ socket_bind_listen(int domain, int type, int protocol,
 	}
 #endif
 
+	if (domain == AF_INET6 && !fd.SetV6Only(true))
+		throw MakeSocketError("setsockopt() failed for V6ONLY");
+
 	if (!fd.SetReuseAddress())
-		throw MakeSocketError("setsockopt() failed");
+		throw MakeSocketError("setsockopt() failed for REUSEADDR");
 
 	if (!fd.Bind(address))
 		throw MakeSocketError("Failed to bind socket");


### PR DESCRIPTION
Currently, MPD emits the following warning on Linux when
`net.ipv6.bindv6only` is set to the default value zero:

	exception: bind to '0.0.0.0:6600' failed (continuing anyway, because binding to '[::]:6600' succeeded): Failed to bind socket: Address already in use

This is a known issues (#673, #557, …) caused by the fact that MPD, by
default, creates separate sockets for `AF_INET` and `AF_INET6`. With
this architecture it is not necessary to use the `AF_INET6` socket for
both IPv6 and IPv4. For this reason, explicitly enable the V6ONLY
socket option for `AF_INET6` sockets, thereby preventing the error
causing the warning to be emitted.