### PR TITLE
[clang-tidy] use using instead of typedef

### DIFF
--- a/src/db/Helpers.cxx
+++ b/src/db/Helpers.cxx
@@ -34,7 +34,7 @@ struct StringLess {
 	}
 };
 
-typedef std::set<const char *, StringLess> StringSet;
+using StringSet = std::set<const char *, StringLess>;
 
 static void
 StatsVisitTag(DatabaseStats &stats, StringSet &artists, StringSet &albums,


### PR DESCRIPTION
Found with modernize-use-using

Signed-off-by: Rosen Penev <rosenp@gmail.com>