### PR TITLE
[clang-tidy] change integer prefixes to uppercase

### DIFF
--- a/src/command/PlayerCommands.cxx
+++ b/src/command/PlayerCommands.cxx
@@ -174,7 +174,7 @@ handle_status(Client &client, gcc_unused Request args, Response &r)
 			 COMMAND_STATUS_BITRATE ": %u\n",
 			 player_status.elapsed_time.RoundS(),
 			 player_status.total_time.IsNegative()
-			 ? 0u
+			 ? 0U
 			 : unsigned(player_status.total_time.RoundS()),
 			 player_status.elapsed_time.ToDoubleS(),
 			 player_status.bit_rate);

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -448,7 +448,7 @@ ProxyDatabase::ProxyDatabase(EventLoop &_loop, DatabaseListener &_listener,
 	 listener(_listener),
 	 host(block.GetBlockValue("host", "")),
 	 password(block.GetBlockValue("password", "")),
-	 port(block.GetBlockValue("port", 0u)),
+	 port(block.GetBlockValue("port", 0U)),
 	 keepalive(block.GetBlockValue("keepalive", false))
 {
 }
@@ -517,7 +517,7 @@ ProxyDatabase::Connect()
 	(void)keepalive;
 #endif
 
-	idle_received = ~0u;
+	idle_received = ~0U;
 	is_idle = false;
 
 	SocketMonitor::Open(SocketDescriptor(mpd_async_get_fd(mpd_connection_get_async(connection))));

--- a/src/decoder/plugins/AdPlugDecoderPlugin.cxx
+++ b/src/decoder/plugins/AdPlugDecoderPlugin.cxx
@@ -41,7 +41,7 @@ adplug_init(const ConfigBlock &block)
 	FormatDebug(adplug_domain, "adplug %s",
 		    CAdPlug::get_version().c_str());
 
-	sample_rate = block.GetPositiveValue("sample_rate", 48000u);
+	sample_rate = block.GetPositiveValue("sample_rate", 48000U);
 	CheckSampleRate(sample_rate);
 
 	return true;

--- a/src/decoder/plugins/FluidsynthDecoderPlugin.cxx
+++ b/src/decoder/plugins/FluidsynthDecoderPlugin.cxx
@@ -77,7 +77,7 @@ fluidsynth_mpd_log_function(int level,
 static bool
 fluidsynth_init(const ConfigBlock &block)
 {
-	sample_rate = block.GetPositiveValue("sample_rate", 48000u);
+	sample_rate = block.GetPositiveValue("sample_rate", 48000U);
 	CheckSampleRate(sample_rate);
 
 	soundfont_path = block.GetBlockValue("soundfont",

--- a/src/decoder/plugins/HybridDsdDecoderPlugin.cxx
+++ b/src/decoder/plugins/HybridDsdDecoderPlugin.cxx
@@ -186,7 +186,7 @@ HybridDsdDecode(DecoderClient &client, InputStream &input)
 		client.Ready(result.first, true, duration);
 		frame_size = result.first.GetFrameSize();
 		kbit_rate = frame_size * result.first.sample_rate /
-			(1024u / 8u);
+			(1024U / 8U);
 		total_frames = result.second / frame_size;
 	} catch (UnsupportedFile) {
 		/* not a Hybrid-DSD file; let the next decoder plugin
@@ -236,7 +236,7 @@ HybridDsdDecode(DecoderClient &client, InputStream &input)
 		/* fill the buffer */
 		auto w = buffer.Write();
 		if (!w.empty()) {
-			if (remaining_bytes < (1<<30ull) &&
+			if (remaining_bytes < (1<<30ULL) &&
 			    w.size > size_t(remaining_bytes))
 				w.size = remaining_bytes;
 

--- a/src/decoder/plugins/MikmodDecoderPlugin.cxx
+++ b/src/decoder/plugins/MikmodDecoderPlugin.cxx
@@ -108,7 +108,7 @@ mikmod_decoder_init(const ConfigBlock &block)
 	static char params[] = "";
 
 	mikmod_loop = block.GetBlockValue("loop", false);
-	mikmod_sample_rate = block.GetPositiveValue("sample_rate", 44100u);
+	mikmod_sample_rate = block.GetPositiveValue("sample_rate", 44100U);
 	if (!audio_valid_sample_rate(mikmod_sample_rate))
 		throw FormatRuntimeError("Invalid sample rate in line %d: %u",
 					 block.line, mikmod_sample_rate);

--- a/src/decoder/plugins/SidplayDecoderPlugin.cxx
+++ b/src/decoder/plugins/SidplayDecoderPlugin.cxx
@@ -127,7 +127,7 @@ SidplayGlobal::SidplayGlobal(const ConfigBlock &block)
 	if (!database_path.IsNull())
 		songlength_database = sidplay_load_songlength_db(database_path);
 
-	default_songlength = block.GetPositiveValue("default_songlength", 0u);
+	default_songlength = block.GetPositiveValue("default_songlength", 0U);
 
 	default_genre = block.GetBlockValue("default_genre", "");
 
@@ -403,7 +403,7 @@ sidplay_file_decode(DecoderClient &client, Path path_fs)
 	const unsigned timebase = player.timebase();
 #endif
 	const unsigned end = duration.IsNegative()
-		? 0u
+		? 0U
 		: duration.ToScale<uint64_t>(timebase);
 
 	DecoderCommand cmd;

--- a/src/encoder/plugins/FlacEncoderPlugin.cxx
+++ b/src/encoder/plugins/FlacEncoderPlugin.cxx
@@ -93,7 +93,7 @@ public:
 };
 
 PreparedFlacEncoder::PreparedFlacEncoder(const ConfigBlock &block)
-	:compression(block.GetBlockValue("compression", 5u))
+	:compression(block.GetBlockValue("compression", 5U))
 {
 }
 

--- a/src/encoder/plugins/OpusEncoderPlugin.cxx
+++ b/src/encoder/plugins/OpusEncoderPlugin.cxx
@@ -105,7 +105,7 @@ PreparedOpusEncoder::PreparedOpusEncoder(const ConfigBlock &block)
 			throw std::runtime_error("Invalid bit rate");
 	}
 
-	complexity = block.GetBlockValue("complexity", 10u);
+	complexity = block.GetBlockValue("complexity", 10U);
 	if (complexity > 10)
 		throw std::runtime_error("Invalid complexity");
 

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -112,7 +112,7 @@ input_cdio_init(EventLoop &, const ConfigBlock &block)
 			throw FormatRuntimeError("Unrecognized 'default_byte_order' setting: %s",
 						 value);
 	}
-	speed = block.GetBlockValue("speed",0u);
+	speed = block.GetBlockValue("speed",0U);
 }
 
 struct CdioUri {

--- a/src/input/plugins/CurlInputPlugin.cxx
+++ b/src/input/plugins/CurlInputPlugin.cxx
@@ -364,7 +364,7 @@ input_curl_init(EventLoop &event_loop, const ConfigBlock &block)
 	http_200_aliases = curl_slist_append(http_200_aliases, "ICY 200 OK");
 
 	proxy = block.GetBlockValue("proxy");
-	proxy_port = block.GetBlockValue("proxy_port", 0u);
+	proxy_port = block.GetBlockValue("proxy_port", 0U);
 	proxy_user = block.GetBlockValue("proxy_user");
 	proxy_password = block.GetBlockValue("proxy_password");
 
@@ -409,9 +409,9 @@ CurlInputStream::InitEasy()
 	request = new CurlRequest(**curl_init, GetURI(), *this);
 
 	request->SetOption(CURLOPT_HTTP200ALIASES, http_200_aliases);
-	request->SetOption(CURLOPT_FOLLOWLOCATION, 1l);
-	request->SetOption(CURLOPT_MAXREDIRS, 5l);
-	request->SetOption(CURLOPT_FAILONERROR, 1l);
+	request->SetOption(CURLOPT_FOLLOWLOCATION, 1L);
+	request->SetOption(CURLOPT_MAXREDIRS, 5L);
+	request->SetOption(CURLOPT_FAILONERROR, 1L);
 
 	if (proxy != nullptr)
 		request->SetOption(CURLOPT_PROXY, proxy);
@@ -424,8 +424,8 @@ CurlInputStream::InitEasy()
 				   StringFormat<1024>("%s:%s", proxy_user,
 						      proxy_password).c_str());
 
-	request->SetOption(CURLOPT_SSL_VERIFYPEER, verify_peer ? 1l : 0l);
-	request->SetOption(CURLOPT_SSL_VERIFYHOST, verify_host ? 2l : 0l);
+	request->SetOption(CURLOPT_SSL_VERIFYPEER, verify_peer ? 1L : 0L);
+	request->SetOption(CURLOPT_SSL_VERIFYHOST, verify_host ? 2L : 0L);
 	request->SetOption(CURLOPT_HTTPHEADER, request_headers.Get());
 }
 

--- a/src/lib/curl/Request.cxx
+++ b/src/lib/curl/Request.cxx
@@ -56,7 +56,7 @@ CurlRequest::CurlRequest(CurlGlobal &_global,
 	easy.SetUserAgent("Music Player Daemon " VERSION);
 	easy.SetHeaderFunction(_HeaderFunction, this);
 	easy.SetWriteFunction(WriteFunction, this);
-	easy.SetOption(CURLOPT_NETRC, 1l);
+	easy.SetOption(CURLOPT_NETRC, 1L);
 	easy.SetErrorBuffer(error_buffer);
 	easy.SetNoProgress();
 	easy.SetNoSignal();

--- a/src/lib/icu/CaseFold.cxx
+++ b/src/lib/icu/CaseFold.cxx
@@ -58,7 +58,7 @@ try {
 	if (u.IsNull())
 		return AllocatedString<>::Duplicate(src);
 
-	AllocatedArray<UChar> folded(u.size() * 2u);
+	AllocatedArray<UChar> folded(u.size() * 2U);
 
 	UErrorCode error_code = U_ZERO_ERROR;
 	size_t folded_length = u_strFoldCase(folded.begin(), folded.size(),

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -404,7 +404,7 @@ AlsaOutput::AlsaOutput(EventLoop &_loop, const ConfigBlock &block)
 #endif
 	 buffer_time(block.GetPositiveValue("buffer_time",
 					    MPD_ALSA_BUFFER_TIME_US)),
-	 period_time(block.GetPositiveValue("period_time", 0u))
+	 period_time(block.GetPositiveValue("period_time", 0U))
 {
 #ifdef SND_PCM_NO_AUTO_RESAMPLE
 	if (!block.GetBlockValue("auto_resample", true))

--- a/src/output/plugins/AoOutputPlugin.cxx
+++ b/src/output/plugins/AoOutputPlugin.cxx
@@ -101,7 +101,7 @@ MakeAoError()
 
 AoOutput::AoOutput(const ConfigBlock &block)
 	:AudioOutput(0),
-	 write_size(block.GetPositiveValue("write_size", 1024u))
+	 write_size(block.GetPositiveValue("write_size", 1024U))
 {
 	const char *value = block.GetBlockValue("driver", "default");
 	if (StringIsEqual(value, "default"))

--- a/src/output/plugins/JackOutputPlugin.cxx
+++ b/src/output/plugins/JackOutputPlugin.cxx
@@ -247,7 +247,7 @@ JackOutput::JackOutput(const ConfigBlock &block)
 			      num_source_ports, num_destination_ports,
 			      block.line);
 
-	ringbuffer_size = block.GetPositiveValue("ringbuffer_size", 32768u);
+	ringbuffer_size = block.GetPositiveValue("ringbuffer_size", 32768U);
 }
 
 inline jack_nframes_t

--- a/src/output/plugins/ShoutOutputPlugin.cxx
+++ b/src/output/plugins/ShoutOutputPlugin.cxx
@@ -99,7 +99,7 @@ ShoutOutput::ShoutOutput(const ConfigBlock &block)
 {
 	const char *host = require_block_string(block, "host");
 	const char *mount = require_block_string(block, "mount");
-	unsigned port = block.GetBlockValue("port", 0u);
+	unsigned port = block.GetBlockValue("port", 0U);
 	if (port == 0)
 		throw std::runtime_error("shout port must be configured");
 

--- a/src/output/plugins/httpd/HttpdOutputPlugin.cxx
+++ b/src/output/plugins/httpd/HttpdOutputPlugin.cxx
@@ -50,11 +50,11 @@ HttpdOutput::HttpdOutput(EventLoop &_loop, const ConfigBlock &block)
 	genre = block.GetBlockValue("genre", "Set genre in config");
 	website = block.GetBlockValue("website", "Set website in config");
 
-	clients_max = block.GetBlockValue("max_clients", 0u);
+	clients_max = block.GetBlockValue("max_clients", 0U);
 
 	/* set up bind_to_address */
 
-	ServerSocketAddGeneric(*this, block.GetBlockValue("bind_to_address"), block.GetBlockValue("port", 8000u));
+	ServerSocketAddGeneric(*this, block.GetBlockValue("bind_to_address"), block.GetBlockValue("port", 8000U));
 
 	/* determine content type */
 	content_type = prepared_encoder->GetMimeType();

--- a/src/storage/plugins/CurlStorage.cxx
+++ b/src/storage/plugins/CurlStorage.cxx
@@ -261,8 +261,8 @@ public:
 		 CommonExpatParser(ExpatNamespaceSeparator{'|'})
 	{
 		request.SetOption(CURLOPT_CUSTOMREQUEST, "PROPFIND");
-		request.SetOption(CURLOPT_FOLLOWLOCATION, 1l);
-		request.SetOption(CURLOPT_MAXREDIRS, 1l);
+		request.SetOption(CURLOPT_FOLLOWLOCATION, 1L);
+		request.SetOption(CURLOPT_MAXREDIRS, 1L);
 
 		request_headers.Append(StringFormat<40>("depth: %u", depth));
 

--- a/src/util/UTF8.cxx
+++ b/src/util/UTF8.cxx
@@ -204,7 +204,7 @@ struct CheckSequenceUTF8 {
 };
 
 template<>
-struct CheckSequenceUTF8<0u> {
+struct CheckSequenceUTF8<0U> {
 	constexpr bool operator()(gcc_unused const char *p) const noexcept {
 		return true;
 	}
@@ -217,7 +217,7 @@ InnerSequenceLengthUTF8(const char *p) noexcept
 {
 	return CheckSequenceUTF8<L>()(p)
 		? L + 1
-		: 0u;
+		: 0U;
 }
 
 size_t


### PR DESCRIPTION
Found with readability-uppercase-literal-suffix

Signed-off-by: Rosen Penev <rosenp@gmail.com>