### PR TITLE
[clang-tidy] use = default

### DIFF
--- a/src/db/plugins/upnp/Directory.cxx
+++ b/src/db/plugins/upnp/Directory.cxx
@@ -30,10 +30,8 @@
 
 #include <string.h>
 
-UPnPDirContent::~UPnPDirContent()
-{
-	/* this destructor exists here just so it won't get inlined */
-}
+/* this destructor exists here just so it won't get inlined */
+UPnPDirContent::~UPnPDirContent() = default;
 
 gcc_pure
 static UPnPDirObject::ItemClass

--- a/src/db/plugins/upnp/Object.cxx
+++ b/src/db/plugins/upnp/Object.cxx
@@ -19,7 +19,5 @@
 
 #include "Object.hxx"
 
-UPnPDirObject::~UPnPDirObject() noexcept
-{
-	/* this destructor exists here just so it won't get inlined */
-}
+/* this destructor exists here just so it won't get inlined */
+UPnPDirObject::~UPnPDirObject() noexcept = default;

--- a/src/lib/upnp/ContentDirectoryService.cxx
+++ b/src/lib/upnp/ContentDirectoryService.cxx
@@ -44,10 +44,8 @@ ContentDirectoryService::ContentDirectoryService(const UPnPDevice &device,
 	}
 }
 
-ContentDirectoryService::~ContentDirectoryService() noexcept
-{
-	/* this destructor exists here just so it won't get inlined */
-}
+/* this destructor exists here just so it won't get inlined */
+ContentDirectoryService::~ContentDirectoryService() noexcept = default;
 
 std::forward_list<std::string>
 ContentDirectoryService::getSearchCapabilities(UpnpClient_Handle hdl) const

--- a/src/lib/upnp/Device.cxx
+++ b/src/lib/upnp/Device.cxx
@@ -23,10 +23,8 @@
 
 #include <string.h>
 
-UPnPDevice::~UPnPDevice() noexcept
-{
-	/* this destructor exists here just so it won't get inlined */
-}
+/* this destructor exists here just so it won't get inlined */
+UPnPDevice::~UPnPDevice() noexcept = default;
 
 /**
  * An XML parser which constructs an UPnP device object from the

--- a/src/song/Filter.cxx
+++ b/src/song/Filter.cxx
@@ -90,10 +90,8 @@ SongFilter::SongFilter(TagType tag, const char *value, bool fold_case)
 							   StringFilter(value, fold_case, fold_case, false)));
 }
 
-SongFilter::~SongFilter()
-{
-	/* this destructor exists here just so it won't get inlined */
-}
+/* this destructor exists here just so it won't get inlined */
+SongFilter::~SongFilter() = default;
 
 std::string
 SongFilter::ToExpression() const noexcept


### PR DESCRIPTION
Found with modernize-use-equals-default

Signed-off-by: Rosen Penev <rosenp@gmail.com>