### PR TITLE
[clang-tidy] remove misplaced const

### DIFF
--- a/src/decoder/plugins/AudiofileDecoderPlugin.cxx
+++ b/src/decoder/plugins/AudiofileDecoderPlugin.cxx
@@ -200,7 +200,7 @@ audiofile_stream_decode(DecoderClient &client, InputStream &is)
 	AudioFileInputStream afis{&client, is};
 	AFvirtualfile *const vf = setup_virtual_fops(afis);
 
-	const AFfilehandle fh = afOpenVirtualFile(vf, "r", nullptr);
+	auto fh = afOpenVirtualFile(vf, "r", nullptr);
 	if (fh == AF_NULL_FILEHANDLE)
 		return;
 

--- a/src/decoder/plugins/FaadDecoderPlugin.cxx
+++ b/src/decoder/plugins/FaadDecoderPlugin.cxx
@@ -231,7 +231,7 @@ faad_song_duration(DecoderBuffer &buffer, InputStream &is)
 static NeAACDecHandle
 faad_decoder_new()
 {
-	const NeAACDecHandle decoder = NeAACDecOpen();
+	auto decoder = NeAACDecOpen();
 
 	NeAACDecConfigurationPtr config =
 		NeAACDecGetCurrentConfiguration(decoder);
@@ -324,7 +324,7 @@ faad_get_file_time(InputStream &is)
 
 static void
 faad_stream_decode(DecoderClient &client, InputStream &is,
-		   DecoderBuffer &buffer, const NeAACDecHandle decoder)
+		   DecoderBuffer &buffer, NeAACDecHandle decoder)
 {
 	const auto total_time = faad_song_duration(buffer, is);
 
@@ -406,7 +406,7 @@ faad_stream_decode(DecoderClient &client, InputStream &is)
 
 	/* create the libfaad decoder */
 
-	const NeAACDecHandle decoder = faad_decoder_new();
+	auto decoder = faad_decoder_new();
 	AtScopeExit(decoder) { NeAACDecClose(decoder); };
 
 	faad_stream_decode(client, is, buffer, decoder);


### PR DESCRIPTION
The rhs evaluates to void *const, not const void*.

Found with misc-misplaced-const

Signed-off-by: Rosen Penev <rosenp@gmail.com>