### PR TITLE
[clang-tidy] pass by value where appropriate

### DIFF
--- a/src/archive/plugins/Bzip2ArchivePlugin.cxx
+++ b/src/archive/plugins/Bzip2ArchivePlugin.cxx
@@ -32,6 +32,7 @@
 #include <bzlib.h>
 
 #include <stdexcept>
+#include <utility>
 
 class Bzip2ArchiveFile final : public ArchiveFile {
 	std::string name;
@@ -65,7 +66,7 @@ class Bzip2InputStream final : public InputStream {
 	char buffer[5000];
 
 public:
-	Bzip2InputStream(const std::shared_ptr<InputStream> &_input,
+	Bzip2InputStream(std::shared_ptr<InputStream> _input,
 			 const char *uri,
 			 Mutex &mutex);
 	~Bzip2InputStream() override;
@@ -111,11 +112,11 @@ bz2_open(Path pathname)
 
 /* single archive handling */
 
-Bzip2InputStream::Bzip2InputStream(const std::shared_ptr<InputStream> &_input,
+Bzip2InputStream::Bzip2InputStream(std::shared_ptr<InputStream> _input,
 				   const char *_uri,
 				   Mutex &_mutex)
 	:InputStream(_uri, _mutex),
-	 input(_input)
+	 input(std::move(_input))
 {
 	Open();
 }

--- a/src/archive/plugins/Iso9660ArchivePlugin.cxx
+++ b/src/archive/plugins/Iso9660ArchivePlugin.cxx
@@ -34,6 +34,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <utility>
+
 #define CEILING(x, y) ((x+(y-1))/y)
 
 struct Iso9660 {
@@ -141,12 +143,12 @@ class Iso9660InputStream final : public InputStream {
 	iso9660_stat_t *statbuf;
 
 public:
-	Iso9660InputStream(const std::shared_ptr<Iso9660> &_iso,
+	Iso9660InputStream(std::shared_ptr<Iso9660> _iso,
 			   const char *_uri,
 			   Mutex &_mutex,
 			   iso9660_stat_t *_statbuf)
 		:InputStream(_uri, _mutex),
-		 iso(_iso), statbuf(_statbuf) {
+		 iso(std::move(_iso)), statbuf(_statbuf) {
 		size = statbuf->size;
 		seekable = true;
 		SetReady();

--- a/src/db/VHelper.cxx
+++ b/src/db/VHelper.cxx
@@ -23,14 +23,15 @@
 #include "song/Filter.hxx"
 
 #include <algorithm>
+#include <utility>
 
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
-DatabaseVisitorHelper::DatabaseVisitorHelper(const DatabaseSelection &_selection,
+DatabaseVisitorHelper::DatabaseVisitorHelper(DatabaseSelection _selection,
 					     VisitSong &visit_song) noexcept
-	:selection(_selection)
+	:selection(std::move(_selection))
 {
 	// TODO: apply URI and SongFilter
 	assert(selection.uri.empty());

--- a/src/db/VHelper.hxx
+++ b/src/db/VHelper.hxx
@@ -60,7 +60,7 @@ public:
 	 * @param visit_song the callback function passed to
 	 * Database::Visit(); may be replaced by this class
 	 */
-	DatabaseVisitorHelper(const DatabaseSelection &selection,
+	DatabaseVisitorHelper(DatabaseSelection selection,
 			      VisitSong &visit_song) noexcept;
 	~DatabaseVisitorHelper() noexcept;
 


### PR DESCRIPTION
Found with modernize-pass-by-value

Signed-off-by: Rosen Penev <rosenp@gmail.com>