### PR TITLE
MadDecoderPlugin: fix bad printf format

### DIFF
--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -760,7 +760,7 @@ MadDecoder::DecodeFirstFrame(Tag *tag) noexcept
 
 	if (max_frames > 8 * 1024 * 1024) {
 		FormatWarning(mad_domain,
-			      "mp3 file header indicates too many frames: %lu",
+			      "mp3 file header indicates too many frames: %zu",
 			      max_frames);
 		return false;
 	}


### PR DESCRIPTION
max_frames is size_t, not unsigned long. Fixes GCC warning.