### PR TITLE
[clang-tidy] remove const in declaration

### DIFF
--- a/src/CommandLine.cxx
+++ b/src/CommandLine.cxx
@@ -297,7 +297,7 @@ public:
 	explicit ConfigLoader(ConfigData &_config) noexcept
 		:config(_config) {}
 
-	bool TryFile(const Path path);
+	bool TryFile(Path path);
 	bool TryFile(const AllocatedPath &base_path, Path path);
 };
 


### PR DESCRIPTION
Found with readability-avoid-const-params-in-decls

Signed-off-by: Rosen Penev <rosenp@gmail.com>