### PR TITLE
[clang-tidy] add ending namespace comments

### DIFF
--- a/src/CommandLine.cxx
+++ b/src/CommandLine.cxx
@@ -78,7 +78,7 @@ constexpr auto USER_CONFIG_FILE_LOCATION1 = Path::FromFS(PATH_LITERAL(".mpdconf"
 constexpr auto USER_CONFIG_FILE_LOCATION2 = Path::FromFS(PATH_LITERAL(".mpd/mpd.conf"));
 constexpr auto USER_CONFIG_FILE_LOCATION_XDG = Path::FromFS(PATH_LITERAL("mpd/mpd.conf"));
 #endif
-}
+} // namespace
 
 enum Option {
 	OPTION_KILL,

--- a/src/command/StickerCommands.cxx
+++ b/src/command/StickerCommands.cxx
@@ -36,7 +36,7 @@ struct sticker_song_find_data {
 	Response &r;
 	const char *name;
 };
-}
+} // namespace
 
 static void
 sticker_song_find_print_cb(const LightSong &song, const char *value,

--- a/src/encoder/plugins/OpusEncoderPlugin.cxx
+++ b/src/encoder/plugins/OpusEncoderPlugin.cxx
@@ -387,7 +387,7 @@ OpusEncoder::SendTag(const Tag &tag)
 	GenerateHeaders(&tag);
 }
 
-}
+} // namespace
 
 const EncoderPlugin opus_encoder_plugin = {
 	"opus",

--- a/src/input/plugins/QobuzClient.cxx
+++ b/src/input/plugins/QobuzClient.cxx
@@ -44,7 +44,7 @@ public:
 	}
 };
 
-}
+} // namespace
 
 QobuzClient::QobuzClient(EventLoop &event_loop,
 			 const char *_base_url,

--- a/src/lib/dbus/Glue.cxx
+++ b/src/lib/dbus/Glue.cxx
@@ -56,4 +56,4 @@ Glue::OnDBusClosed() noexcept
 	// TODO: reconnect
 }
 
-}
+} // namespace ODBus

--- a/src/lib/upnp/ixmlwrap.cxx
+++ b/src/lib/upnp/ixmlwrap.cxx
@@ -38,4 +38,4 @@ getFirstElementValue(IXML_Document *doc, const char *name) noexcept
 	return ixmlNode_getNodeValue(dnode);
 }
 
-}
+} // namespace ixmlwrap

--- a/src/sticker/SongSticker.cxx
+++ b/src/sticker/SongSticker.cxx
@@ -82,7 +82,7 @@ struct sticker_song_find_data {
 		     void *user_data);
 	void *user_data;
 };
-}
+} // namespace
 
 static void
 sticker_song_find_cb(const char *uri, const char *value, void *user_data)


### PR DESCRIPTION
Found with llvm-namespace-comment

Signed-off-by: Rosen Penev <rosenp@gmail.com>