### PR TITLE
[clang-tidy] add const to parameter

### DIFF
--- a/src/decoder/plugins/DsdiffDecoderPlugin.cxx
+++ b/src/decoder/plugins/DsdiffDecoderPlugin.cxx
@@ -342,7 +342,7 @@ dsdiff_read_metadata(DecoderClient *client, InputStream &is,
 }
 
 static void
-bit_reverse_buffer(uint8_t *p, uint8_t *end)
+bit_reverse_buffer(uint8_t *p, const uint8_t *end)
 {
 	for (; p < end; ++p)
 		*p = bit_reverse(*p);

--- a/src/decoder/plugins/DsfDecoderPlugin.cxx
+++ b/src/decoder/plugins/DsfDecoderPlugin.cxx
@@ -181,7 +181,7 @@ dsf_read_metadata(DecoderClient *client, InputStream &is,
 }
 
 static void
-bit_reverse_buffer(uint8_t *p, uint8_t *end)
+bit_reverse_buffer(uint8_t *p, const uint8_t *end)
 {
 	for (; p < end; ++p)
 		*p = bit_reverse(*p);


### PR DESCRIPTION
Found with readability-non-const-parameter

Signed-off-by: Rosen Penev <rosenp@gmail.com>