### PR TITLE
[clang-tidy] use override instead of virtual

### DIFF
--- a/src/archive/plugins/Bzip2ArchivePlugin.cxx
+++ b/src/archive/plugins/Bzip2ArchivePlugin.cxx
@@ -47,7 +47,7 @@ public:
 			name.erase(len - 4);
 	}
 
-	virtual void Visit(ArchiveVisitor &visitor) override {
+	void Visit(ArchiveVisitor &visitor) override {
 		visitor.VisitArchiveEntry(name.c_str());
 	}
 
@@ -68,7 +68,7 @@ public:
 	Bzip2InputStream(const std::shared_ptr<InputStream> &_input,
 			 const char *uri,
 			 Mutex &mutex);
-	~Bzip2InputStream();
+	~Bzip2InputStream() override;
 
 	/* virtual methods from InputStream */
 	bool IsEOF() const noexcept override;

--- a/src/archive/plugins/Iso9660ArchivePlugin.cxx
+++ b/src/archive/plugins/Iso9660ArchivePlugin.cxx
@@ -71,7 +71,7 @@ public:
 	void Visit(char *path, size_t length, size_t capacity,
 		   ArchiveVisitor &visitor);
 
-	virtual void Visit(ArchiveVisitor &visitor) override;
+	void Visit(ArchiveVisitor &visitor) override;
 
 	InputStreamPtr OpenStream(const char *path,
 				  Mutex &mutex) override;
@@ -152,7 +152,7 @@ public:
 		SetReady();
 	}
 
-	~Iso9660InputStream() {
+	~Iso9660InputStream() override {
 		free(statbuf);
 	}
 

--- a/src/archive/plugins/ZzipArchivePlugin.cxx
+++ b/src/archive/plugins/ZzipArchivePlugin.cxx
@@ -57,7 +57,7 @@ public:
 	ZzipArchiveFile(std::shared_ptr<ZzipDir> &&_dir)
 		:dir(std::move(_dir)) {}
 
-	virtual void Visit(ArchiveVisitor &visitor) override;
+	void Visit(ArchiveVisitor &visitor) override;
 
 	InputStreamPtr OpenStream(const char *path,
 				  Mutex &mutex) override;
@@ -106,7 +106,7 @@ public:
 		SetReady();
 	}
 
-	~ZzipInputStream() {
+	~ZzipInputStream() override {
 		zzip_file_close(file);
 	}
 

--- a/src/db/update/Archive.cxx
+++ b/src/db/update/Archive.cxx
@@ -107,7 +107,7 @@ class UpdateArchiveVisitor final : public ArchiveVisitor {
 			     Directory &_directory) noexcept
 		:walk(_walk), archive(_archive), directory(_directory) {}
 
-	virtual void VisitArchiveEntry(const char *path_utf8) override {
+	void VisitArchiveEntry(const char *path_utf8) override {
 		FormatDebug(update_domain,
 			    "adding archive file: %s", path_utf8);
 		walk.UpdateArchiveTree(archive, directory, path_utf8);

--- a/src/event/FullyBufferedSocket.hxx
+++ b/src/event/FullyBufferedSocket.hxx
@@ -69,7 +69,7 @@ protected:
 	/* virtual methods from class SocketMonitor */
 	bool OnSocketReady(unsigned flags) noexcept override;
 
-	virtual void OnIdle() noexcept override;
+	void OnIdle() noexcept override;
 };
 
 #endif

--- a/src/filter/NullFilter.hxx
+++ b/src/filter/NullFilter.hxx
@@ -27,7 +27,7 @@ class NullFilter final : public Filter {
 public:
 	explicit NullFilter(const AudioFormat &af):Filter(af) {}
 
-	virtual ConstBuffer<void> FilterPCM(ConstBuffer<void> src) override {
+	ConstBuffer<void> FilterPCM(ConstBuffer<void> src) override {
 		return src;
 	}
 };

--- a/src/filter/Observer.cxx
+++ b/src/filter/Observer.cxx
@@ -36,7 +36,7 @@ public:
 		:observer(_observer),
 		 prepared_filter(std::move(_prepared_filter)) {}
 
-	~PreparedProxy() noexcept {
+	~PreparedProxy() noexcept override {
 		assert(child == nullptr);
 		assert(observer.proxy == this);
 
@@ -63,7 +63,7 @@ public:
 		:Filter(_filter->GetOutAudioFormat()),
 		 parent(_parent), filter(std::move(_filter)) {}
 
-	~Proxy() noexcept {
+	~Proxy() noexcept override {
 		parent.Clear(this);
 	}
 

--- a/src/filter/plugins/NormalizeFilterPlugin.cxx
+++ b/src/filter/plugins/NormalizeFilterPlugin.cxx
@@ -38,7 +38,7 @@ public:
 		:Filter(audio_format), compressor(Compressor_new(0)) {
 	}
 
-	~NormalizeFilter() {
+	~NormalizeFilter() override {
 		Compressor_delete(compressor);
 	}
 

--- a/src/filter/plugins/NullFilterPlugin.cxx
+++ b/src/filter/plugins/NullFilterPlugin.cxx
@@ -32,7 +32,7 @@
 
 class PreparedNullFilter final : public PreparedFilter {
 public:
-	virtual std::unique_ptr<Filter> Open(AudioFormat &af) override {
+	std::unique_ptr<Filter> Open(AudioFormat &af) override {
 		return std::make_unique<NullFilter>(af);
 	}
 };

--- a/src/fs/io/AutoGunzipReader.hxx
+++ b/src/fs/io/AutoGunzipReader.hxx
@@ -40,7 +40,7 @@ public:
 	~AutoGunzipReader() noexcept;
 
 	/* virtual methods from class Reader */
-	virtual size_t Read(void *data, size_t size) override;
+	size_t Read(void *data, size_t size) override;
 
 private:
 	void Detect();

--- a/src/fs/io/PeekReader.hxx
+++ b/src/fs/io/PeekReader.hxx
@@ -43,7 +43,7 @@ public:
 	const void *Peek(size_t size);
 
 	/* virtual methods from class Reader */
-	virtual size_t Read(void *data, size_t size) override;
+	size_t Read(void *data, size_t size) override;
 };
 
 #endif

--- a/src/input/AsyncInputStream.hxx
+++ b/src/input/AsyncInputStream.hxx
@@ -74,7 +74,7 @@ public:
 			 size_t _buffer_size,
 			 size_t _resume_at) noexcept;
 
-	virtual ~AsyncInputStream() noexcept;
+	~AsyncInputStream() noexcept override;
 
 	auto &GetEventLoop() const noexcept {
 		return deferred_resume.GetEventLoop();

--- a/src/input/plugins/AlsaInputPlugin.cxx
+++ b/src/input/plugins/AlsaInputPlugin.cxx
@@ -89,7 +89,7 @@ public:
 			Mutex &_mutex,
 			const SourceSpec &spec);
 
-	~AlsaInputStream() {
+	~AlsaInputStream() override {
 		BlockingCall(MultiSocketMonitor::GetEventLoop(), [this](){
 				MultiSocketMonitor::Reset();
 				defer_invalidate_sockets.Cancel();
@@ -103,13 +103,13 @@ public:
 
 protected:
 	/* virtual methods from AsyncInputStream */
-	virtual void DoResume() override {
+	void DoResume() override {
 		snd_pcm_resume(capture_handle);
 
 		InvalidateSockets();
 	}
 
-	virtual void DoSeek(gcc_unused offset_type new_offset) override {
+	void DoSeek(gcc_unused offset_type new_offset) override {
 		/* unreachable because seekable==false */
 		SeekDone();
 	}

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -81,7 +81,7 @@ class CdioParanoiaInputStream final : public InputStream {
 		SetReady();
 	}
 
-	~CdioParanoiaInputStream() {
+	~CdioParanoiaInputStream() override {
 		para = {};
 		cdio_cddap_close_no_free_cdio(drv);
 		cdio_destroy(cdio);

--- a/src/input/plugins/CurlInputPlugin.cxx
+++ b/src/input/plugins/CurlInputPlugin.cxx
@@ -85,7 +85,7 @@ public:
 			I &&_icy,
 			Mutex &_mutex);
 
-	~CurlInputStream() noexcept;
+	~CurlInputStream() noexcept override;
 
 	CurlInputStream(const CurlInputStream &) = delete;
 	CurlInputStream &operator=(const CurlInputStream &) = delete;
@@ -137,8 +137,8 @@ private:
 	void OnError(std::exception_ptr e) noexcept override;
 
 	/* virtual methods from AsyncInputStream */
-	virtual void DoResume() override;
-	virtual void DoSeek(offset_type new_offset) override;
+	void DoResume() override;
+	void DoSeek(offset_type new_offset) override;
 };
 
 /** libcurl should accept "ICY 200 OK" */

--- a/src/input/plugins/MmsInputPlugin.cxx
+++ b/src/input/plugins/MmsInputPlugin.cxx
@@ -42,8 +42,8 @@ public:
 	}
 
 protected:
-	virtual void Open() override;
-	virtual size_t ThreadRead(void *ptr, size_t size) override;
+	void Open() override;
+	size_t ThreadRead(void *ptr, size_t size) override;
 
 	void Close() noexcept override {
 		mmsx_close(mms);

--- a/src/input/plugins/NfsInputPlugin.cxx
+++ b/src/input/plugins/NfsInputPlugin.cxx
@@ -47,7 +47,7 @@ public:
 				  NFS_MAX_BUFFERED,
 				  NFS_RESUME_AT) {}
 
-	virtual ~NfsInputStream() {
+	~NfsInputStream() override {
 		DeferClose();
 	}
 
@@ -62,8 +62,8 @@ private:
 
 protected:
 	/* virtual methods from AsyncInputStream */
-	virtual void DoResume() override;
-	virtual void DoSeek(offset_type new_offset) override;
+	void DoResume() override;
+	void DoSeek(offset_type new_offset) override;
 
 private:
 	/* virtual methods from NfsFileReader */

--- a/src/input/plugins/QobuzInputPlugin.cxx
+++ b/src/input/plugins/QobuzInputPlugin.cxx
@@ -53,7 +53,7 @@ public:
 		qobuz_client->AddLoginHandler(*this);
 	}
 
-	~QobuzInputStream() {
+	~QobuzInputStream() override {
 		qobuz_client->RemoveLoginHandler(*this);
 	}
 

--- a/src/input/plugins/SmbclientInputPlugin.cxx
+++ b/src/input/plugins/SmbclientInputPlugin.cxx
@@ -43,7 +43,7 @@ public:
 		SetReady();
 	}
 
-	~SmbclientInputStream() {
+	~SmbclientInputStream() override {
 		const std::lock_guard<Mutex> lock(smbclient_mutex);
 		smbc_close(fd);
 		smbc_free_context(ctx, 1);

--- a/src/input/plugins/TidalInputPlugin.cxx
+++ b/src/input/plugins/TidalInputPlugin.cxx
@@ -65,7 +65,7 @@ public:
 		tidal_session->AddLoginHandler(*this);
 	}
 
-	~TidalInputStream() {
+	~TidalInputStream() override {
 		tidal_session->RemoveLoginHandler(*this);
 	}
 

--- a/src/lib/upnp/Device.cxx
+++ b/src/lib/upnp/Device.cxx
@@ -45,7 +45,7 @@ public:
 		 value(nullptr) {}
 
 protected:
-	virtual void StartElement(const XML_Char *name, const XML_Char **) {
+	void StartElement(const XML_Char *name, const XML_Char **) override {
 		value = nullptr;
 
 		switch (name[0]) {
@@ -80,7 +80,7 @@ protected:
 		}
 	}
 
-	virtual void EndElement(const XML_Char *name) {
+	void EndElement(const XML_Char *name) override {
 		if (value != nullptr) {
 			trimstring(*value);
 			value = nullptr;
@@ -90,7 +90,7 @@ protected:
 		}
 	}
 
-	virtual void CharacterData(const XML_Char *s, int len) {
+	void CharacterData(const XML_Char *s, int len) override {
 		if (value != nullptr)
 			value->append(s, len);
 	}

--- a/src/mixer/plugins/AlsaMixerPlugin.cxx
+++ b/src/mixer/plugins/AlsaMixerPlugin.cxx
@@ -86,7 +86,7 @@ public:
 		:Mixer(alsa_mixer_plugin, _listener),
 		 event_loop(_event_loop) {}
 
-	virtual ~AlsaMixer();
+	~AlsaMixer() override;
 
 	void Configure(const ConfigBlock &block);
 	void Setup();

--- a/src/mixer/plugins/HaikuMixerPlugin.cxx
+++ b/src/mixer/plugins/HaikuMixerPlugin.cxx
@@ -36,14 +36,14 @@ public:
 		 self(_output) {}
 
 	/* virtual methods from class Mixer */
-	virtual void Open() override {
+	void Open() override {
 	}
 
 	void Close() noexcept override {
 	}
 
-	virtual int GetVolume() override;
-	virtual void SetVolume(unsigned volume) override;
+	int GetVolume() override;
+	void SetVolume(unsigned volume) override;
 };
 
 static Mixer *

--- a/src/mixer/plugins/PulseMixerPlugin.cxx
+++ b/src/mixer/plugins/PulseMixerPlugin.cxx
@@ -54,7 +54,7 @@ public:
 	{
 	}
 
-	virtual ~PulseMixer();
+	~PulseMixer() override;
 
 	void Offline();
 	void VolumeCallback(const pa_sink_input_info *i, int eol);

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -210,7 +210,7 @@ class AlsaOutput final
 public:
 	AlsaOutput(EventLoop &loop, const ConfigBlock &block);
 
-	~AlsaOutput() noexcept {
+	~AlsaOutput() noexcept override {
 		/* free libasound's config cache */
 		snd_config_update_free_global();
 	}

--- a/src/output/plugins/AoOutputPlugin.cxx
+++ b/src/output/plugins/AoOutputPlugin.cxx
@@ -53,7 +53,7 @@ class AoOutput final : AudioOutput, SafeSingleton<AoInit> {
 	size_t frame_size;
 
 	AoOutput(const ConfigBlock &block);
-	~AoOutput();
+	~AoOutput() override;
 
 public:
 	static AudioOutput *Create(EventLoop &, const ConfigBlock &block) {

--- a/src/output/plugins/FifoOutputPlugin.cxx
+++ b/src/output/plugins/FifoOutputPlugin.cxx
@@ -44,7 +44,7 @@ class FifoOutput final : AudioOutput {
 public:
 	FifoOutput(const ConfigBlock &block);
 
-	~FifoOutput() {
+	~FifoOutput() override {
 		CloseFifo();
 	}
 

--- a/src/output/plugins/ShoutOutputPlugin.cxx
+++ b/src/output/plugins/ShoutOutputPlugin.cxx
@@ -49,7 +49,7 @@ struct ShoutOutput final : AudioOutput {
 	uint8_t buffer[32768];
 
 	explicit ShoutOutput(const ConfigBlock &block);
-	~ShoutOutput();
+	~ShoutOutput() override;
 
 	static AudioOutput *Create(EventLoop &event_loop,
 				   const ConfigBlock &block);

--- a/src/playlist/MemorySongEnumerator.hxx
+++ b/src/playlist/MemorySongEnumerator.hxx
@@ -32,7 +32,7 @@ public:
 	MemorySongEnumerator(std::forward_list<DetachedSong> &&_songs)
 		:songs(std::move(_songs)) {}
 
-	virtual std::unique_ptr<DetachedSong> NextSong() override;
+	std::unique_ptr<DetachedSong> NextSong() override;
 };
 
 #endif

--- a/src/playlist/plugins/CuePlaylistPlugin.cxx
+++ b/src/playlist/plugins/CuePlaylistPlugin.cxx
@@ -32,7 +32,7 @@ class CuePlaylist final : public SongEnumerator {
 		:tis(std::move(is)) {
 	}
 
-	virtual std::unique_ptr<DetachedSong> NextSong() override;
+	std::unique_ptr<DetachedSong> NextSong() override;
 };
 
 static std::unique_ptr<SongEnumerator>

--- a/src/playlist/plugins/ExtM3uPlaylistPlugin.cxx
+++ b/src/playlist/plugins/ExtM3uPlaylistPlugin.cxx
@@ -55,7 +55,7 @@ public:
 		return nullptr;
 	}
 
-	virtual std::unique_ptr<DetachedSong> NextSong() override;
+	std::unique_ptr<DetachedSong> NextSong() override;
 };
 
 static std::unique_ptr<SongEnumerator>

--- a/src/playlist/plugins/M3uPlaylistPlugin.cxx
+++ b/src/playlist/plugins/M3uPlaylistPlugin.cxx
@@ -32,7 +32,7 @@ public:
 		:tis(std::move(is)) {
 	}
 
-	virtual std::unique_ptr<DetachedSong> NextSong() override;
+	std::unique_ptr<DetachedSong> NextSong() override;
 };
 
 static std::unique_ptr<SongEnumerator>

--- a/src/storage/plugins/NfsStorage.cxx
+++ b/src/storage/plugins/NfsStorage.cxx
@@ -80,7 +80,7 @@ public:
 		nfs_init(_loop);
 	}
 
-	~NfsStorage() {
+	~NfsStorage() override {
 		BlockingCall(GetEventLoop(), [this](){ Disconnect(); });
 		nfs_finish();
 	}

--- a/src/storage/plugins/SmbclientStorage.cxx
+++ b/src/storage/plugins/SmbclientStorage.cxx
@@ -42,7 +42,7 @@ public:
 	SmbclientDirectoryReader(std::string &&_base, unsigned _handle)
 		:base(std::move(_base)), handle(_handle) {}
 
-	virtual ~SmbclientDirectoryReader();
+	~SmbclientDirectoryReader() override;
 
 	/* virtual methods from class StorageDirectoryReader */
 	const char *Read() noexcept override;
@@ -58,7 +58,7 @@ public:
 	SmbclientStorage(const char *_base, SMBCCTX *_ctx)
 		:base(_base), ctx(_ctx) {}
 
-	virtual ~SmbclientStorage() {
+	~SmbclientStorage() override {
 		const std::lock_guard<Mutex> lock(smbclient_mutex);
 		smbc_free_context(ctx, 1);
 	}

--- a/src/zeroconf/AvahiPoll.cxx
+++ b/src/zeroconf/AvahiPoll.cxx
@@ -71,7 +71,7 @@ public:
 
 private:
 	/* virtual methods from class SocketMonitor */
-	bool OnSocketReady(unsigned flags) noexcept {
+	bool OnSocketReady(unsigned flags) noexcept override {
 		received = ToAvahiWatchEvent(flags);
 		callback(this, GetSocket().Get(), received, userdata);
 		received = AvahiWatchEvent(0);

--- a/test/DumpDatabase.cxx
+++ b/test/DumpDatabase.cxx
@@ -68,11 +68,11 @@ InputStream::LockRead(void *, size_t)
 
 class MyDatabaseListener final : public DatabaseListener {
 public:
-	virtual void OnDatabaseModified() noexcept override {
+	void OnDatabaseModified() noexcept override {
 		cout << "DatabaseModified" << endl;
 	}
 
-	virtual void OnDatabaseSongRemoved(const char *uri) noexcept override {
+	void OnDatabaseSongRemoved(const char *uri) noexcept override {
 		cout << "SongRemoved " << uri << endl;
 	}
 };

--- a/test/run_neighbor_explorer.cxx
+++ b/test/run_neighbor_explorer.cxx
@@ -32,12 +32,12 @@
 class MyNeighborListener final : public NeighborListener {
  public:
 	/* virtual methods from class NeighborListener */
-	virtual void FoundNeighbor(const NeighborInfo &info) noexcept override {
+	void FoundNeighbor(const NeighborInfo &info) noexcept override {
 		printf("found '%s' (%s)\n",
 		       info.display_name.c_str(), info.uri.c_str());
 	}
 
-	virtual void LostNeighbor(const NeighborInfo &info) noexcept override {
+	void LostNeighbor(const NeighborInfo &info) noexcept override {
 		printf("lost '%s' (%s)\n",
 		       info.display_name.c_str(), info.uri.c_str());
 	}

--- a/test/visit_archive.cxx
+++ b/test/visit_archive.cxx
@@ -54,7 +54,7 @@ public:
 
 class MyArchiveVisitor final : public ArchiveVisitor {
 public:
-	virtual void VisitArchiveEntry(const char *path_utf8) override {
+	void VisitArchiveEntry(const char *path_utf8) override {
 		printf("%s\n", path_utf8);
 	}
 };


### PR DESCRIPTION
Found with modernize-use-override

Signed-off-by: Rosen Penev <rosenp@gmail.com>