### PR TITLE
[clang-tidy] convert several functions to const &

### DIFF
--- a/src/archive/plugins/ZzipArchivePlugin.cxx
+++ b/src/archive/plugins/ZzipArchivePlugin.cxx
@@ -91,7 +91,7 @@ class ZzipInputStream final : public InputStream {
 	ZZIP_FILE *const file;
 
 public:
-	ZzipInputStream(const std::shared_ptr<ZzipDir> _dir, const char *_uri,
+	ZzipInputStream(const std::shared_ptr<ZzipDir>& _dir, const char *_uri,
 			Mutex &_mutex,
 			ZZIP_FILE *_file)
 		:InputStream(_uri, _mutex),

--- a/src/command/CommandError.cxx
+++ b/src/command/CommandError.cxx
@@ -82,7 +82,7 @@ ToAck(DatabaseErrorCode code) noexcept
 
 gcc_pure
 static enum ack
-ToAck(std::exception_ptr ep) noexcept
+ToAck(const std::exception_ptr& ep) noexcept
 {
 	try {
 		std::rethrow_exception(ep);
@@ -113,7 +113,7 @@ ToAck(std::exception_ptr ep) noexcept
 }
 
 void
-PrintError(Response &r, std::exception_ptr ep)
+PrintError(Response &r, const std::exception_ptr& ep)
 {
 	LogError(ep);
 	r.Error(ToAck(ep), GetFullMessage(ep).c_str());

--- a/src/command/CommandError.hxx
+++ b/src/command/CommandError.hxx
@@ -28,6 +28,6 @@ class Response;
  * Send the exception to the client.
  */
 void
-PrintError(Response &r, std::exception_ptr ep);
+PrintError(Response &r, const std::exception_ptr& ep);
 
 #endif

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -50,8 +50,9 @@
 #include <mpd/async.h>
 
 #include <cassert>
-#include <string>
 #include <list>
+#include <string>
+#include <utility>
 
 class LibmpdclientError final : public std::runtime_error {
 	enum mpd_error code;
@@ -674,15 +675,15 @@ ProxyDatabase::ReturnSong(const LightSong *_song) const noexcept
 static void
 Visit(struct mpd_connection *connection, const char *uri,
       bool recursive, const SongFilter *filter,
-      VisitDirectory visit_directory, VisitSong visit_song,
-      VisitPlaylist visit_playlist);
+      const VisitDirectory& visit_directory, const VisitSong& visit_song,
+      const VisitPlaylist& visit_playlist);
 
 static void
 Visit(struct mpd_connection *connection,
       bool recursive, const SongFilter *filter,
       const struct mpd_directory *directory,
-      VisitDirectory visit_directory, VisitSong visit_song,
-      VisitPlaylist visit_playlist)
+      const VisitDirectory& visit_directory, const VisitSong& visit_song,
+      const VisitPlaylist& visit_playlist)
 {
 	const char *path = mpd_directory_get_path(directory);
 
@@ -697,7 +698,7 @@ Visit(struct mpd_connection *connection,
 
 	if (recursive)
 		Visit(connection, path, recursive, filter,
-		      visit_directory, visit_song, visit_playlist);
+		      visit_directory, std::move(visit_song), std::move(visit_playlist));
 }
 
 gcc_pure
@@ -710,7 +711,7 @@ Match(const SongFilter *filter, const LightSong &song) noexcept
 static void
 Visit(const SongFilter *filter,
       const mpd_song *_song,
-      VisitSong visit_song)
+      const VisitSong& visit_song)
 {
 	if (!visit_song)
 		return;
@@ -722,7 +723,7 @@ Visit(const SongFilter *filter,
 
 static void
 Visit(const struct mpd_playlist *playlist,
-      VisitPlaylist visit_playlist)
+      const VisitPlaylist& visit_playlist)
 {
 	if (!visit_playlist)
 		return;
@@ -778,8 +779,8 @@ ReceiveEntities(struct mpd_connection *connection) noexcept
 static void
 Visit(struct mpd_connection *connection, const char *uri,
       bool recursive, const SongFilter *filter,
-      VisitDirectory visit_directory, VisitSong visit_song,
-      VisitPlaylist visit_playlist)
+      const VisitDirectory& visit_directory, const VisitSong& visit_song,
+      const VisitPlaylist& visit_playlist)
 {
 	if (!mpd_send_list_meta(connection, uri))
 		ThrowError(connection);
@@ -813,7 +814,7 @@ Visit(struct mpd_connection *connection, const char *uri,
 static void
 SearchSongs(struct mpd_connection *connection,
 	    const DatabaseSelection &selection,
-	    VisitSong visit_song)
+	    const VisitSong& visit_song)
 try {
 	assert(selection.recursive);
 	assert(visit_song);

--- a/src/db/plugins/simple/Directory.cxx
+++ b/src/db/plugins/simple/Directory.cxx
@@ -220,8 +220,8 @@ Directory::Sort() noexcept
 
 void
 Directory::Walk(bool recursive, const SongFilter *filter,
-		VisitDirectory visit_directory, VisitSong visit_song,
-		VisitPlaylist visit_playlist) const
+		const VisitDirectory& visit_directory, const VisitSong& visit_song,
+		const VisitPlaylist& visit_playlist) const
 {
 	if (IsMount()) {
 		assert(IsEmpty());

--- a/src/db/plugins/simple/Directory.hxx
+++ b/src/db/plugins/simple/Directory.hxx
@@ -284,8 +284,8 @@ public:
 	 * Caller must lock #db_mutex.
 	 */
 	void Walk(bool recursive, const SongFilter *match,
-		  VisitDirectory visit_directory, VisitSong visit_song,
-		  VisitPlaylist visit_playlist) const;
+		  const VisitDirectory& visit_directory, const VisitSong& visit_song,
+		  const VisitPlaylist& visit_playlist) const;
 
 	gcc_pure
 	LightDirectory Export() const noexcept;

--- a/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
+++ b/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
@@ -41,6 +41,7 @@
 #include "util/SplitString.hxx"
 
 #include <string>
+#include <utility>
 
 #include <assert.h>
 #include <string.h>
@@ -107,9 +108,9 @@ private:
 	void VisitServer(const ContentDirectoryService &server,
 			 std::forward_list<std::string> &&vpath,
 			 const DatabaseSelection &selection,
-			 VisitDirectory visit_directory,
-			 VisitSong visit_song,
-			 VisitPlaylist visit_playlist) const;
+			 const VisitDirectory& visit_directory,
+			 const VisitSong& visit_song,
+			 const VisitPlaylist& visit_playlist) const;
 
 	/**
 	 * Run an UPnP search according to MPD parameters, and
@@ -118,7 +119,7 @@ private:
 	void SearchSongs(const ContentDirectoryService &server,
 			 const char *objid,
 			 const DatabaseSelection &selection,
-			 VisitSong visit_song) const;
+			 const VisitSong& visit_song) const;
 
 	UPnPDirContent SearchSongs(const ContentDirectoryService &server,
 				   const char *objid,
@@ -311,7 +312,7 @@ UpnpDatabase::SearchSongs(const ContentDirectoryService &server,
 static void
 visitSong(const UPnPDirObject &meta, const char *path,
 	  const DatabaseSelection &selection,
-	  VisitSong visit_song)
+	  const VisitSong& visit_song)
 {
 	if (!visit_song)
 		return;
@@ -339,7 +340,7 @@ void
 UpnpDatabase::SearchSongs(const ContentDirectoryService &server,
 			  const char *objid,
 			  const DatabaseSelection &selection,
-			  VisitSong visit_song) const
+			  const VisitSong& visit_song) const
 {
 	if (!visit_song)
 		return;
@@ -440,13 +441,13 @@ UpnpDatabase::Namei(const ContentDirectoryService &server,
 static void
 VisitItem(const UPnPDirObject &object, const char *uri,
 	  const DatabaseSelection &selection,
-	  VisitSong visit_song, VisitPlaylist visit_playlist)
+	  const VisitSong& visit_song, const VisitPlaylist& visit_playlist)
 {
 	assert(object.type == UPnPDirObject::Type::ITEM);
 
 	switch (object.item_class) {
 	case UPnPDirObject::ItemClass::MUSIC:
-		visitSong(object, uri, selection, visit_song);
+		visitSong(object, uri, selection, std::move(visit_song));
 		break;
 
 	case UPnPDirObject::ItemClass::PLAYLIST:
@@ -469,9 +470,9 @@ VisitItem(const UPnPDirObject &object, const char *uri,
 static void
 VisitObject(const UPnPDirObject &object, const char *uri,
 	    const DatabaseSelection &selection,
-	    VisitDirectory visit_directory,
-	    VisitSong visit_song,
-	    VisitPlaylist visit_playlist)
+	    const VisitDirectory& visit_directory,
+	    const VisitSong& visit_song,
+	    const VisitPlaylist& visit_playlist)
 {
 	switch (object.type) {
 	case UPnPDirObject::Type::UNKNOWN:
@@ -486,7 +487,7 @@ VisitObject(const UPnPDirObject &object, const char *uri,
 
 	case UPnPDirObject::Type::ITEM:
 		VisitItem(object, uri, selection,
-			  visit_song, visit_playlist);
+			  std::move(visit_song), std::move(visit_playlist));
 		break;
 	}
 }
@@ -497,9 +498,9 @@ void
 UpnpDatabase::VisitServer(const ContentDirectoryService &server,
 			  std::forward_list<std::string> &&vpath,
 			  const DatabaseSelection &selection,
-			  VisitDirectory visit_directory,
-			  VisitSong visit_song,
-			  VisitPlaylist visit_playlist) const
+			  const VisitDirectory& visit_directory,
+			  const VisitSong& visit_song,
+			  const VisitPlaylist& visit_playlist) const
 {
 	/* If the path begins with rootid, we know that this is a
 	   song, not a directory (because that's how we set things

--- a/src/input/Error.cxx
+++ b/src/input/Error.cxx
@@ -30,11 +30,13 @@
 #include <nfsc/libnfs-raw-nfs.h>
 #endif
 
+#include <utility>
+
 bool
 IsFileNotFound(std::exception_ptr ep) noexcept
 {
 	try {
-		std::rethrow_exception(ep);
+		std::rethrow_exception(std::move(ep));
 	} catch (const std::system_error &e) {
 		return IsFileNotFound(e);
 #ifdef ENABLE_CURL

--- a/src/input/plugins/QobuzInputPlugin.cxx
+++ b/src/input/plugins/QobuzInputPlugin.cxx
@@ -65,7 +65,7 @@ public:
 	}
 
 private:
-	void Failed(std::exception_ptr e) {
+	void Failed(const std::exception_ptr& e) {
 		SetInput(std::make_unique<FailingInputStream>(GetURI(), e,
 							      mutex));
 	}

--- a/src/input/plugins/TidalInputPlugin.cxx
+++ b/src/input/plugins/TidalInputPlugin.cxx
@@ -35,6 +35,7 @@
 #include "Log.hxx"
 
 #include <memory>
+#include <utility>
 
 static constexpr Domain tidal_domain("tidal");
 
@@ -77,7 +78,7 @@ public:
 	}
 
 private:
-	void Failed(std::exception_ptr e) {
+	void Failed(const std::exception_ptr& e) {
 		SetInput(std::make_unique<FailingInputStream>(GetURI(), e,
 							      mutex));
 	}
@@ -133,7 +134,7 @@ static bool
 IsInvalidSession(std::exception_ptr e) noexcept
 {
 	try {
-		std::rethrow_exception(e);
+		std::rethrow_exception(std::move(e));
 	} catch (const TidalError &te) {
 		return te.IsInvalidSession();
 	} catch (...) {

--- a/src/tag/ApeLoader.cxx
+++ b/src/tag/ApeLoader.cxx
@@ -38,7 +38,7 @@ struct ApeFooter {
 };
 
 bool
-tag_ape_scan(InputStream &is, ApeTagCallback callback)
+tag_ape_scan(InputStream &is, const ApeTagCallback& callback)
 try {
 	std::unique_lock<Mutex> lock(is.mutex);
 

--- a/src/tag/ApeLoader.hxx
+++ b/src/tag/ApeLoader.hxx
@@ -37,6 +37,6 @@ typedef std::function<bool(unsigned long flags, const char *key,
  * present
  */
 bool
-tag_ape_scan(InputStream &is, ApeTagCallback callback);
+tag_ape_scan(InputStream &is, const ApeTagCallback& callback);
 
 #endif


### PR DESCRIPTION
Found with performance-unnecessary-value-param

Signed-off-by: Rosen Penev <rosenp@gmail.com>