### PR TITLE
[clang-tidy] remove needless std::move

### DIFF
--- a/src/client/ThreadBackgroundCommand.cxx
+++ b/src/client/ThreadBackgroundCommand.cxx
@@ -54,7 +54,7 @@ ThreadBackgroundCommand::DeferredFinish() noexcept
 	Response response(client, 0);
 
 	if (error) {
-		PrintError(response, std::move(error));
+		PrintError(response, error);
 	} else {
 		SendResponse(response);
 		command_success(client);

--- a/src/config/File.cxx
+++ b/src/config/File.cxx
@@ -72,7 +72,7 @@ config_read_name_value(ConfigBlock &block, char *input, unsigned line)
 		throw FormatRuntimeError("\"%s\" is duplicate, first defined on line %i",
 					 name, bp->line);
 
-	block.AddBlockParam(name, std::move(value), line);
+	block.AddBlockParam(name, value, line);
 }
 
 static ConfigBlock

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -698,7 +698,7 @@ Visit(struct mpd_connection *connection,
 
 	if (recursive)
 		Visit(connection, path, recursive, filter,
-		      visit_directory, std::move(visit_song), std::move(visit_playlist));
+		      visit_directory, visit_song, visit_playlist);
 }
 
 gcc_pure

--- a/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
+++ b/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
@@ -368,7 +368,7 @@ UpnpDatabase::SearchSongs(const ContentDirectoryService &server,
 		// which we later have to detect.
 		const std::string path = songPath(server.getFriendlyName(),
 						  dirent.id);
-		visitSong(std::move(dirent), path.c_str(),
+		visitSong(dirent, path.c_str(),
 			  selection, visit_song);
 	}
 }
@@ -447,7 +447,7 @@ VisitItem(const UPnPDirObject &object, const char *uri,
 
 	switch (object.item_class) {
 	case UPnPDirObject::ItemClass::MUSIC:
-		visitSong(object, uri, selection, std::move(visit_song));
+		visitSong(object, uri, selection, visit_song);
 		break;
 
 	case UPnPDirObject::ItemClass::PLAYLIST:
@@ -487,7 +487,7 @@ VisitObject(const UPnPDirObject &object, const char *uri,
 
 	case UPnPDirObject::Type::ITEM:
 		VisitItem(object, uri, selection,
-			  std::move(visit_song), std::move(visit_playlist));
+			  visit_song, visit_playlist);
 		break;
 	}
 }
@@ -531,7 +531,7 @@ UpnpDatabase::VisitServer(const ContentDirectoryService &server,
 
 			std::string path = songPath(server.getFriendlyName(),
 						    dirent.id);
-			visitSong(std::move(dirent), path.c_str(),
+			visitSong(dirent, path.c_str(),
 				  selection, visit_song);
 		}
 

--- a/src/neighbor/plugins/SmbclientNeighborPlugin.cxx
+++ b/src/neighbor/plugins/SmbclientNeighborPlugin.cxx
@@ -211,7 +211,7 @@ SmbclientNeighborExplorer::Run() noexcept
 		if (f != found_end) {
 			/* still visible: remove from "found" so we
 			   don't believe it's a new one */
-			*i = std::move(*std::next(f));
+			*i = *std::next(f);
 			found.erase_after(f);
 			prev = i;
 		} else {

--- a/src/storage/CompositeStorage.cxx
+++ b/src/storage/CompositeStorage.cxx
@@ -118,7 +118,7 @@ CompositeStorage::Directory::Make(const char *uri)
 	Directory *directory = this;
 	while (*uri != 0) {
 		const std::string name = NextSegment(uri);
-		auto i = directory->children.emplace(std::move(name),
+		auto i = directory->children.emplace(name,
 						     Directory());
 		directory = &i.first->second;
 	}

--- a/src/storage/plugins/SmbclientStorage.cxx
+++ b/src/storage/plugins/SmbclientStorage.cxx
@@ -137,7 +137,7 @@ SmbclientStorage::OpenDirectory(const char *uri_utf8)
 			throw MakeErrno("Failed to open directory");
 	}
 
-	return std::make_unique<SmbclientDirectoryReader>(std::move(mapped.c_str()),
+	return std::make_unique<SmbclientDirectoryReader>(mapped.c_str(),
 							  handle);
 }
 

--- a/src/storage/plugins/UdisksStorage.cxx
+++ b/src/storage/plugins/UdisksStorage.cxx
@@ -168,7 +168,7 @@ UdisksStorage::OnListReply(ODBus::Message reply) noexcept
 			if (!o.IsId(id))
 				return;
 
-			dbus_path = std::move(o.path);
+			dbus_path = o.path;
 			mount_point = std::move(o.mount_point);
 		});
 


### PR DESCRIPTION
As a result of the last commit.

Found with performance-move-const-arg

Signed-off-by: Rosen Penev <rosenp@gmail.com>