### PR TITLE
[clang-tidy] simplify boolean expressions

### DIFF
--- a/src/CommandLine.cxx
+++ b/src/CommandLine.cxx
@@ -283,7 +283,7 @@ static void help(void)
 	       "Options:\n");
 
 	for (const auto &i : option_defs)
-		if(i.HasDescription() == true) // hide hidden options from help print
+		if(i.HasDescription()) // hide hidden options from help print
 			PrintOption(i);
 
 	exit(EXIT_SUCCESS);

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -863,10 +863,7 @@ IsFilterSupported(const ISongFilter &f) noexcept
 			return true;
 
 		const auto tag = Convert(t->GetTagType());
-		if (tag == MPD_TAG_COUNT)
-			return false;
-
-		return true;
+		return tag != MPD_TAG_COUNT;
 	} else if (auto u = dynamic_cast<const UriSongFilter *>(&f)) {
 		if (u->IsNegated())
 			// TODO implement

--- a/src/event/FullyBufferedSocket.cxx
+++ b/src/event/FullyBufferedSocket.cxx
@@ -102,10 +102,7 @@ FullyBufferedSocket::OnSocketReady(unsigned flags) noexcept
 			return false;
 	}
 
-	if (!BufferedSocket::OnSocketReady(flags))
-		return false;
-
-	return true;
+	return BufferedSocket::OnSocketReady(flags);
 }
 
 void


### PR DESCRIPTION
Found with readability-simplify-boolean-expr

Signed-off-by: Rosen Penev <rosenp@gmail.com>