### PR TITLE
[clang-tidy] remove pointless void arg

### DIFF
--- a/src/CommandLine.cxx
+++ b/src/CommandLine.cxx
@@ -107,7 +107,7 @@ static constexpr OptionDef option_defs[] = {
 static constexpr Domain cmdline_domain("cmdline");
 
 gcc_noreturn
-static void version(void)
+static void version()
 {
 	printf("Music Player Daemon " VERSION " (%s)"
 	       "\n"
@@ -273,7 +273,7 @@ static void PrintOption(const OptionDef &opt)
 }
 
 gcc_noreturn
-static void help(void)
+static void help()
 {
 	printf("Usage:\n"
 	       "  mpd [OPTION...] [path/to/mpd.conf]\n"

--- a/src/LogInit.cxx
+++ b/src/LogInit.cxx
@@ -63,7 +63,7 @@ static void redirect_logs(int fd)
 }
 
 static int
-open_log_file(void)
+open_log_file()
 {
 	assert(!out_path.IsNull());
 

--- a/src/archive/ArchiveList.cxx
+++ b/src/archive/ArchiveList.cxx
@@ -73,7 +73,7 @@ archive_plugin_from_name(const char *name) noexcept
 	return nullptr;
 }
 
-void archive_plugin_init_all(void)
+void archive_plugin_init_all()
 {
 	for (unsigned i = 0; archive_plugins[i] != nullptr; ++i) {
 		const ArchivePlugin *plugin = archive_plugins[i];

--- a/src/db/update/InotifyUpdate.cxx
+++ b/src/db/update/InotifyUpdate.cxx
@@ -330,7 +330,7 @@ mpd_inotify_init(EventLoop &loop, Storage &storage, UpdateService &update,
 }
 
 void
-mpd_inotify_finish(void) noexcept
+mpd_inotify_finish() noexcept
 {
 	if (inotify_source == nullptr)
 		return;

--- a/src/decoder/plugins/FlacDecoderPlugin.cxx
+++ b/src/decoder/plugins/FlacDecoderPlugin.cxx
@@ -102,7 +102,7 @@ flac_scan_stream(InputStream &is, TagHandler &handler) noexcept
  * Some glue code around FLAC__stream_decoder_new().
  */
 static FlacStreamDecoder
-flac_decoder_new(void)
+flac_decoder_new()
 {
 	FlacStreamDecoder sd;
 	if(!FLAC__stream_decoder_set_metadata_respond(sd.get(), FLAC__METADATA_TYPE_VORBIS_COMMENT))

--- a/src/decoder/plugins/MikmodDecoderPlugin.cxx
+++ b/src/decoder/plugins/MikmodDecoderPlugin.cxx
@@ -38,24 +38,24 @@ static constexpr Domain mikmod_domain("mikmod");
 static constexpr size_t MIKMOD_FRAME_SIZE = 4096;
 
 static BOOL
-mikmod_mpd_init(void)
+mikmod_mpd_init()
 {
 	return VC_Init();
 }
 
 static void
-mikmod_mpd_exit(void)
+mikmod_mpd_exit()
 {
 	VC_Exit();
 }
 
 static void
-mikmod_mpd_update(void)
+mikmod_mpd_update()
 {
 }
 
 static BOOL
-mikmod_mpd_is_present(void)
+mikmod_mpd_is_present()
 {
 	return true;
 }

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -162,7 +162,7 @@ parse_cdio_uri(const char *src)
 }
 
 static AllocatedPath
-cdio_detect_device(void)
+cdio_detect_device()
 {
 	char **devices = cdio_get_devices_with_cap(nullptr, CDIO_FS_AUDIO,
 						   false);

--- a/src/output/State.cxx
+++ b/src/output/State.cxx
@@ -80,7 +80,7 @@ audio_output_state_read(const char *line, MultipleOutputs &outputs)
 }
 
 unsigned
-audio_output_state_get_version(void)
+audio_output_state_get_version()
 {
 	return audio_output_state_version;
 }

--- a/src/output/plugins/JackOutputPlugin.cxx
+++ b/src/output/plugins/JackOutputPlugin.cxx
@@ -419,7 +419,7 @@ JackOutput::Connect()
 }
 
 static bool
-mpd_jack_test_default_device(void)
+mpd_jack_test_default_device()
 {
 	return true;
 }

--- a/src/output/plugins/PulseOutputPlugin.cxx
+++ b/src/output/plugins/PulseOutputPlugin.cxx
@@ -872,7 +872,7 @@ try {
 }
 
 static bool
-pulse_output_test_default_device(void)
+pulse_output_test_default_device()
 {
 	return PulseOutput::TestDefaultDevice();
 }

--- a/src/unix/Daemon.cxx
+++ b/src/unix/Daemon.cxx
@@ -66,7 +66,7 @@ static bool had_group = false;
 static int detach_fd = -1;
 
 void
-daemonize_kill(void)
+daemonize_kill()
 {
 	if (pidfile.IsNull())
 		throw std::runtime_error("no pid_file specified in the config file");
@@ -85,14 +85,14 @@ daemonize_kill(void)
 }
 
 void
-daemonize_close_stdin(void)
+daemonize_close_stdin()
 {
 	close(STDIN_FILENO);
 	open("/dev/null", O_RDONLY);
 }
 
 void
-daemonize_set_user(void)
+daemonize_set_user()
 {
 	if (user_name == nullptr)
 		return;
@@ -245,7 +245,7 @@ daemonize_init(const char *user, const char *group, AllocatedPath &&_pidfile)
 }
 
 void
-daemonize_finish(void)
+daemonize_finish()
 {
 	if (!pidfile.IsNull()) {
 		unlink(pidfile.c_str());


### PR DESCRIPTION
Found with modernize-redundant-void-arg

Signed-off-by: Rosen Penev <rosenp@gmail.com>