### PR TITLE
[clang-tidy] use emplace_back

### DIFF
--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -770,7 +770,7 @@ ReceiveEntities(struct mpd_connection *connection) noexcept
 	std::list<ProxyEntity> entities;
 	struct mpd_entity *entity;
 	while ((entity = mpd_recv_entity(connection)) != nullptr)
-		entities.push_back(ProxyEntity(entity));
+		entities.emplace_back(entity);
 
 	mpd_response_finish(connection);
 	return entities;


### PR DESCRIPTION
Found with hicpp-use-emplace

Signed-off-by: Rosen Penev <rosenp@gmail.com>