### PR TITLE
[clang-tidy] use forward instead of move

### DIFF
--- a/src/config/Data.cxx
+++ b/src/config/Data.cxx
@@ -50,7 +50,7 @@ template<typename T>
 static auto
 Append(std::forward_list<T> &list, T &&src)
 {
-	return list.emplace_after(FindLast(list), std::move(src));
+	return list.emplace_after(FindLast(list), std::forward<T>(src));
 }
 
 void

--- a/src/lib/dbus/UDisks2.cxx
+++ b/src/lib/dbus/UDisks2.cxx
@@ -167,7 +167,7 @@ ParseObjects(ODBus::ReadMessageIter &&i,
 
 	ForEachInterface(std::move(i), [&callback](const char *path, auto &&j){
 			Object o(path);
-			ParseObject(o, std::move(j));
+			ParseObject(o, std::forward<decltype(j)>(j));
 			if (o.IsValid())
 				callback(std::move(o));
 		});

--- a/src/neighbor/plugins/UdisksNeighborPlugin.cxx
+++ b/src/neighbor/plugins/UdisksNeighborPlugin.cxx
@@ -231,7 +231,7 @@ UdisksNeighborExplorer::HandleMessage(DBusConnection *, DBusMessage *message) no
 	    dbus_message_has_signature(message, InterfacesAddedType::value)) {
 		RecurseInterfaceDictEntry(ReadMessageIter(*message), [this](const char *path, auto &&i){
 				UDisks2::Object o(path);
-				UDisks2::ParseObject(o, std::move(i));
+				UDisks2::ParseObject(o, std::forward<decltype(i)>(i));
 				if (o.IsValid())
 					this->Insert(std::move(o));
 			});


### PR DESCRIPTION
Found with bugprone-move-forwarding-reference

Signed-off-by: Rosen Penev <rosenp@gmail.com>