### PR TITLE
[clang-tidy] convert several loops to range based ones

### DIFF
--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -246,8 +246,8 @@ static CommandResult
 PrintAvailableCommands(Response &r, const Partition &partition,
 		     unsigned permission) noexcept
 {
-	for (unsigned i = 0; i < num_commands; ++i) {
-		const struct command *cmd = &commands[i];
+	for (const auto & i : commands) {
+		const struct command *cmd = &i;
 
 		if (cmd->permission == (permission & cmd->permission) &&
 		    command_available(partition, cmd))
@@ -260,8 +260,8 @@ PrintAvailableCommands(Response &r, const Partition &partition,
 static CommandResult
 PrintUnavailableCommands(Response &r, unsigned permission) noexcept
 {
-	for (unsigned i = 0; i < num_commands; ++i) {
-		const struct command *cmd = &commands[i];
+	for (const auto & i : commands) {
+		const struct command *cmd = &i;
 
 		if (cmd->permission != (permission & cmd->permission))
 			r.Format("command: %s\n", cmd->cmd);

--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -516,8 +516,8 @@ parse_xing(struct xing *xing, struct mad_bitptr *ptr, int *oldbitlen) noexcept
 	if (xing->flags & XING_TOC) {
 		if (bitlen < 800)
 			return false;
-		for (unsigned i = 0; i < 100; ++i)
-			xing->toc[i] = mad_bit_read(ptr, 8);
+		for (unsigned char & i : xing->toc)
+			i = mad_bit_read(ptr, 8);
 		bitlen -= 800;
 	}
 

--- a/src/neighbor/Glue.cxx
+++ b/src/neighbor/Glue.cxx
@@ -84,8 +84,8 @@ NeighborGlue::Open()
 void
 NeighborGlue::Close() noexcept
 {
-	for (auto i = explorers.begin(), end = explorers.end(); i != end; ++i)
-		i->explorer->Close();
+	for (auto & explorer : explorers)
+		explorer.explorer->Close();
 }
 
 NeighborGlue::List


### PR DESCRIPTION
Found with modernize-loop-convert

Signed-off-by: Rosen Penev <rosenp@gmail.com>