### PR TITLE
[clang-tidy] use bool literals where appropriate

### DIFF
--- a/src/player/CrossFade.cxx
+++ b/src/player/CrossFade.cxx
@@ -44,7 +44,7 @@ mixramp_interpolate(const char *ramp_list, float required_db) noexcept
 	 * between the dB and seconds of a pair.
 	 * The dB values must be monotonically increasing for this to work. */
 
-	while (1) {
+	while (true) {
 		/* Parse the dB value. */
 		char *endptr;
 		const float db = ParseFloat(ramp_list, &endptr);

--- a/src/player/Thread.cxx
+++ b/src/player/Thread.cxx
@@ -1155,7 +1155,7 @@ try {
 
 	std::unique_lock<Mutex> lock(mutex);
 
-	while (1) {
+	while (true) {
 		switch (command) {
 		case PlayerCommand::SEEK:
 		case PlayerCommand::QUEUE:

--- a/src/playlist/plugins/SoundCloudPlaylistPlugin.cxx
+++ b/src/playlist/plugins/SoundCloudPlaylistPlugin.cxx
@@ -177,11 +177,11 @@ SoundCloudJsonData::EndMap() noexcept
 {
 	if (got_url > 1) {
 		got_url--;
-		return 1;
+		return true;
 	}
 
 	if (got_url == 0)
-		return 1;
+		return true;
 
 	/* got_url == 1, track finished, make it into a song */
 	got_url = 0;


### PR DESCRIPTION
Found with modernize-use-bool-literals

Signed-off-by: Rosen Penev <rosenp@gmail.com>