### PR TITLE
[clang-tidy] convert several loops to const auto&

### DIFF
--- a/src/input/InputPlugin.cxx
+++ b/src/input/InputPlugin.cxx
@@ -33,7 +33,7 @@ InputPlugin::SupportsUri(const char *uri) const noexcept
 			if (StringStartsWithIgnoreCase(uri, *i))
 				return true;
 	} else {
-		for (auto schema : protocols()) {
+		for (const auto& schema : protocols()) {
 			if (StringStartsWithIgnoreCase(uri, schema.c_str())){
 				return true;
 			}

--- a/src/ls.cxx
+++ b/src/ls.cxx
@@ -39,7 +39,7 @@ void print_supported_uri_schemes_to_fp(FILE *fp)
 			protocols.emplace(uri);
 		});
 
-	for (auto protocol : protocols) {
+	for (const auto& protocol : protocols) {
 		fprintf(fp, " %s", protocol.c_str());
 	}
 	fprintf(fp,"\n");
@@ -54,7 +54,7 @@ print_supported_uri_schemes(Response &r)
 			protocols.emplace(uri);
 		});
 
-	for (auto protocol : protocols) {
+	for (const auto& protocol : protocols) {
 		r.Format("handler: %s\n", protocol.c_str());
 	}
 }

--- a/src/storage/StorageState.cxx
+++ b/src/storage/StorageState.cxx
@@ -139,7 +139,7 @@ storage_state_get_hash(const Instance &instance)
 
 	boost::crc_32_type result;
 
-	for (auto mount: mounts) {
+	for (const auto& mount : mounts) {
 		result.process_bytes(mount.c_str(), mount.length());
 	}
 


### PR DESCRIPTION
Found with performance-for-range-copy

Signed-off-by: Rosen Penev <rosenp@gmail.com>