### PR TITLE
[clang-tidy] use dynamic_cast for derived classes

### DIFF
--- a/src/Main.cxx
+++ b/src/Main.cxx
@@ -222,7 +222,7 @@ glue_db_init_and_load(Instance &instance, const ConfigData &config)
 
 	instance.update = new UpdateService(config,
 					    instance.event_loop, *sdb,
-					    static_cast<CompositeStorage &>(*instance.storage),
+					    dynamic_cast<CompositeStorage &>(*instance.storage),
 					    instance);
 
 	/* run database update after daemonization? */


### PR DESCRIPTION
Found with cppcoreguidelines-pro-type-static-cast-downcast

Signed-off-by: Rosen Penev <rosenp@gmail.com>