### PR TITLE
revert to {} to work around gcc bug

### DIFF
--- a/src/storage/CompositeStorage.cxx
+++ b/src/storage/CompositeStorage.cxx
@@ -179,7 +179,10 @@ CompositeStorage::Directory::MapToRelativeUTF8(std::string &buffer,
 	return false;
 }
 
-CompositeStorage::CompositeStorage() noexcept = default;
+CompositeStorage::CompositeStorage() noexcept
+{
+}
+
 CompositeStorage::~CompositeStorage() = default;
 
 Storage *


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>