### PR TITLE
[clang-tidy] add parentheses to macros

### DIFF
--- a/src/archive/plugins/Iso9660ArchivePlugin.cxx
+++ b/src/archive/plugins/Iso9660ArchivePlugin.cxx
@@ -36,7 +36,7 @@
 
 #include <utility>
 
-#define CEILING(x, y) ((x+(y-1))/y)
+#define CEILING(x, y) (((x)+((y)-1))/(y))
 
 struct Iso9660 {
 	iso9660_t *const iso;

--- a/src/util/bit_reverse.c
+++ b/src/util/bit_reverse.c
@@ -24,8 +24,8 @@
  */
 const uint8_t bit_reverse_table[256] =
 {
-#define R2(n)     n,     n + 2*64,     n + 1*64,     n + 3*64
-#define R4(n) R2(n), R2(n + 2*16), R2(n + 1*16), R2(n + 3*16)
-#define R6(n) R4(n), R4(n + 2*4 ), R4(n + 1*4 ), R4(n + 3*4 )
+#define R2(n)    n,     (n) + 2*64,     (n) + 1*64,     (n) + 3*64
+#define R4(n) R2(n), R2((n) + 2*16), R2((n) + 1*16), R2((n) + 3*16)
+#define R6(n) R4(n), R4((n) + 2*4 ), R4((n) + 1*4 ), R4((n) + 3*4 )
     R6(0), R6(2), R6(1), R6(3)
 };


### PR DESCRIPTION
Found with bugprone-macro-parentheses

Signed-off-by: Rosen Penev <rosenp@gmail.com>