### PR TITLE
remove redundant const qualification

### DIFF
--- a/src/output/Control.cxx
+++ b/src/output/Control.cxx
@@ -116,7 +116,7 @@ AudioOutputControl::GetMixer() const noexcept
 	return output ? output->mixer : nullptr;
 }
 
-const std::map<std::string, std::string>
+std::map<std::string, std::string>
 AudioOutputControl::GetAttributes() const noexcept
 {
 	return output

--- a/src/output/Control.hxx
+++ b/src/output/Control.hxx
@@ -357,7 +357,7 @@ public:
 
 	void BeginDestroy() noexcept;
 
-	const std::map<std::string, std::string> GetAttributes() const noexcept;
+	std::map<std::string, std::string> GetAttributes() const noexcept;
 	void SetAttribute(std::string &&name, std::string &&value);
 
 	/**

--- a/src/output/Filtered.cxx
+++ b/src/output/Filtered.cxx
@@ -39,7 +39,7 @@ FilteredAudioOutput::SupportsPause() const noexcept
 	return output->SupportsPause();
 }
 
-const std::map<std::string, std::string>
+std::map<std::string, std::string>
 FilteredAudioOutput::GetAttributes() const noexcept
 {
 	return output->GetAttributes();

--- a/src/output/Filtered.hxx
+++ b/src/output/Filtered.hxx
@@ -170,7 +170,7 @@ public:
 	gcc_pure
 	bool SupportsPause() const noexcept;
 
-	const std::map<std::string, std::string> GetAttributes() const noexcept;
+	std::map<std::string, std::string> GetAttributes() const noexcept;
 	void SetAttribute(std::string &&name, std::string &&value);
 
 	/**

--- a/src/output/Interface.hxx
+++ b/src/output/Interface.hxx
@@ -64,7 +64,7 @@ public:
 	 *
 	 * This method must be thread-safe.
 	 */
-	virtual const std::map<std::string, std::string> GetAttributes() const noexcept {
+	virtual std::map<std::string, std::string> GetAttributes() const noexcept {
 		return {};
 	}
 

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -228,7 +228,7 @@ public:
 	}
 
 private:
-	const std::map<std::string, std::string> GetAttributes() const noexcept override;
+	std::map<std::string, std::string> GetAttributes() const noexcept override;
 	void SetAttribute(std::string &&name, std::string &&value) override;
 
 	void Enable() override;
@@ -427,7 +427,7 @@ AlsaOutput::AlsaOutput(EventLoop &_loop, const ConfigBlock &block)
 		allowed_formats = Alsa::AllowedFormat::ParseList(allowed_formats_string);
 }
 
-const std::map<std::string, std::string>
+std::map<std::string, std::string>
 AlsaOutput::GetAttributes() const noexcept
 {
 	const std::lock_guard<Mutex> lock(attributes_mutex);


### PR DESCRIPTION
Found with readability-const-return-type

Signed-off-by: Rosen Penev <rosenp@gmail.com>