### PR TITLE
[clang-tidy] use auto where appropriate

### DIFF
--- a/src/IcyMetaDataParser.cxx
+++ b/src/IcyMetaDataParser.cxx
@@ -194,7 +194,7 @@ icy_parse_tag(
 size_t
 IcyMetaDataParser::Meta(const void *data, size_t length) noexcept
 {
-	const auto *p = (const unsigned char *)data;
+	auto p = (const unsigned char *)data;
 
 	assert(IsDefined());
 	assert(data_rest == 0);
@@ -254,7 +254,7 @@ IcyMetaDataParser::Meta(const void *data, size_t length) noexcept
 size_t
 IcyMetaDataParser::ParseInPlace(void *data, size_t length) noexcept
 {
-	auto *const dest0 = (uint8_t *)data;
+	auto const dest0 = (uint8_t *)data;
 	uint8_t *dest = dest0;
 	const uint8_t *src = dest0;
 

--- a/src/Main.cxx
+++ b/src/Main.cxx
@@ -172,7 +172,7 @@ InitStorage(Instance &instance, EventLoop &event_loop,
 	if (storage == nullptr)
 		return;
 
-	auto *composite = new CompositeStorage();
+	auto composite = new CompositeStorage();
 	instance.storage = composite;
 	composite->Mount("", std::move(storage));
 }

--- a/src/client/New.cxx
+++ b/src/client/New.cxx
@@ -67,7 +67,7 @@ client_new(EventLoop &loop, Partition &partition,
 	(void)fd.Write(GREETING, sizeof(GREETING) - 1);
 
 	const unsigned num = next_client_num++;
-	auto *client = new Client(loop, partition, std::move(fd), uid,
+	auto client = new Client(loop, partition, std::move(fd), uid,
 				    permission,
 				    num);
 

--- a/src/client/Read.cxx
+++ b/src/client/Read.cxx
@@ -31,8 +31,8 @@ Client::OnSocketInput(void *data, size_t length) noexcept
 	if (background_command)
 		return InputResult::PAUSE;
 
-	char *p = (char *)data;
-	char *newline = (char *)memchr(p, '\n', length);
+	auto p = (char *)data;
+	auto newline = (char *)memchr(p, '\n', length);
 	if (newline == nullptr)
 		return InputResult::MORE;
 

--- a/src/command/StickerCommands.cxx
+++ b/src/command/StickerCommands.cxx
@@ -42,8 +42,7 @@ static void
 sticker_song_find_print_cb(const LightSong &song, const char *value,
 			   void *user_data)
 {
-	auto *data =
-		(struct sticker_song_find_data *)user_data;
+	auto data = (struct sticker_song_find_data *)user_data;
 
 	song_print_uri(data->r, song);
 	sticker_print_value(data->r, data->name, value);

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -667,7 +667,7 @@ ProxyDatabase::ReturnSong(const LightSong *_song) const noexcept
 {
 	assert(_song != nullptr);
 
-	auto *song = (AllocatedProxySong *)
+	auto song = (AllocatedProxySong *)
 		const_cast<LightSong *>(_song);
 	delete song;
 }

--- a/src/db/plugins/simple/Directory.cxx
+++ b/src/db/plugins/simple/Directory.cxx
@@ -83,7 +83,7 @@ Directory::CreateChild(const char *name_utf8) noexcept
 		? std::string(name_utf8)
 		: PathTraitsUTF8::Build(GetPath(), name_utf8);
 
-	auto *child = new Directory(std::move(path_utf8), this);
+	auto child = new Directory(std::move(path_utf8), this);
 	children.push_back(*child);
 	return child;
 }

--- a/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
+++ b/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
@@ -178,7 +178,7 @@ UpnpDatabase::ReturnSong(const LightSong *_song) const noexcept
 {
 	assert(_song != nullptr);
 
-	auto *song = (UpnpSong *)const_cast<LightSong *>(_song);
+	auto song = (UpnpSong *)const_cast<LightSong *>(_song);
 	delete song;
 }
 

--- a/src/db/update/InotifySource.cxx
+++ b/src/db/update/InotifySource.cxx
@@ -47,8 +47,7 @@ InotifySource::OnSocketReady(gcc_unused unsigned flags) noexcept
 
 	while (true) {
 		const size_t remaining = end - p;
-		const auto *event =
-			(const struct inotify_event *)p;
+		auto event = (const struct inotify_event *)p;
 		if (remaining < sizeof(*event) ||
 		    remaining < sizeof(*event) + event->len)
 			break;

--- a/src/decoder/DecoderAPI.cxx
+++ b/src/decoder/DecoderAPI.cxx
@@ -46,7 +46,7 @@ bool
 decoder_read_full(DecoderClient *client, InputStream &is,
 		  void *_buffer, size_t size)
 {
-	auto *buffer = (uint8_t *)_buffer;
+	auto buffer = (uint8_t *)_buffer;
 
 	while (size > 0) {
 		size_t nbytes = decoder_read(client, is, buffer, size);

--- a/src/decoder/plugins/AudiofileDecoderPlugin.cxx
+++ b/src/decoder/plugins/AudiofileDecoderPlugin.cxx
@@ -129,7 +129,7 @@ audiofile_file_seek(AFvirtualfile *vfile, AFfileoffset _offset,
 static AFvirtualfile *
 setup_virtual_fops(AudioFileInputStream &afis) noexcept
 {
-	AFvirtualfile *vf = (AFvirtualfile *)malloc(sizeof(*vf));
+	auto vf = (AFvirtualfile *)malloc(sizeof(AFvirtualfile));
 	vf->closure = &afis;
 	vf->write = nullptr;
 	vf->read    = audiofile_file_read;

--- a/src/decoder/plugins/DsdLib.cxx
+++ b/src/decoder/plugins/DsdLib.cxx
@@ -133,7 +133,7 @@ dsdlib_tag_id3(InputStream &is, TagHandler &handler,
 
 	const id3_length_t count = count64;
 
-	auto *const id3_buf = new id3_byte_t[count];
+	auto const id3_buf = new id3_byte_t[count];
 	if (id3_buf == nullptr)
 		return;
 

--- a/src/decoder/plugins/FaadDecoderPlugin.cxx
+++ b/src/decoder/plugins/FaadDecoderPlugin.cxx
@@ -72,7 +72,7 @@ adts_find_frame(DecoderBuffer &buffer)
 			return 0;
 
 		/* find the 0xff marker */
-		const auto *p = (const uint8_t *)
+		const auto p = (const uint8_t *)
 			memchr(data.data, 0xff, data.size);
 		if (p == nullptr) {
 			/* no marker - discard the buffer */

--- a/src/decoder/plugins/FlacInput.cxx
+++ b/src/decoder/plugins/FlacInput.cxx
@@ -102,7 +102,7 @@ FlacInput::Read(gcc_unused const FLAC__StreamDecoder *flac_decoder,
 		FLAC__byte buffer[], size_t *bytes,
 		void *client_data)
 {
-	auto *i = (FlacInput *)client_data;
+	auto i = (FlacInput *)client_data;
 
 	return i->Read(buffer, bytes);
 }
@@ -111,7 +111,7 @@ FLAC__StreamDecoderSeekStatus
 FlacInput::Seek(gcc_unused const FLAC__StreamDecoder *flac_decoder,
 		FLAC__uint64 absolute_byte_offset, void *client_data)
 {
-	auto *i = (FlacInput *)client_data;
+	auto i = (FlacInput *)client_data;
 
 	return i->Seek(absolute_byte_offset);
 }
@@ -120,7 +120,7 @@ FLAC__StreamDecoderTellStatus
 FlacInput::Tell(gcc_unused const FLAC__StreamDecoder *flac_decoder,
 		FLAC__uint64 *absolute_byte_offset, void *client_data)
 {
-	auto *i = (FlacInput *)client_data;
+	auto i = (FlacInput *)client_data;
 
 	return i->Tell(absolute_byte_offset);
 }
@@ -129,7 +129,7 @@ FLAC__StreamDecoderLengthStatus
 FlacInput::Length(gcc_unused const FLAC__StreamDecoder *flac_decoder,
 		  FLAC__uint64 *stream_length, void *client_data)
 {
-	auto *i = (FlacInput *)client_data;
+	auto i = (FlacInput *)client_data;
 
 	return i->Length(stream_length);
 }
@@ -138,7 +138,7 @@ FLAC__bool
 FlacInput::Eof(gcc_unused const FLAC__StreamDecoder *flac_decoder,
 	       void *client_data)
 {
-	auto *i = (FlacInput *)client_data;
+	auto i = (FlacInput *)client_data;
 
 	return i->Eof();
 }
@@ -147,7 +147,7 @@ void
 FlacInput::Error(gcc_unused const FLAC__StreamDecoder *decoder,
 		 FLAC__StreamDecoderErrorStatus status, void *client_data)
 {
-	auto *i = (FlacInput *)client_data;
+	auto i = (FlacInput *)client_data;
 
 	i->Error(status);
 }

--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -276,10 +276,10 @@ parse_id3_mixramp(struct id3_tag *tag) noexcept
 		if (frame->nfields < 3)
 			continue;
 
-		char *const key = (char *)
+		auto const key = (char *)
 		    id3_ucs4_latin1duplicate(id3_field_getstring
 					     (&frame->fields[1]));
-		char *const value = (char *)
+		auto const value = (char *)
 		    id3_ucs4_latin1duplicate(id3_field_getstring
 					     (&frame->fields[2]));
 

--- a/src/decoder/plugins/MikmodDecoderPlugin.cxx
+++ b/src/decoder/plugins/MikmodDecoderPlugin.cxx
@@ -145,7 +145,7 @@ mikmod_decoder_file_decode(DecoderClient &client, Path path_fs)
 {
 	/* deconstify the path because libmikmod wants a non-const
 	   string pointer */
-	char *const path2 = const_cast<char *>(path_fs.c_str());
+	auto const path2 = const_cast<char *>(path_fs.c_str());
 
 	MODULE *handle;
 	int ret;
@@ -183,7 +183,7 @@ mikmod_decoder_scan_file(Path path_fs, TagHandler &handler) noexcept
 {
 	/* deconstify the path because libmikmod wants a non-const
 	   string pointer */
-	char *const path2 = const_cast<char *>(path_fs.c_str());
+	auto const path2 = const_cast<char *>(path_fs.c_str());
 
 	MODULE *handle = Player_Load(path2, 128, 0);
 

--- a/src/decoder/plugins/OpusHead.cxx
+++ b/src/decoder/plugins/OpusHead.cxx
@@ -33,7 +33,7 @@ struct OpusHead {
 bool
 ScanOpusHeader(const void *data, size_t size, unsigned &channels_r)
 {
-	const auto *h = (const OpusHead *)data;
+	const auto h = (const OpusHead *)data;
 	if (size < 19 || (h->version & 0xf0) != 0)
 		return false;
 

--- a/src/decoder/plugins/WavpackDecoderPlugin.cxx
+++ b/src/decoder/plugins/WavpackDecoderPlugin.cxx
@@ -127,7 +127,7 @@ template<typename T>
 static void
 format_samples_int(void *buffer, uint32_t count)
 {
-	auto *src = (int32_t *)buffer;
+	auto src = (int32_t *)buffer;
 	T *dst = (T *)buffer;
 	/*
 	 * The asserts like the following one are because we do the
@@ -368,7 +368,7 @@ wavpack_input_read_bytes(void *id, void *data, int32_t bcount)
 int32_t
 WavpackInput::ReadBytes(void *data, size_t bcount)
 {
-	auto *buf = (uint8_t *)data;
+	auto buf = (uint8_t *)data;
 	int32_t i = 0;
 
 	if (last_byte != EOF) {

--- a/src/encoder/plugins/LameEncoderPlugin.cxx
+++ b/src/encoder/plugins/LameEncoderPlugin.cxx
@@ -166,7 +166,7 @@ LameEncoder::~LameEncoder() noexcept
 void
 LameEncoder::Write(const void *data, size_t length)
 {
-	const auto *src = (const int16_t*)data;
+	const auto src = (const int16_t*)data;
 
 	assert(output_begin == output_end);
 

--- a/src/encoder/plugins/OpusEncoderPlugin.cxx
+++ b/src/encoder/plugins/OpusEncoderPlugin.cxx
@@ -248,7 +248,7 @@ OpusEncoder::WriteSilence(unsigned fill_frames)
 void
 OpusEncoder::Write(const void *_data, size_t length)
 {
-	const auto *data = (const uint8_t *)_data;
+	auto data = (const uint8_t *)_data;
 
 	if (lookahead > 0) {
 		/* generate some silence at the beginning of the
@@ -323,7 +323,7 @@ OpusEncoder::GenerateTags(const Tag *tag) noexcept
 		}
 	}
 
-	auto *comments = new unsigned char[comments_size];
+	auto comments = new unsigned char[comments_size];
 	unsigned char *p = comments;
 
 	memcpy(comments, "OpusTags", 8);

--- a/src/encoder/plugins/TwolameEncoderPlugin.cxx
+++ b/src/encoder/plugins/TwolameEncoderPlugin.cxx
@@ -186,7 +186,7 @@ TwolameEncoder::~TwolameEncoder() noexcept
 void
 TwolameEncoder::Write(const void *data, size_t length)
 {
-	const auto *src = (const int16_t*)data;
+	auto src = (const int16_t*)data;
 
 	assert(output_buffer_position == output_buffer_length);
 

--- a/src/filter/plugins/ConvertFilterPlugin.cxx
+++ b/src/filter/plugins/ConvertFilterPlugin.cxx
@@ -130,7 +130,7 @@ convert_filter_new(const AudioFormat in_audio_format,
 void
 convert_filter_set(Filter *_filter, AudioFormat out_audio_format)
 {
-	auto *filter = (ConvertFilter *)_filter;
+	auto filter = (ConvertFilter *)_filter;
 
 	filter->Set(out_audio_format);
 }

--- a/src/filter/plugins/NormalizeFilterPlugin.cxx
+++ b/src/filter/plugins/NormalizeFilterPlugin.cxx
@@ -69,7 +69,7 @@ PreparedNormalizeFilter::Open(AudioFormat &audio_format)
 ConstBuffer<void>
 NormalizeFilter::FilterPCM(ConstBuffer<void> src)
 {
-	auto *dest = (int16_t *)buffer.Get(src.size);
+	auto dest = (int16_t *)buffer.Get(src.size);
 	memcpy(dest, src.data, src.size);
 
 	Compressor_Process_int16(compressor, dest, src.size / 2);

--- a/src/filter/plugins/RouteFilterPlugin.cxx
+++ b/src/filter/plugins/RouteFilterPlugin.cxx
@@ -230,14 +230,14 @@ RouteFilter::FilterPCM(ConstBuffer<void> src)
 	const size_t bytes_per_frame_per_channel = input_format.GetSampleSize();
 
 	// A moving pointer that always refers to channel 0 in the input, at the currently handled frame
-	const auto *base_source = (const uint8_t *)src.data;
+	auto base_source = (const uint8_t *)src.data;
 
 	// Grow our reusable buffer, if needed, and set the moving pointer
 	const size_t result_size = number_of_frames * output_frame_size;
 	void *const result = output_buffer.Get(result_size);
 
 	// A moving pointer that always refers to the currently filled channel of the currently handled frame, in the output
-	auto *chan_destination = (uint8_t *)result;
+	auto chan_destination = (uint8_t *)result;
 
 	// Perform our copy operations, with N input channels and M output channels
 	for (unsigned int s=0; s<number_of_frames; ++s) {

--- a/src/filter/plugins/VolumeFilterPlugin.cxx
+++ b/src/filter/plugins/VolumeFilterPlugin.cxx
@@ -73,8 +73,7 @@ volume_filter_prepare() noexcept
 unsigned
 volume_filter_get(const Filter *_filter) noexcept
 {
-	const auto *filter =
-		(const VolumeFilter *)_filter;
+	auto filter = (const VolumeFilter *)_filter;
 
 	return filter->GetVolume();
 }
@@ -82,7 +81,7 @@ volume_filter_get(const Filter *_filter) noexcept
 void
 volume_filter_set(Filter *_filter, unsigned volume) noexcept
 {
-	auto *filter = (VolumeFilter *)_filter;
+	auto filter = (VolumeFilter *)_filter;
 
 	filter->SetVolume(volume);
 }

--- a/src/fs/io/AutoGunzipReader.cxx
+++ b/src/fs/io/AutoGunzipReader.cxx
@@ -36,7 +36,7 @@ IsGzip(const uint8_t data[4]) noexcept
 inline void
 AutoGunzipReader::Detect()
 {
-	const auto *data = (const uint8_t *)peek.Peek(4);
+	const auto data = (const uint8_t *)peek.Peek(4);
 	if (data == nullptr) {
 		next = &peek;
 		return;

--- a/src/fs/io/GzipOutputStream.cxx
+++ b/src/fs/io/GzipOutputStream.cxx
@@ -81,7 +81,7 @@ void
 GzipOutputStream::Write(const void *_data, size_t size)
 {
 	/* zlib's API requires non-const input pointer */
-	void *data = const_cast<void *>(_data);
+	auto data = const_cast<void *>(_data);
 
 	z.next_in = reinterpret_cast<Bytef *>(data);
 	z.avail_in = size;

--- a/src/input/InputStream.cxx
+++ b/src/input/InputStream.cxx
@@ -124,7 +124,7 @@ InputStream::LockRead(void *ptr, size_t _size)
 void
 InputStream::ReadFull(std::unique_lock<Mutex> &lock, void *_ptr, size_t _size)
 {
-	auto *ptr = (uint8_t *)_ptr;
+	auto ptr = (uint8_t *)_ptr;
 
 	size_t nbytes_total = 0;
 	while (_size > 0) {

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -280,7 +280,7 @@ CdioParanoiaInputStream::Read(std::unique_lock<Mutex> &,
 			      void *ptr, size_t length)
 {
 	size_t nbytes = 0;
-	char *wptr = (char *) ptr;
+	auto wptr = (char *) ptr;
 
 	while (length > 0) {
 		/* end of track ? */

--- a/src/lib/nfs/Connection.cxx
+++ b/src/lib/nfs/Connection.cxx
@@ -160,7 +160,7 @@ NfsConnection::CancellableCallback::Callback(int err, void *data) noexcept
 			assert(close_fh == nullptr);
 
 			if (err >= 0) {
-				auto *fh = (struct nfsfh *)data;
+				auto fh = (struct nfsfh *)data;
 				connection.Close(fh);
 			}
 		} else if (close_fh != nullptr)
@@ -574,7 +574,7 @@ void
 NfsConnection::MountCallback(int status, nfs_context *nfs, void *data,
 			     void *private_data) noexcept
 {
-	auto *c = (NfsConnection *)private_data;
+	auto c = (NfsConnection *)private_data;
 
 	c->MountCallback(status, nfs, data);
 }

--- a/src/lib/nfs/Error.cxx
+++ b/src/lib/nfs/Error.cxx
@@ -45,7 +45,7 @@ FormatNfsClientError(struct nfs_context *nfs, const char *msg) noexcept
 {
 	assert(msg != nullptr);
 
-	const char *msg2 = nfs_get_error(nfs);
+	auto msg2 = nfs_get_error(nfs);
 	return StringFormat<256>("%s: %s", msg, msg2);
 }
 
@@ -60,7 +60,7 @@ FormatNfsClientError(int err, struct nfs_context *nfs, void *data,
 	assert(msg != nullptr);
 	assert(err < 0);
 
-	const char *msg2 = (const char *)data;
+	auto msg2 = (const char *)data;
 	if (data == nullptr || *(const char *)data == 0) {
 		msg2 = nfs_get_error(nfs);
 		if (msg2 == nullptr)

--- a/src/lib/xiph/FlacIOHandle.cxx
+++ b/src/lib/xiph/FlacIOHandle.cxx
@@ -28,7 +28,7 @@
 static size_t
 FlacIORead(void *ptr, size_t size, size_t nmemb, FLAC__IOHandle handle)
 {
-	auto *is = (InputStream *)handle;
+	auto is = (InputStream *)handle;
 
 	uint8_t *const p0 = (uint8_t *)ptr, *p = p0,
 		*const end = p0 + size * nmemb;
@@ -70,7 +70,7 @@ FlacIORead(void *ptr, size_t size, size_t nmemb, FLAC__IOHandle handle)
 static int
 FlacIOSeek(FLAC__IOHandle handle, FLAC__int64 _offset, int whence)
 {
-	auto *is = (InputStream *)handle;
+	auto is = (InputStream *)handle;
 
 	offset_type offset = _offset;
 	switch (whence) {
@@ -104,7 +104,7 @@ FlacIOSeek(FLAC__IOHandle handle, FLAC__int64 _offset, int whence)
 static FLAC__int64
 FlacIOTell(FLAC__IOHandle handle)
 {
-	auto *is = (InputStream *)handle;
+	auto is = (InputStream *)handle;
 
 	return is->GetOffset();
 }
@@ -112,7 +112,7 @@ FlacIOTell(FLAC__IOHandle handle)
 static int
 FlacIOEof(FLAC__IOHandle handle)
 {
-	auto *is = (InputStream *)handle;
+	auto is = (InputStream *)handle;
 
 	return is->LockIsEOF();
 }

--- a/src/mixer/plugins/AlsaMixerPlugin.cxx
+++ b/src/mixer/plugins/AlsaMixerPlugin.cxx
@@ -177,7 +177,7 @@ alsa_mixer_init(EventLoop &event_loop, gcc_unused AudioOutput &ao,
 		MixerListener &listener,
 		const ConfigBlock &block)
 {
-	auto *am = new AlsaMixer(event_loop, listener);
+	auto am = new AlsaMixer(event_loop, listener);
 	am->Configure(block);
 
 	return am;

--- a/src/mixer/plugins/PulseMixerPlugin.cxx
+++ b/src/mixer/plugins/PulseMixerPlugin.cxx
@@ -108,7 +108,7 @@ static void
 pulse_mixer_volume_cb(gcc_unused pa_context *context, const pa_sink_input_info *i,
 		      int eol, void *userdata)
 {
-	auto *pm = (PulseMixer *)userdata;
+	auto pm = (PulseMixer *)userdata;
 	pm->VolumeCallback(i, eol);
 }
 
@@ -189,7 +189,7 @@ pulse_mixer_init(gcc_unused EventLoop &event_loop, AudioOutput &ao,
 {
 	auto &po = (PulseOutput &)ao;
 	float scale = parse_volume_scale_factor(block.GetBlockValue("scale_volume"));
-	auto *pm = new PulseMixer(po, listener, scale);
+	auto pm = new PulseMixer(po, listener, scale);
 
 	pulse_output_set_mixer(po, *pm);
 

--- a/src/net/IPv4Address.cxx
+++ b/src/net/IPv4Address.cxx
@@ -37,7 +37,7 @@ CastToIPv4(const struct sockaddr *p) noexcept
 	assert(p->sa_family == AF_INET);
 
 	/* cast through void to work around the bogus alignment warning */
-	const void *q = reinterpret_cast<const void *>(p);
+	const auto q = reinterpret_cast<const void *>(p);
 	return reinterpret_cast<const struct sockaddr_in *>(q);
 }
 

--- a/src/net/IPv6Address.cxx
+++ b/src/net/IPv6Address.cxx
@@ -39,7 +39,7 @@ CastToIPv6(const struct sockaddr *p) noexcept
 	assert(p->sa_family == AF_INET6);
 
 	/* cast through void to work around the bogus alignment warning */
-	const void *q = reinterpret_cast<const void *>(p);
+	const auto q = reinterpret_cast<const void *>(p);
 	return reinterpret_cast<const struct sockaddr_in6 *>(q);
 }
 

--- a/src/output/plugins/AoOutputPlugin.cxx
+++ b/src/output/plugins/AoOutputPlugin.cxx
@@ -198,7 +198,7 @@ AoOutput::Play(const void *chunk, size_t size)
 	/* For whatever reason, libao wants a non-const pointer.
 	   Let's hope it does not write to the buffer, and use the
 	   union deconst hack to * work around this API misdesign. */
-	char *data = const_cast<char *>((const char *)chunk);
+	auto data = const_cast<char *>((const char *)chunk);
 
 	if (ao_play(device, data, size) == 0)
 		throw MakeAoError();

--- a/src/output/plugins/JackOutputPlugin.cxx
+++ b/src/output/plugins/JackOutputPlugin.cxx
@@ -283,7 +283,7 @@ MultiReadAdvance(ConstBuffer<jack_ringbuffer_t *> buffers,
 static void
 WriteSilence(jack_port_t &port, jack_nframes_t nframes)
 {
-	auto *out =
+	auto out =
 		(jack_default_audio_sample_t *)
 		jack_port_get_buffer(&port, nframes);
 	if (out == nullptr)
@@ -313,7 +313,7 @@ static void
 Copy(jack_port_t &dest, jack_nframes_t nframes,
      jack_ringbuffer_t &src, jack_nframes_t available)
 {
-	auto *out =
+	auto out =
 		(jack_default_audio_sample_t *)
 		jack_port_get_buffer(&dest, nframes);
 	if (out == nullptr)

--- a/src/output/plugins/RecorderOutputPlugin.cxx
+++ b/src/output/plugins/RecorderOutputPlugin.cxx
@@ -251,7 +251,7 @@ RecorderOutput::ReopenFormat(AllocatedPath &&new_path)
 	assert(path.IsNull());
 	assert(file == nullptr);
 
-	auto *new_file = new FileOutputStream(new_path);
+	auto new_file = new FileOutputStream(new_path);
 
 	AudioFormat new_audio_format = effective_audio_format;
 

--- a/src/output/plugins/httpd/HttpdClient.cxx
+++ b/src/output/plugins/httpd/HttpdClient.cxx
@@ -411,8 +411,8 @@ HttpdClient::OnSocketInput(void *data, size_t length) noexcept
 		return InputResult::CLOSED;
 	}
 
-	char *line = (char *)data;
-	char *newline = (char *)memchr(line, '\n', length);
+	auto line = (char *)data;
+	auto newline = (char *)memchr(line, '\n', length);
 	if (newline == nullptr)
 		return InputResult::MORE;
 

--- a/src/pcm/Export.cxx
+++ b/src/pcm/Export.cxx
@@ -297,7 +297,7 @@ PcmExport::Export(ConstBuffer<void> data) noexcept
 		const auto src = ConstBuffer<int32_t>::FromVoid(data);
 		const size_t num_samples = src.size;
 		const size_t dest_size = num_samples * 3;
-		auto *dest = (uint8_t *)pack_buffer.Get(dest_size);
+		auto dest = (uint8_t *)pack_buffer.Get(dest_size);
 		assert(dest != nullptr);
 
 		pcm_pack_24(dest, src.begin(), src.end());
@@ -307,7 +307,7 @@ PcmExport::Export(ConstBuffer<void> data) noexcept
 	} else if (shift8) {
 		const auto src = ConstBuffer<int32_t>::FromVoid(data);
 
-		auto *dest = (uint32_t *)pack_buffer.Get(data.size);
+		auto dest = (uint32_t *)pack_buffer.Get(data.size);
 		data.data = dest;
 
 		for (auto i : src)
@@ -319,7 +319,7 @@ PcmExport::Export(ConstBuffer<void> data) noexcept
 
 		const auto src = ConstBuffer<uint8_t>::FromVoid(data);
 
-		auto *dest = (uint8_t *)reverse_buffer.Get(data.size);
+		auto dest = (uint8_t *)reverse_buffer.Get(data.size);
 		assert(dest != nullptr);
 		data.data = dest;
 

--- a/src/pcm/Pack.cxx
+++ b/src/pcm/Pack.cxx
@@ -23,7 +23,7 @@
 static void
 pack_sample(uint8_t *dest, const int32_t *src0) noexcept
 {
-	const auto *src = (const uint8_t *)src0;
+	auto src = (const uint8_t *)src0;
 
 	if (IsBigEndian())
 		++src;

--- a/src/pcm/PcmDsd.cxx
+++ b/src/pcm/PcmDsd.cxx
@@ -33,7 +33,7 @@ PcmDsd::ToFloat(unsigned channels, ConstBuffer<uint8_t> src) noexcept
 	const size_t num_samples = src.size;
 	const size_t num_frames = src.size / channels;
 
-	auto *dest = buffer.GetT<float>(num_samples);
+	auto dest = buffer.GetT<float>(num_samples);
 
 	dsd2pcm.Translate(channels, num_frames, src.data, dest);
 	return { dest, num_samples };

--- a/src/pcm/SoxrResampler.cxx
+++ b/src/pcm/SoxrResampler.cxx
@@ -157,7 +157,7 @@ SoxrPcmResampler::Resample(ConstBuffer<void> src)
 	/* always round up: worst case output buffer size */
 	const size_t o_frames = size_t(n_frames * ratio) + 1;
 
-	auto *output_buffer = (float *)buffer.Get(o_frames * frame_size);
+	auto output_buffer = (float *)buffer.Get(o_frames * frame_size);
 
 	size_t i_done, o_done;
 	soxr_error_t e = soxr_process(soxr, src.data, n_frames, &i_done,
@@ -174,7 +174,7 @@ SoxrPcmResampler::Flush()
 	const size_t frame_size = channels * sizeof(float);
 	const size_t o_frames = 1024;
 
-	auto *output_buffer = (float *)buffer.Get(o_frames * frame_size);
+	auto output_buffer = (float *)buffer.Get(o_frames * frame_size);
 
 	size_t o_done;
 	soxr_error_t e = soxr_process(soxr, nullptr, 0, nullptr,

--- a/src/playlist/plugins/AsxPlaylistPlugin.cxx
+++ b/src/playlist/plugins/AsxPlaylistPlugin.cxx
@@ -65,7 +65,7 @@ static void XMLCALL
 asx_start_element(void *user_data, const XML_Char *element_name,
 		  const XML_Char **atts)
 {
-	auto *parser = (AsxParser *)user_data;
+	auto parser = (AsxParser *)user_data;
 
 	switch (parser->state) {
 	case AsxParser::ROOT:
@@ -97,7 +97,7 @@ asx_start_element(void *user_data, const XML_Char *element_name,
 static void XMLCALL
 asx_end_element(void *user_data, const XML_Char *element_name)
 {
-	auto *parser = (AsxParser *)user_data;
+	auto parser = (AsxParser *)user_data;
 
 	switch (parser->state) {
 	case AsxParser::ROOT:
@@ -120,7 +120,7 @@ asx_end_element(void *user_data, const XML_Char *element_name)
 static void XMLCALL
 asx_char_data(void *user_data, const XML_Char *s, int len)
 {
-	auto *parser = (AsxParser *)user_data;
+	auto parser = (AsxParser *)user_data;
 
 	switch (parser->state) {
 	case AsxParser::ROOT:

--- a/src/playlist/plugins/RssPlaylistPlugin.cxx
+++ b/src/playlist/plugins/RssPlaylistPlugin.cxx
@@ -65,7 +65,7 @@ static void XMLCALL
 rss_start_element(void *user_data, const XML_Char *element_name,
 		  const XML_Char **atts)
 {
-	auto *parser = (RssParser *)user_data;
+	auto parser = (RssParser *)user_data;
 
 	switch (parser->state) {
 	case RssParser::ROOT:
@@ -95,7 +95,7 @@ rss_start_element(void *user_data, const XML_Char *element_name,
 static void XMLCALL
 rss_end_element(void *user_data, const XML_Char *element_name)
 {
-	auto *parser = (RssParser *)user_data;
+	auto parser = (RssParser *)user_data;
 
 	switch (parser->state) {
 	case RssParser::ROOT:
@@ -118,7 +118,7 @@ rss_end_element(void *user_data, const XML_Char *element_name)
 static void XMLCALL
 rss_char_data(void *user_data, const XML_Char *s, int len)
 {
-	auto *parser = (RssParser *)user_data;
+	auto parser = (RssParser *)user_data;
 
 	switch (parser->state) {
 	case RssParser::ROOT:

--- a/src/playlist/plugins/XspfPlaylistPlugin.cxx
+++ b/src/playlist/plugins/XspfPlaylistPlugin.cxx
@@ -68,7 +68,7 @@ static void XMLCALL
 xspf_start_element(void *user_data, const XML_Char *element_name,
 		   gcc_unused const XML_Char **atts)
 {
-	auto *parser = (XspfParser *)user_data;
+	auto parser = (XspfParser *)user_data;
 
 	switch (parser->state) {
 	case XspfParser::ROOT:
@@ -118,7 +118,7 @@ xspf_start_element(void *user_data, const XML_Char *element_name,
 static void XMLCALL
 xspf_end_element(void *user_data, const XML_Char *element_name)
 {
-	auto *parser = (XspfParser *)user_data;
+	auto parser = (XspfParser *)user_data;
 
 	switch (parser->state) {
 	case XspfParser::ROOT:
@@ -157,7 +157,7 @@ xspf_end_element(void *user_data, const XML_Char *element_name)
 static void XMLCALL
 xspf_char_data(void *user_data, const XML_Char *s, int len)
 {
-	auto *parser = (XspfParser *)user_data;
+	auto parser = (XspfParser *)user_data;
 
 	switch (parser->state) {
 	case XspfParser::ROOT:

--- a/src/sticker/Database.cxx
+++ b/src/sticker/Database.cxx
@@ -160,8 +160,8 @@ StickerDatabase::ListValues(std::map<std::string, std::string> &table,
 	};
 
 	ExecuteForEach(s, [s, &table](){
-		const char *name = (const char *)sqlite3_column_text(s, 0);
-		const char *value = (const char *)sqlite3_column_text(s, 1);
+		auto name = (const char *)sqlite3_column_text(s, 0);
+		auto value = (const char *)sqlite3_column_text(s, 1);
 		table.insert(std::make_pair(name, value));
 	});
 }

--- a/src/sticker/SongSticker.cxx
+++ b/src/sticker/SongSticker.cxx
@@ -87,8 +87,7 @@ struct sticker_song_find_data {
 static void
 sticker_song_find_cb(const char *uri, const char *value, void *user_data)
 {
-	auto *data =
-		(struct sticker_song_find_data *)user_data;
+	auto data = (struct sticker_song_find_data *)user_data;
 
 	if (memcmp(uri, data->base_uri, data->base_uri_length) != 0)
 		/* should not happen, ignore silently */

--- a/src/storage/plugins/NfsStorage.cxx
+++ b/src/storage/plugins/NfsStorage.cxx
@@ -358,7 +358,7 @@ protected:
 
 	void HandleResult(gcc_unused unsigned status,
 			  void *data) noexcept override {
-		auto *const dir = (struct nfsdir *)data;
+		auto const dir = (struct nfsdir *)data;
 
 		CollectEntries(dir);
 		connection.CloseDirectory(dir);

--- a/src/system/FileDescriptor.cxx
+++ b/src/system/FileDescriptor.cxx
@@ -290,7 +290,7 @@ FileDescriptor::GetSize() const noexcept
 void
 FileDescriptor::FullRead(void *_buffer, size_t length)
 {
-	auto *buffer = (uint8_t *)_buffer;
+	auto buffer = (uint8_t *)_buffer;
 
 	while (length > 0) {
 		ssize_t nbytes = Read(buffer, length);

--- a/src/tag/ApeLoader.cxx
+++ b/src/tag/ApeLoader.cxx
@@ -83,7 +83,7 @@ try {
 
 		/* get the key */
 		const char *key = p;
-		const char *key_end = (const char *)memchr(p, '\0', remaining);
+		auto key_end = (const char *)memchr(p, '\0', remaining);
 		if (key_end == nullptr)
 			break;
 

--- a/src/tag/FixString.cxx
+++ b/src/tag/FixString.cxx
@@ -57,7 +57,7 @@ patch_utf8(StringView src, const char *_invalid)
 {
 	/* duplicate the string, and replace invalid bytes in that
 	   buffer */
-	char *dest = (char *)xmemdup(src.data, src.size);
+	auto dest = (char *)xmemdup(src.data, src.size);
 	char *const end = dest + src.size;
 
 	char *invalid = dest + (_invalid - src.data);
@@ -110,7 +110,7 @@ clear_non_printable(StringView src)
 	if (first == nullptr)
 		return nullptr;
 
-	char *dest = (char *)xmemdup(src.data, src.size);
+	auto dest = (char *)xmemdup(src.data, src.size);
 
 	for (size_t i = first - src.data; i < src.size; ++i)
 		if (char_is_non_printable(dest[i]))

--- a/src/tag/Id3ReplayGain.cxx
+++ b/src/tag/Id3ReplayGain.cxx
@@ -38,10 +38,10 @@ Id3ToReplayGainInfo(ReplayGainInfo &rgi, const struct id3_tag *tag) noexcept
 		if (frame->nfields < 3)
 			continue;
 
-		char *const key = (char *)
+		auto const key = (char *)
 		    id3_ucs4_latin1duplicate(id3_field_getstring
 					     (&frame->fields[1]));
-		char *const value = (char *)
+		auto const value = (char *)
 		    id3_ucs4_latin1duplicate(id3_field_getstring
 					     (&frame->fields[2]));
 

--- a/src/tag/Id3Scan.cxx
+++ b/src/tag/Id3Scan.cxx
@@ -294,7 +294,7 @@ tag_id3_handle_apic(const struct id3_tag *id3_tag,
 		return;
 
 	for (unsigned i = 0;; ++i) {
-		const id3_frame *frame = id3_tag_findframe(id3_tag, "APIC", i);
+		auto frame = id3_tag_findframe(id3_tag, "APIC", i);
 		if (frame == nullptr)
 			break;
 
@@ -302,7 +302,7 @@ tag_id3_handle_apic(const struct id3_tag *id3_tag,
 		if (mime_type_field == nullptr)
 			continue;
 
-		const char *mime_type = (const char *)
+		auto mime_type = (const char *)
 			id3_field_getlatin1(mime_type_field);
 		if (mime_type != nullptr &&
 		    StringIsEqual(mime_type, "-->"))
@@ -315,8 +315,7 @@ tag_id3_handle_apic(const struct id3_tag *id3_tag,
 			continue;
 
 		id3_length_t size;
-		const id3_byte_t *data =
-			id3_field_getbinarydata(data_field, &size);
+		auto data = id3_field_getbinarydata(data_field, &size);
 		if (data == nullptr || size == 0)
 			continue;
 

--- a/src/util/Alloc.cxx
+++ b/src/util/Alloc.cxx
@@ -87,7 +87,7 @@ t_xstrcatdup(Args&&... args)
 	size_t lengths[n];
 	const size_t total = FillLengths(lengths, args...);
 
-	char *p = (char *)xalloc(total + 1);
+	auto p = (char *)xalloc(total + 1);
 	*StringCat(p, lengths, args...) = 0;
 	return p;
 }

--- a/src/util/FormatString.cxx
+++ b/src/util/FormatString.cxx
@@ -35,7 +35,7 @@ FormatStringV(const char *fmt, va_list args) noexcept
 		/* wtf.. */
 		abort();
 
-	char *buffer = new char[length + 1];
+	auto buffer = new char[length + 1];
 	vsnprintf(buffer, length + 1, fmt, args);
 	return AllocatedString<>::Donate(buffer);
 }

--- a/src/util/UriUtil.cxx
+++ b/src/util/UriUtil.cxx
@@ -30,8 +30,8 @@
 #include "UriUtil.hxx"
 #include "ASCII.hxx"
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 static const char *
 verify_uri_segment(const char *p) noexcept
@@ -45,7 +45,7 @@ verify_uri_segment(const char *p) noexcept
 	if (dots <= 2 && (*p == 0 || *p == '/'))
 		return nullptr;
 
-	const char *q = strchr(p + 1, '/');
+	auto q = std::strchr(p + 1, '/');
 	return q != nullptr ? q : "";
 }
 
@@ -83,16 +83,16 @@ SkipUriScheme(const char *uri) noexcept
 std::string
 uri_remove_auth(const char *uri) noexcept
 {
-	const char *auth = SkipUriScheme(uri);
+	auto auth = SkipUriScheme(uri);
 	if (auth == nullptr)
 		/* unrecognized URI */
 		return std::string();
 
-	const char *slash = strchr(auth, '/');
+	auto slash = std::strchr(auth, '/');
 	if (slash == nullptr)
 		slash = auth + strlen(auth);
 
-	const char *at = (const char *)memchr(auth, '@', slash - auth);
+	auto at = (const char *)std::memchr(auth, '@', slash - auth);
 	if (at == nullptr)
 		/* no auth info present, do nothing */
 		return std::string();


### PR DESCRIPTION
Found with modernize-use-auto

Signed-off-by: Rosen Penev <rosenp@gmail.com>

My understanding is the following:

auto c = (const char *) -> lhs is const char *
const auto *c = (const char *) -> lhs is const char *
const auto c = (const char *) -> lhs is const char * const

Removing the * makes the type clearer IMO.