### PR TITLE
[clang-tidy] fix mismatching declarations

### DIFF
--- a/src/AudioCompress/compress.h
+++ b/src/AudioCompress/compress.h
@@ -36,7 +36,7 @@ void Compressor_setHistory(struct Compressor *, unsigned int history);
 struct CompressorConfig *Compressor_getConfig(struct Compressor *);
 
 //! Process 16-bit signed data
-void Compressor_Process_int16(struct Compressor *, int16_t *data, unsigned int count);
+void Compressor_Process_int16(struct Compressor *, int16_t *audio, unsigned int count);
 
 #ifdef __cplusplus
 }

--- a/src/Instance.hxx
+++ b/src/Instance.hxx
@@ -228,7 +228,7 @@ private:
 #endif
 
 	/* callback for #idle_monitor */
-	void OnIdle(unsigned mask) noexcept;
+	void OnIdle(unsigned flags) noexcept;
 };
 
 #endif

--- a/src/PlaylistFile.hxx
+++ b/src/PlaylistFile.hxx
@@ -77,8 +77,8 @@ spl_append_song(const char *utf8path, const DetachedSong &song);
  * Throws #std::runtime_error on error.
  */
 void
-spl_append_uri(const char *path_utf8,
-	       const SongLoader &loader, const char *uri_utf8);
+spl_append_uri(const char *utf8file,
+	       const SongLoader &loader, const char *url);
 
 void
 spl_rename(const char *utf8from, const char *utf8to);

--- a/src/archive/plugins/Bzip2ArchivePlugin.cxx
+++ b/src/archive/plugins/Bzip2ArchivePlugin.cxx
@@ -74,7 +74,7 @@ public:
 	/* virtual methods from InputStream */
 	bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,
-		    void *ptr, size_t size) override;
+		    void *ptr, size_t length) override;
 
 private:
 	void Open();

--- a/src/command/ClientCommands.hxx
+++ b/src/command/ClientCommands.hxx
@@ -21,19 +21,20 @@
 #define MPD_CLIENT_COMMANDS_HXX
 
 #include "CommandResult.hxx"
+#include "util/Compiler.h"
 
 class Client;
 class Request;
 class Response;
 
 CommandResult
-handle_close(Client &client, Request request, Response &response);
+handle_close(gcc_unused Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_ping(Client &client, Request request, Response &response);
+handle_ping(gcc_unused Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_password(Client &client, Request request, Response &response);
+handle_password(Client &client, Request args, Response &response);
 
 CommandResult
 handle_tagtypes(Client &client, Request request, Response &response);

--- a/src/command/DatabaseCommands.hxx
+++ b/src/command/DatabaseCommands.hxx
@@ -33,30 +33,30 @@ CommandResult
 handle_lsinfo2(Client &client, const char *uri, Response &response);
 
 CommandResult
-handle_find(Client &client, Request request, Response &response);
+handle_find(Client &client, Request args, Response &response);
 
 CommandResult
-handle_findadd(Client &client, Request request, Response &response);
+handle_findadd(Client &client, Request args, Response &response);
 
 CommandResult
-handle_search(Client &client, Request request, Response &response);
+handle_search(Client &client, Request args, Response &response);
 
 CommandResult
-handle_searchadd(Client &client, Request request, Response &response);
+handle_searchadd(Client &client, Request args, Response &response);
 
 CommandResult
-handle_searchaddpl(Client &client, Request request, Response &response);
+handle_searchaddpl(Client &client, Request args, Response &response);
 
 CommandResult
-handle_count(Client &client, Request request, Response &response);
+handle_count(Client &client, Request args, Response &response);
 
 CommandResult
-handle_listall(Client &client, Request request, Response &response);
+handle_listall(Client &client, Request args, Response &response);
 
 CommandResult
-handle_list(Client &client, Request request, Response &response);
+handle_list(Client &client, Request args, Response &response);
 
 CommandResult
-handle_listallinfo(Client &client, Request request, Response &response);
+handle_listallinfo(Client &client, Request args, Response &response);
 
 #endif

--- a/src/command/FileCommands.hxx
+++ b/src/command/FileCommands.hxx
@@ -31,12 +31,12 @@ CommandResult
 handle_listfiles_local(Response &response, Path path_fs);
 
 CommandResult
-handle_read_comments(Client &client, Request request, Response &response);
+handle_read_comments(Client &client, Request args, Response &response);
 
 CommandResult
-handle_album_art(Client &client, Request request, Response &response);
+handle_album_art(Client &client, Request args, Response &response);
 
 CommandResult
-handle_read_picture(Client &client, Request request, Response &response);
+handle_read_picture(Client &client, Request args, Response &response);
 
 #endif

--- a/src/command/FingerprintCommands.cxx
+++ b/src/command/FingerprintCommands.cxx
@@ -71,7 +71,7 @@ protected:
 	}
 
 private:
-	void DecodeStream(InputStream &is, const DecoderPlugin &plugin);
+	void DecodeStream(InputStream &input_stream, const DecoderPlugin &plugin);
 	bool DecodeStream(InputStream &is, const char *suffix,
 			  const DecoderPlugin &plugin);
 	void DecodeStream(InputStream &is);

--- a/src/command/FingerprintCommands.hxx
+++ b/src/command/FingerprintCommands.hxx
@@ -27,6 +27,6 @@ class Request;
 class Response;
 
 CommandResult
-handle_getfingerprint(Client &client, Request request, Response &response);
+handle_getfingerprint(Client &client, Request args, Response &response);
 
 #endif

--- a/src/command/MessageCommands.hxx
+++ b/src/command/MessageCommands.hxx
@@ -27,18 +27,18 @@ class Request;
 class Response;
 
 CommandResult
-handle_subscribe(Client &client, Request request, Response &response);
+handle_subscribe(Client &client, Request args, Response &response);
 
 CommandResult
-handle_unsubscribe(Client &client, Request request, Response &response);
+handle_unsubscribe(Client &client, Request args, Response &response);
 
 CommandResult
-handle_channels(Client &client, Request request, Response &response);
+handle_channels(Client &client, Request args, Response &response);
 
 CommandResult
-handle_read_messages(Client &client, Request request, Response &response);
+handle_read_messages(Client &client, Request args, Response &response);
 
 CommandResult
-handle_send_message(Client &client, Request request, Response &response);
+handle_send_message(Client &client, Request args, Response &response);
 
 #endif

--- a/src/command/NeighborCommands.hxx
+++ b/src/command/NeighborCommands.hxx
@@ -33,6 +33,6 @@ bool
 neighbor_commands_available(const Instance &instance) noexcept;
 
 CommandResult
-handle_listneighbors(Client &client, Request request, Response &response);
+handle_listneighbors(Client &client, gcc_unused Request args, Response &r);
 
 #endif

--- a/src/command/OtherCommands.hxx
+++ b/src/command/OtherCommands.hxx
@@ -21,45 +21,46 @@
 #define MPD_OTHER_COMMANDS_HXX
 
 #include "CommandResult.hxx"
+#include "util/Compiler.h"
 
 class Client;
 class Request;
 class Response;
 
 CommandResult
-handle_urlhandlers(Client &client, Request request, Response &response);
+handle_urlhandlers(Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_decoders(Client &client, Request request, Response &response);
+handle_decoders(Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
 handle_kill(Client &client, Request request, Response &response);
 
 CommandResult
-handle_listfiles(Client &client, Request request, Response &response);
+handle_listfiles(Client &client, Request args, Response &response);
 
 CommandResult
-handle_lsinfo(Client &client, Request request, Response &response);
+handle_lsinfo(Client &client, Request args, Response &response);
 
 CommandResult
-handle_update(Client &client, Request request, Response &response);
+handle_update(Client &client, Request args, Response &response);
 
 CommandResult
-handle_rescan(Client &client, Request request, Response &response);
+handle_rescan(Client &client, Request args, Response &response);
 
 CommandResult
-handle_setvol(Client &client, Request request, Response &response);
+handle_setvol(Client &client, Request args, Response &response);
 
 CommandResult
-handle_volume(Client &client, Request request, Response &response);
+handle_volume(Client &client, Request args, Response &response);
 
 CommandResult
-handle_stats(Client &client, Request request, Response &response);
+handle_stats(Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_config(Client &client, Request request, Response &response);
+handle_config(Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_idle(Client &client, Request request, Response &response);
+handle_idle(Client &client, Request args, Response &response);
 
 #endif

--- a/src/command/OutputCommands.hxx
+++ b/src/command/OutputCommands.hxx
@@ -27,18 +27,18 @@ class Request;
 class Response;
 
 CommandResult
-handle_enableoutput(Client &client, Request request, Response &response);
+handle_enableoutput(Client &client, Request args, Response &response);
 
 CommandResult
-handle_disableoutput(Client &client, Request request, Response &response);
+handle_disableoutput(Client &client, Request args, Response &response);
 
 CommandResult
-handle_toggleoutput(Client &client, Request request, Response &response);
+handle_toggleoutput(Client &client, Request args, Response &response);
 
 CommandResult
 handle_outputset(Client &client, Request request, Response &response);
 
 CommandResult
-handle_devices(Client &client, Request request, Response &response);
+handle_devices(Client &client, Request args, Response &response);
 
 #endif

--- a/src/command/PlayerCommands.hxx
+++ b/src/command/PlayerCommands.hxx
@@ -21,72 +21,73 @@
 #define MPD_PLAYER_COMMANDS_HXX
 
 #include "CommandResult.hxx"
+#include "util/Compiler.h"
 
 class Client;
 class Request;
 class Response;
 
 CommandResult
-handle_play(Client &client, Request request, Response &response);
+handle_play(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playid(Client &client, Request request, Response &response);
+handle_playid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_stop(Client &client, Request request, Response &response);
+handle_stop(Client &client, gcc_unused Request args, gcc_unused Response &r);
 
 CommandResult
-handle_currentsong(Client &client, Request request, Response &response);
+handle_currentsong(Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_pause(Client &client, Request request, Response &response);
+handle_pause(Client &client, Request args, Response &response);
 
 CommandResult
-handle_status(Client &client, Request request, Response &response);
+handle_status(Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_next(Client &client, Request request, Response &response);
+handle_next(Client &client, gcc_unused Request args, gcc_unused Response &r);
 
 CommandResult
-handle_previous(Client &client, Request request, Response &response);
+handle_previous(Client &client, gcc_unused Request args, gcc_unused Response &r);
 
 CommandResult
-handle_repeat(Client &client, Request request, Response &response);
+handle_repeat(Client &client, Request args, Response &response);
 
 CommandResult
-handle_single(Client &client, Request request, Response &response);
+handle_single(Client &client, Request args, Response &response);
 
 CommandResult
-handle_consume(Client &client, Request request, Response &response);
+handle_consume(Client &client, Request args, Response &response);
 
 CommandResult
-handle_random(Client &client, Request request, Response &response);
+handle_random(Client &client, Request args, Response &response);
 
 CommandResult
-handle_clearerror(Client &client, Request request, Response &response);
+handle_clearerror(Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_seek(Client &client, Request request, Response &response);
+handle_seek(Client &client, Request args, Response &response);
 
 CommandResult
-handle_seekid(Client &client, Request request, Response &response);
+handle_seekid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_seekcur(Client &client, Request request, Response &response);
+handle_seekcur(Client &client, Request args, Response &response);
 
 CommandResult
-handle_crossfade(Client &client, Request request, Response &response);
+handle_crossfade(Client &client, Request args, Response &response);
 
 CommandResult
-handle_mixrampdb(Client &client, Request request, Response &response);
+handle_mixrampdb(Client &client, Request args, Response &response);
 
 CommandResult
-handle_mixrampdelay(Client &client, Request request, Response &response);
+handle_mixrampdelay(Client &client, Request args, Response &response);
 
 CommandResult
-handle_replay_gain_mode(Client &client, Request request, Response &response);
+handle_replay_gain_mode(Client &client, Request args, Response &response);
 
 CommandResult
-handle_replay_gain_status(Client &client, Request request, Response &response);
+handle_replay_gain_status(Client &client, Request args, Response &r);
 
 #endif

--- a/src/command/PlaylistCommands.hxx
+++ b/src/command/PlaylistCommands.hxx
@@ -32,36 +32,36 @@ bool
 playlist_commands_available() noexcept;
 
 CommandResult
-handle_save(Client &client, Request request, Response &response);
+handle_save(Client &client, Request args, Response &response);
 
 CommandResult
-handle_load(Client &client, Request request, Response &response);
+handle_load(Client &client, Request args, Response &response);
 
 CommandResult
-handle_listplaylist(Client &client, Request request, Response &response);
+handle_listplaylist(Client &client, Request args, Response &response);
 
 CommandResult
-handle_listplaylistinfo(Client &client, Request request, Response &response);
+handle_listplaylistinfo(Client &client, Request args, Response &response);
 
 CommandResult
-handle_rm(Client &client, Request request, Response &response);
+handle_rm(Client &client, Request args, Response &response);
 
 CommandResult
-handle_rename(Client &client, Request request, Response &response);
+handle_rename(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playlistdelete(Client &client, Request request, Response &response);
+handle_playlistdelete(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playlistmove(Client &client, Request request, Response &response);
+handle_playlistmove(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playlistclear(Client &client, Request request, Response &response);
+handle_playlistclear(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playlistadd(Client &client, Request request, Response &response);
+handle_playlistadd(Client &client, Request args, Response &response);
 
 CommandResult
-handle_listplaylists(Client &client, Request request, Response &response);
+handle_listplaylists(gcc_unused Client &client, gcc_unused Request args, Response &r);
 
 #endif

--- a/src/command/QueueCommands.hxx
+++ b/src/command/QueueCommands.hxx
@@ -21,69 +21,70 @@
 #define MPD_QUEUE_COMMANDS_HXX
 
 #include "CommandResult.hxx"
+#include "util/Compiler.h"
 
 class Client;
 class Request;
 class Response;
 
 CommandResult
-handle_add(Client &client, Request request, Response &response);
+handle_add(Client &client, Request args, Response &response);
 
 CommandResult
-handle_addid(Client &client, Request request, Response &response);
+handle_addid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_rangeid(Client &client, Request request, Response &response);
+handle_rangeid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_delete(Client &client, Request request, Response &response);
+handle_delete(Client &client, Request args, Response &response);
 
 CommandResult
-handle_deleteid(Client &client, Request request, Response &response);
+handle_deleteid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playlist(Client &client, Request request, Response &response);
+handle_playlist(Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_shuffle(Client &client, Request request, Response &response);
+handle_shuffle(Client &client, Request args, Response &response);
 
 CommandResult
-handle_clear(Client &client, Request request, Response &response);
+handle_clear(Client &client, gcc_unused Request args, gcc_unused Response &r);
 
 CommandResult
-handle_plchanges(Client &client, Request request, Response &response);
+handle_plchanges(Client &client, Request args, Response &response);
 
 CommandResult
-handle_plchangesposid(Client &client, Request request, Response &response);
+handle_plchangesposid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playlistinfo(Client &client, Request request, Response &response);
+handle_playlistinfo(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playlistid(Client &client, Request request, Response &response);
+handle_playlistid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playlistfind(Client &client, Request request, Response &response);
+handle_playlistfind(Client &client, Request args, Response &response);
 
 CommandResult
-handle_playlistsearch(Client &client, Request request, Response &response);
+handle_playlistsearch(Client &client, Request args, Response &response);
 
 CommandResult
-handle_prio(Client &client, Request request, Response &response);
+handle_prio(Client &client, Request args, Response &response);
 
 CommandResult
-handle_prioid(Client &client, Request request, Response &response);
+handle_prioid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_move(Client &client, Request request, Response &response);
+handle_move(Client &client, Request args, Response &response);
 
 CommandResult
-handle_moveid(Client &client, Request request, Response &response);
+handle_moveid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_swap(Client &client, Request request, Response &response);
+handle_swap(Client &client, Request args, Response &response);
 
 CommandResult
-handle_swapid(Client &client, Request request, Response &response);
+handle_swapid(Client &client, Request args, Response &response);
 
 #endif

--- a/src/command/StickerCommands.hxx
+++ b/src/command/StickerCommands.hxx
@@ -27,6 +27,6 @@ class Request;
 class Response;
 
 CommandResult
-handle_sticker(Client &client, Request request, Response &response);
+handle_sticker(Client &client, Request args, Response &response);
 
 #endif

--- a/src/command/StorageCommands.hxx
+++ b/src/command/StorageCommands.hxx
@@ -21,6 +21,7 @@
 #define MPD_STORAGE_COMMANDS_HXX
 
 #include "CommandResult.hxx"
+#include "util/Compiler.h"
 
 class Client;
 class Storage;
@@ -34,12 +35,12 @@ CommandResult
 handle_listfiles_storage(Client &client, Response &r, const char *uri);
 
 CommandResult
-handle_listmounts(Client &client, Request request, Response &response);
+handle_listmounts(Client &client, gcc_unused Request args, Response &r);
 
 CommandResult
-handle_mount(Client &client, Request request, Response &response);
+handle_mount(Client &client, Request args, Response &response);
 
 CommandResult
-handle_unmount(Client &client, Request request, Response &response);
+handle_unmount(Client &client, Request args, Response &response);
 
 #endif

--- a/src/command/TagCommands.hxx
+++ b/src/command/TagCommands.hxx
@@ -27,9 +27,9 @@ class Request;
 class Response;
 
 CommandResult
-handle_addtagid(Client &client, Request request, Response &response);
+handle_addtagid(Client &client, Request args, Response &response);
 
 CommandResult
-handle_cleartagid(Client &client, Request request, Response &response);
+handle_cleartagid(Client &client, Request args, Response &response);
 
 #endif

--- a/src/db/plugins/simple/Directory.hxx
+++ b/src/db/plugins/simple/Directory.hxx
@@ -283,7 +283,7 @@ public:
 	/**
 	 * Caller must lock #db_mutex.
 	 */
-	void Walk(bool recursive, const SongFilter *match,
+	void Walk(bool recursive, const SongFilter *filter,
 		  const VisitDirectory& visit_directory, const VisitSong& visit_song,
 		  const VisitPlaylist& visit_playlist) const;
 

--- a/src/db/plugins/simple/Song.hxx
+++ b/src/db/plugins/simple/Song.hxx
@@ -118,7 +118,7 @@ struct Song {
 	 * @return the song on success, nullptr if the file was not
 	 * recognized
 	 */
-	static SongPtr LoadFile(Storage &storage, const char *name_utf8,
+	static SongPtr LoadFile(Storage &storage, const char *path_utf8,
 				Directory &parent);
 
 	/**

--- a/src/db/plugins/upnp/Directory.hxx
+++ b/src/db/plugins/upnp/Directory.hxx
@@ -61,7 +61,7 @@ public:
 	 * actually global, nothing really bad will happen if you mix
 	 * up...
 	 */
-	void Parse(const char *didltext);
+	void Parse(const char *input);
 };
 
 #endif /* _UPNPDIRCONTENT_H_X_INCLUDED_ */

--- a/src/db/update/Editor.hxx
+++ b/src/db/update/Editor.hxx
@@ -35,7 +35,7 @@ public:
 	/**
 	 * Caller must lock the #db_mutex.
 	 */
-	void DeleteSong(Directory &parent, Song *song);
+	void DeleteSong(Directory &dir, Song *del);
 
 	/**
 	 * DeleteSong() with automatic locking.

--- a/src/db/update/Walk.hxx
+++ b/src/db/update/Walk.hxx
@@ -98,14 +98,14 @@ private:
 
 
 #ifdef ENABLE_ARCHIVE
-	void UpdateArchiveTree(ArchiveFile &archive, Directory &parent,
+	void UpdateArchiveTree(ArchiveFile &archive, Directory &directory,
 			       const char *name) noexcept;
 
 	bool UpdateArchiveFile(Directory &directory,
 			       const char *name, const char *suffix,
 			       const StorageFileInfo &info) noexcept;
 
-	void UpdateArchiveFile(Directory &directory, const char *name,
+	void UpdateArchiveFile(Directory &parent, const char *name,
 			       const StorageFileInfo &info,
 			       const ArchivePlugin &plugin) noexcept;
 

--- a/src/decoder/DecoderAPI.hxx
+++ b/src/decoder/DecoderAPI.hxx
@@ -62,7 +62,7 @@ class StopDecoder {};
  * occurs: end of file; error; command (like SEEK or STOP).
  */
 size_t
-decoder_read(DecoderClient *decoder, InputStream &is,
+decoder_read(DecoderClient *client, InputStream &is,
 	     void *buffer, size_t length);
 
 static inline size_t
@@ -80,7 +80,7 @@ decoder_read(DecoderClient &decoder, InputStream &is,
  * data
  */
 bool
-decoder_read_full(DecoderClient *decoder, InputStream &is,
+decoder_read_full(DecoderClient *client, InputStream &is,
 		  void *buffer, size_t size);
 
 /**
@@ -89,6 +89,6 @@ decoder_read_full(DecoderClient *decoder, InputStream &is,
  * @return true on success, false on error or command
  */
 bool
-decoder_skip(DecoderClient *decoder, InputStream &is, size_t size);
+decoder_skip(DecoderClient *client, InputStream &is, size_t size);
 
 #endif

--- a/src/decoder/plugins/FfmpegIo.hxx
+++ b/src/decoder/plugins/FfmpegIo.hxx
@@ -43,7 +43,7 @@ struct AvioStream {
 	bool Open();
 
 private:
-	int Read(void *buffer, int size);
+	int Read(void *dest, int size);
 	int64_t Seek(int64_t pos, int whence);
 
 	static int _Read(void *opaque, uint8_t *buf, int size);

--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -182,7 +182,7 @@ private:
 	 * Sends the synthesized current frame via
 	 * DecoderClient::SubmitData().
 	 */
-	DecoderCommand SubmitPCM(size_t start, size_t n) noexcept;
+	DecoderCommand SubmitPCM(size_t i, size_t pcm_length) noexcept;
 
 	/**
 	 * Synthesize the current frame and send it via

--- a/src/encoder/plugins/WaveEncoderPlugin.cxx
+++ b/src/encoder/plugins/WaveEncoderPlugin.cxx
@@ -36,7 +36,7 @@ public:
 	explicit WaveEncoder(AudioFormat &audio_format) noexcept;
 
 	/* virtual methods from class Encoder */
-	void Write(const void *data, size_t length) override;
+	void Write(const void *src, size_t length) override;
 
 	size_t Read(void *dest, size_t length) noexcept override {
 		return buffer.Read((uint8_t *)dest, length);

--- a/src/filter/plugins/AutoConvertFilterPlugin.cxx
+++ b/src/filter/plugins/AutoConvertFilterPlugin.cxx
@@ -67,7 +67,7 @@ public:
 	explicit PreparedAutoConvertFilter(std::unique_ptr<PreparedFilter> _filter) noexcept
 		:filter(std::move(_filter)) {}
 
-	std::unique_ptr<Filter> Open(AudioFormat &af) override;
+	std::unique_ptr<Filter> Open(AudioFormat &in_audio_format) override;
 };
 
 std::unique_ptr<Filter>

--- a/src/filter/plugins/ChainFilterPlugin.cxx
+++ b/src/filter/plugins/ChainFilterPlugin.cxx
@@ -98,7 +98,7 @@ public:
 	}
 
 	/* virtual methods from class PreparedFilter */
-	std::unique_ptr<Filter> Open(AudioFormat &af) override;
+	std::unique_ptr<Filter> Open(AudioFormat &in_audio_format) override;
 };
 
 std::unique_ptr<Filter>

--- a/src/filter/plugins/ConvertFilterPlugin.cxx
+++ b/src/filter/plugins/ConvertFilterPlugin.cxx
@@ -62,7 +62,7 @@ public:
 
 class PreparedConvertFilter final : public PreparedFilter {
 public:
-	std::unique_ptr<Filter> Open(AudioFormat &af) override;
+	std::unique_ptr<Filter> Open(AudioFormat &audio_format) override;
 };
 
 void

--- a/src/filter/plugins/FfmpegFilterPlugin.cxx
+++ b/src/filter/plugins/FfmpegFilterPlugin.cxx
@@ -33,7 +33,7 @@ public:
 		:graph_string(_graph) {}
 
 	/* virtual methods from class PreparedFilter */
-	std::unique_ptr<Filter> Open(AudioFormat &af) override;
+	std::unique_ptr<Filter> Open(AudioFormat &in_audio_format) override;
 };
 
 std::unique_ptr<Filter>

--- a/src/filter/plugins/HdcdFilterPlugin.cxx
+++ b/src/filter/plugins/HdcdFilterPlugin.cxx
@@ -76,7 +76,7 @@ OpenHdcdFilter(AudioFormat &in_audio_format)
 class PreparedHdcdFilter final : public PreparedFilter {
 public:
 	/* virtual methods from class PreparedFilter */
-	std::unique_ptr<Filter> Open(AudioFormat &af) override;
+	std::unique_ptr<Filter> Open(AudioFormat &audio_format) override;
 };
 
 std::unique_ptr<Filter>

--- a/src/filter/plugins/NormalizeFilterPlugin.cxx
+++ b/src/filter/plugins/NormalizeFilterPlugin.cxx
@@ -49,7 +49,7 @@ public:
 class PreparedNormalizeFilter final : public PreparedFilter {
 public:
 	/* virtual methods from class PreparedFilter */
-	std::unique_ptr<Filter> Open(AudioFormat &af) override;
+	std::unique_ptr<Filter> Open(AudioFormat &audio_format) override;
 };
 
 static std::unique_ptr<PreparedFilter>

--- a/src/filter/plugins/RouteFilterPlugin.cxx
+++ b/src/filter/plugins/RouteFilterPlugin.cxx
@@ -133,7 +133,7 @@ public:
 	explicit PreparedRouteFilter(const ConfigBlock &block);
 
 	/* virtual methods from class PreparedFilter */
-	std::unique_ptr<Filter> Open(AudioFormat &af) override;
+	std::unique_ptr<Filter> Open(AudioFormat &audio_format) override;
 };
 
 PreparedRouteFilter::PreparedRouteFilter(const ConfigBlock &block)

--- a/src/filter/plugins/VolumeFilterPlugin.cxx
+++ b/src/filter/plugins/VolumeFilterPlugin.cxx
@@ -49,7 +49,7 @@ public:
 class PreparedVolumeFilter final : public PreparedFilter {
 public:
 	/* virtual methods from class Filter */
-	std::unique_ptr<Filter> Open(AudioFormat &af) override;
+	std::unique_ptr<Filter> Open(AudioFormat &audio_format) override;
 };
 
 std::unique_ptr<Filter>

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -90,7 +90,7 @@ class CdioParanoiaInputStream final : public InputStream {
 	/* virtual methods from InputStream */
 	bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,
-		    void *ptr, size_t size) override;
+		    void *ptr, size_t length) override;
 	void Seek(std::unique_lock<Mutex> &lock, offset_type offset) override;
 };
 

--- a/src/lib/dbus/Watch.hxx
+++ b/src/lib/dbus/Watch.hxx
@@ -69,7 +69,7 @@ class WatchManager {
 		void Toggled() noexcept;
 
 	private:
-		bool OnSocketReady(unsigned flags) noexcept override;
+		bool OnSocketReady(unsigned events) noexcept override;
 	};
 
 	std::map<DBusWatch *, Watch> watches;

--- a/src/lib/nfs/Connection.hxx
+++ b/src/lib/nfs/Connection.hxx
@@ -66,12 +66,12 @@ class NfsConnection : SocketMonitor {
 			 connection(_connection),
 			 open(_open), close_fh(nullptr) {}
 
-		void Stat(nfs_context *context, const char *path);
-		void Lstat(nfs_context *context, const char *path);
-		void OpenDirectory(nfs_context *context, const char *path);
-		void Open(nfs_context *context, const char *path, int flags);
-		void Stat(nfs_context *context, struct nfsfh *fh);
-		void Read(nfs_context *context, struct nfsfh *fh,
+		void Stat(nfs_context *ctx, const char *path);
+		void Lstat(nfs_context *ctx, const char *path);
+		void OpenDirectory(nfs_context *ctx, const char *path);
+		void Open(nfs_context *ctx, const char *path, int flags);
+		void Stat(nfs_context *ctx, struct nfsfh *fh);
+		void Read(nfs_context *ctx, struct nfsfh *fh,
 			  uint64_t offset, size_t size);
 
 		/**

--- a/src/lib/upnp/ContentDirectoryService.hxx
+++ b/src/lib/upnp/ContentDirectoryService.hxx
@@ -79,7 +79,7 @@ public:
 	UPnPDirContent readDir(UpnpClient_Handle handle,
 			       const char *objectId) const;
 
-	void readDirSlice(UpnpClient_Handle handle,
+	void readDirSlice(UpnpClient_Handle hdl,
 			  const char *objectId, unsigned offset,
 			  unsigned count, UPnPDirContent& dirbuf,
 			  unsigned &didread, unsigned &total) const;
@@ -93,15 +93,15 @@ public:
 	 * UPnP document: UPnP-av-ContentDirectory-v1-Service-20020625.pdf
 	 * section 2.5.5. Maybe we'll provide an easier way some day...
 	 */
-	UPnPDirContent search(UpnpClient_Handle handle,
+	UPnPDirContent search(UpnpClient_Handle hdl,
 			      const char *objectId,
-			      const char *searchstring) const;
+			      const char *ss) const;
 
 	/** Read metadata for a given node.
 	 *
 	 * @param objectId the UPnP object Id. Root has Id "0"
 	 */
-	UPnPDirContent getMetadata(UpnpClient_Handle handle,
+	UPnPDirContent getMetadata(UpnpClient_Handle hdl,
 				   const char *objectId) const;
 
 	/** Retrieve search capabilities
@@ -111,7 +111,7 @@ public:
 	 * @param[out] result an empty vector: no search, or a single '*' element:
 	 *     any tag can be used in a search, or a list of usable tag names.
 	 */
-	std::forward_list<std::string> getSearchCapabilities(UpnpClient_Handle handle) const;
+	std::forward_list<std::string> getSearchCapabilities(UpnpClient_Handle hdl) const;
 
 	gcc_pure
 	std::string GetURI() const noexcept {

--- a/src/pcm/CheckAudioFormat.hxx
+++ b/src/pcm/CheckAudioFormat.hxx
@@ -29,7 +29,7 @@ void
 CheckSampleFormat(SampleFormat sample_format);
 
 void
-CheckChannelCount(unsigned sample_format);
+CheckChannelCount(unsigned channels);
 
 /**
  * Check #AudioFormat attributes and construct an #AudioFormat

--- a/src/pcm/Convert.hxx
+++ b/src/pcm/Convert.hxx
@@ -77,7 +77,7 @@ public:
 	 * @param src the source PCM buffer
 	 * @return the destination buffer
 	 */
-	ConstBuffer<void> Convert(ConstBuffer<void> src);
+	ConstBuffer<void> Convert(ConstBuffer<void> buffer);
 
 	/**
 	 * Flush pending data and return it.  This should be called

--- a/src/pcm/Export.hxx
+++ b/src/pcm/Export.hxx
@@ -228,7 +228,7 @@ public:
 	 * @return the destination buffer; may be empty (and may be a
 	 * pointer to the source buffer)
 	 */
-	ConstBuffer<void> Export(ConstBuffer<void> src) noexcept;
+	ConstBuffer<void> Export(ConstBuffer<void> data) noexcept;
 
 	/**
 	 * Converts the number of consumed bytes from the Export()

--- a/src/playlist/plugins/EmbeddedCuePlaylistPlugin.cxx
+++ b/src/playlist/plugins/EmbeddedCuePlaylistPlugin.cxx
@@ -70,7 +70,7 @@ public:
 
 	ExtractCuesheetTagHandler() noexcept:NullTagHandler(WANT_PAIR) {}
 
-	void OnPair(StringView key, StringView value) noexcept override;
+	void OnPair(StringView name, StringView value) noexcept override;
 };
 
 void

--- a/src/playlist/plugins/SoundCloudPlaylistPlugin.cxx
+++ b/src/playlist/plugins/SoundCloudPlaylistPlugin.cxx
@@ -111,7 +111,7 @@ struct SoundCloudJsonData {
 
 	std::forward_list<DetachedSong> songs;
 
-	bool Integer(long long value) noexcept;
+	bool Integer(long long intval) noexcept;
 	bool String(StringView value) noexcept;
 	bool StartMap() noexcept;
 	bool MapKey(StringView value) noexcept;

--- a/src/queue/Playlist.hxx
+++ b/src/queue/Playlist.hxx
@@ -226,7 +226,7 @@ protected:
 			    unsigned song, const DetachedSong **queued_p) noexcept;
 
 public:
-	void DeletePosition(PlayerControl &pc, unsigned position);
+	void DeletePosition(PlayerControl &pc, unsigned song);
 
 	void DeleteOrder(PlayerControl &pc, unsigned order) {
 		DeletePosition(pc, queue.OrderToPosition(order));
@@ -293,7 +293,7 @@ public:
 	/**
 	 * Throws on error.
 	 */
-	void PlayPosition(PlayerControl &pc, int position);
+	void PlayPosition(PlayerControl &pc, int song);
 
 	/**
 	 * Throws on error.
@@ -319,14 +319,14 @@ public:
 	 * Throws on error.
 	 */
 	void SeekSongOrder(PlayerControl &pc,
-			   unsigned song_order,
+			   unsigned i,
 			   SongTime seek_time);
 
 	/**
 	 * Throws on error.
 	 */
 	void SeekSongPosition(PlayerControl &pc,
-			      unsigned sonag_position,
+			      unsigned song,
 			      SongTime seek_time);
 
 	/**
@@ -352,25 +352,25 @@ public:
 		return queue.repeat;
 	}
 
-	void SetRepeat(PlayerControl &pc, bool new_value) noexcept;
+	void SetRepeat(PlayerControl &pc, bool status) noexcept;
 
 	bool GetRandom() const noexcept {
 		return queue.random;
 	}
 
-	void SetRandom(PlayerControl &pc, bool new_value) noexcept;
+	void SetRandom(PlayerControl &pc, bool status) noexcept;
 
 	SingleMode GetSingle() const noexcept {
 		return queue.single;
 	}
 
-	void SetSingle(PlayerControl &pc, SingleMode new_value) noexcept;
+	void SetSingle(PlayerControl &pc, SingleMode status) noexcept;
 
 	bool GetConsume() const noexcept {
 		return queue.consume;
 	}
 
-	void SetConsume(bool new_value) noexcept;
+	void SetConsume(bool status) noexcept;
 
 private:
 	/**

--- a/src/system/Open.hxx
+++ b/src/system/Open.hxx
@@ -42,7 +42,7 @@ OpenWriteOnly(const char *path, int flags=0);
 #ifndef _WIN32
 
 UniqueFileDescriptor
-OpenDirectory(const char *name, int flags=0);
+OpenDirectory(const char *path, int flags=0);
 
 #endif
 

--- a/src/tag/Handler.hxx
+++ b/src/tag/Handler.hxx
@@ -173,7 +173,7 @@ public:
 				AudioFormat *_audio_format=nullptr) noexcept
 		:FullTagHandler(0, _builder, _audio_format) {}
 
-	void OnPair(StringView key, StringView value) noexcept override;
+	void OnPair(StringView name, StringView value) noexcept override;
 	void OnAudioFormat(AudioFormat af) noexcept override;
 };
 

--- a/src/zeroconf/ZeroconfAvahi.hxx
+++ b/src/zeroconf/ZeroconfAvahi.hxx
@@ -23,7 +23,7 @@
 class EventLoop;
 
 void
-AvahiInit(EventLoop &loop, const char *service_name);
+AvahiInit(EventLoop &loop, const char *serviceName);
 
 void
 AvahiDeinit();


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name

Signed-off-by: Rosen Penev <rosenp@gmail.com>