### PR TITLE
[clang-tidy] replace std::bind with lambdas

### DIFF
--- a/src/db/DatabasePlaylist.cxx
+++ b/src/db/DatabasePlaylist.cxx
@@ -39,7 +39,6 @@ search_add_to_playlist(const Database &db, const Storage *storage,
 		       const DatabaseSelection &selection)
 {
 	using namespace std::placeholders;
-	const auto f = std::bind(AddSong, storage,
-				 playlist_path_utf8, _1);
+	const auto f = [=](auto && arg1) { return AddSong(storage, playlist_path_utf8, arg1); };
 	db.Visit(selection, f);
 }

--- a/src/pcm/Dop.cxx
+++ b/src/pcm/Dop.cxx
@@ -94,5 +94,5 @@ DsdToDopConverter::Convert(ConstBuffer<uint8_t> src) noexcept
 {
 	using namespace std::placeholders;
 	return rest_buffer.Process<uint32_t>(buffer, src, 2 * channels,
-					     std::bind(DsdToDop, _1, _2, _3, channels));
+					     [=](auto && arg1, auto && arg2, auto && arg3) { return DsdToDop(arg1, arg2, arg3, channels); });
 }

--- a/src/pcm/Dsd16.cxx
+++ b/src/pcm/Dsd16.cxx
@@ -65,5 +65,5 @@ Dsd16Converter::Convert(ConstBuffer<uint8_t> src) noexcept
 {
 	using namespace std::placeholders;
 	return rest_buffer.Process<uint16_t>(buffer, src, channels,
-					     std::bind(Dsd8To16, _1, _2, _3, channels));
+					     [=](auto && arg1, auto && arg2, auto && arg3) { return Dsd8To16(arg1, arg2, arg3, channels); });
 }

--- a/src/pcm/Dsd32.cxx
+++ b/src/pcm/Dsd32.cxx
@@ -67,5 +67,5 @@ Dsd32Converter::Convert(ConstBuffer<uint8_t> src) noexcept
 {
 	using namespace std::placeholders;
 	return rest_buffer.Process<uint32_t>(buffer, src, channels,
-					     std::bind(Dsd8To32, _1, _2, _3, channels));
+					     [=](auto && arg1, auto && arg2, auto && arg3) { return Dsd8To32(arg1, arg2, arg3, channels); });
 }


### PR DESCRIPTION
Found with modernize-avoid-bind

Signed-off-by: Rosen Penev <rosenp@gmail.com>