### PR TITLE
[clang-tidy] remove unneeded return

### DIFF
--- a/src/decoder/plugins/DsdLib.cxx
+++ b/src/decoder/plugins/DsdLib.cxx
@@ -150,6 +150,5 @@ dsdlib_tag_id3(InputStream &is, TagHandler &handler,
 	scan_id3_tag(id3_tag, handler);
 
 	id3_tag_delete(id3_tag);
-	return;
 }
 #endif

--- a/src/decoder/plugins/DsdiffDecoderPlugin.cxx
+++ b/src/decoder/plugins/DsdiffDecoderPlugin.cxx
@@ -213,7 +213,6 @@ dsdiff_handle_native_tag(DecoderClient *client, InputStream &is,
 		return;
 
 	handler.OnTag(type, {label, length});
-	return;
 }
 
 /**


### PR DESCRIPTION
Found with readability-redundant-control-flow

Signed-off-by: Rosen Penev <rosenp@gmail.com>