### PR TITLE
[clang-tidy] do not use else after return

### DIFF
--- a/src/LocateUri.cxx
+++ b/src/LocateUri.cxx
@@ -108,18 +108,18 @@ LocateUri(UriPluginKind kind,
 				     , storage
 #endif
 				     );
-	} else if (PathTraitsUTF8::IsAbsolute(uri))
+	}
+	if (PathTraitsUTF8::IsAbsolute(uri))
 		return LocateFileUri(uri, client
 #ifdef ENABLE_DATABASE
 				     , storage
 #endif
 				     );
-	else if (uri_has_scheme(uri))
+	if (uri_has_scheme(uri))
 		return LocateAbsoluteUri(kind, uri
 #ifdef ENABLE_DATABASE
 					 , storage
 #endif
 					 );
-	else
-		return LocatedUri(LocatedUri::Type::RELATIVE, uri);
+	return LocatedUri(LocatedUri::Type::RELATIVE, uri);
 }

--- a/src/LogInit.cxx
+++ b/src/LogInit.cxx
@@ -99,10 +99,10 @@ parse_log_level(const char *value)
 		return LogLevel::DEFAULT;
 	if (0 == strcmp(value, "secure"))
 		return LOG_LEVEL_SECURE;
-	else if (0 == strcmp(value, "verbose"))
+	if (0 == strcmp(value, "verbose"))
 		return LogLevel::DEBUG;
-	else
-		throw FormatRuntimeError("unknown log level \"%s\"", value);
+
+	throw FormatRuntimeError("unknown log level \"%s\"", value);
 }
 
 #endif

--- a/src/PlaylistFile.cxx
+++ b/src/PlaylistFile.cxx
@@ -288,8 +288,7 @@ spl_clear(const char *utf8path)
 		if (IsFileNotFound(e))
 			throw PlaylistError(PlaylistResult::NO_SUCH_LIST,
 					    "No such playlist");
-		else
-			throw;
+		throw;
 	}
 
 	idle_add(IDLE_STORED_PLAYLIST);
@@ -307,8 +306,7 @@ spl_delete(const char *name_utf8)
 		if (IsFileNotFound(e))
 			throw PlaylistError(PlaylistResult::NO_SUCH_LIST,
 					    "No such playlist");
-		else
-			throw;
+		throw;
 	}
 
 	idle_add(IDLE_STORED_PLAYLIST);
@@ -374,8 +372,7 @@ spl_rename_internal(Path from_path_fs, Path to_path_fs)
 		if (IsFileNotFound(e))
 			throw PlaylistError(PlaylistResult::NO_SUCH_LIST,
 					    "No such playlist");
-		else
-			throw;
+		throw;
 	}
 
 	idle_add(IDLE_STORED_PLAYLIST);

--- a/src/ReplayGainMode.cxx
+++ b/src/ReplayGainMode.cxx
@@ -52,12 +52,12 @@ FromString(const char *s)
 
 	if (strcmp(s, "off") == 0)
 		return ReplayGainMode::OFF;
-	else if (strcmp(s, "track") == 0)
+	if (strcmp(s, "track") == 0)
 		return ReplayGainMode::TRACK;
-	else if (strcmp(s, "album") == 0)
+	if (strcmp(s, "album") == 0)
 		return ReplayGainMode::ALBUM;
-	else if (strcmp(s, "auto") == 0)
+	if (strcmp(s, "auto") == 0)
 		return ReplayGainMode::AUTO;
-	else
-		throw std::invalid_argument("Unrecognized replay gain mode");
+
+	throw std::invalid_argument("Unrecognized replay gain mode");
 }

--- a/src/SingleMode.cxx
+++ b/src/SingleMode.cxx
@@ -49,10 +49,10 @@ SingleFromString(const char *s)
 
 	if (strcmp(s, "0") == 0)
 		return SingleMode::OFF;
-	else if (strcmp(s, "1") == 0)
+	if (strcmp(s, "1") == 0)
 		return SingleMode::ON;
-	else if (strcmp(s, "oneshot") == 0)
+	if (strcmp(s, "oneshot") == 0)
 		return SingleMode::ONE_SHOT;
-	else
-		throw std::invalid_argument("Unrecognized single mode, expected 0, 1, or oneshot");
+
+	throw std::invalid_argument("Unrecognized single mode, expected 0, 1, or oneshot");
 }

--- a/src/SongUpdate.cxx
+++ b/src/SongUpdate.cxx
@@ -154,7 +154,9 @@ DetachedSong::Update()
 			AllocatedPath::FromUTF8Throw(GetRealURI());
 
 		return LoadFile(path_fs);
-	} else if (IsRemote()) {
+	}
+
+	if (IsRemote()) {
 		TagBuilder tag_builder;
 		if (!tag_stream_scan(uri.c_str(), tag_builder))
 			return false;
@@ -162,7 +164,8 @@ DetachedSong::Update()
 		mtime = std::chrono::system_clock::time_point::min();
 		tag_builder.Commit(tag);
 		return true;
-	} else
-		// TODO: implement
-		return false;
+	}
+
+	// TODO: implement
+	return false;
 }

--- a/src/client/Idle.cxx
+++ b/src/client/Idle.cxx
@@ -73,9 +73,9 @@ Client::IdleWait(unsigned flags) noexcept
 	if (idle_flags & idle_subscriptions) {
 		IdleNotify();
 		return true;
-	} else {
-		/* disable timeouts while in "idle" */
-		timeout_event.Cancel();
-		return false;
 	}
+
+	/* disable timeouts while in "idle" */
+	timeout_event.Cancel();
+	return false;
 }

--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -307,9 +307,11 @@ command_lookup(const char *name) noexcept
 		const auto cmp = strcmp(name, commands[i].cmd);
 		if (cmp == 0)
 			return &commands[i];
-		else if (cmp < 0)
+
+		if (cmp < 0)
 			b = i;
-		else if (cmp > 0)
+
+		if (cmp > 0)
 			a = i + 1;
 	} while (a < b);
 
@@ -338,16 +340,21 @@ command_check_request(const struct command *cmd, Response &r,
 			      "wrong number of arguments for \"%s\"",
 			      cmd->cmd);
 		return false;
-	} else if (args.size < unsigned(min)) {
+	}
+
+	if (args.size < unsigned(min)) {
 		r.FormatError(ACK_ERROR_ARG,
 			      "too few arguments for \"%s\"", cmd->cmd);
 		return false;
-	} else if (max >= 0 && args.size > unsigned(max)) {
+	}
+
+	if (max >= 0 && args.size > unsigned(max)) {
 		r.FormatError(ACK_ERROR_ARG,
 			      "too many arguments for \"%s\"", cmd->cmd);
 		return false;
-	} else
-		return true;
+	}
+
+	return true;
 }
 
 static const struct command *

--- a/src/command/ClientCommands.cxx
+++ b/src/command/ClientCommands.cxx
@@ -90,7 +90,9 @@ handle_tagtypes(Client &client, Request request, Response &r)
 
 		client.tag_mask = TagMask::All();
 		return CommandResult::OK;
-	} else if (StringIsEqual(cmd, "clear")) {
+	}
+
+	if (StringIsEqual(cmd, "clear")) {
 		if (!request.empty()) {
 			r.Error(ACK_ERROR_ARG, "Too many arguments");
 			return CommandResult::ERROR;
@@ -98,14 +100,18 @@ handle_tagtypes(Client &client, Request request, Response &r)
 
 		client.tag_mask = TagMask::None();
 		return CommandResult::OK;
-	} else if (StringIsEqual(cmd, "enable")) {
+	}
+
+	if (StringIsEqual(cmd, "enable")) {
 		client.tag_mask |= ParseTagMask(request);
 		return CommandResult::OK;
-	} else if (StringIsEqual(cmd, "disable")) {
+	}
+
+	if (StringIsEqual(cmd, "disable")) {
 		client.tag_mask &= ~ParseTagMask(request);
 		return CommandResult::OK;
-	} else {
-		r.Error(ACK_ERROR_ARG, "Unknown sub command");
-		return CommandResult::ERROR;
 	}
+
+	r.Error(ACK_ERROR_ARG, "Unknown sub command");
+	return CommandResult::ERROR;
 }

--- a/src/command/FingerprintCommands.cxx
+++ b/src/command/FingerprintCommands.cxx
@@ -213,11 +213,14 @@ GetChromaprintCommand::DecodeFile(const char *suffix, InputStream &is,
 	if (plugin.file_decode != nullptr) {
 		plugin.FileDecode(*this, path);
 		return IsReady();
-	} else if (plugin.stream_decode != nullptr) {
+	}
+
+	if (plugin.stream_decode != nullptr) {
 		plugin.StreamDecode(*this, is);
 		return IsReady();
-	} else
-		return false;
+	}
+
+	return false;
 }
 
 inline void

--- a/src/command/MessageCommands.cxx
+++ b/src/command/MessageCommands.cxx
@@ -66,10 +66,9 @@ handle_unsubscribe(Client &client, Request args, Response &r)
 
 	if (client.Unsubscribe(channel_name))
 		return CommandResult::OK;
-	else {
-		r.Error(ACK_ERROR_NO_EXIST, "not subscribed to this channel");
-		return CommandResult::ERROR;
-	}
+
+	r.Error(ACK_ERROR_NO_EXIST, "not subscribed to this channel");
+	return CommandResult::ERROR;
 }
 
 CommandResult
@@ -127,9 +126,8 @@ handle_send_message(Client &client, Request args, Response &r)
 
 	if (sent)
 		return CommandResult::OK;
-	else {
-		r.Error(ACK_ERROR_NO_EXIST,
-			"nobody is subscribed to this channel");
-		return CommandResult::ERROR;
-	}
+
+	r.Error(ACK_ERROR_NO_EXIST,
+		"nobody is subscribed to this channel");
+	return CommandResult::ERROR;
 }

--- a/src/command/OtherCommands.cxx
+++ b/src/command/OtherCommands.cxx
@@ -260,12 +260,12 @@ handle_update(Response &r, Database &db,
 	if (id > 0) {
 		r.Format("updating_db: %i\n", id);
 		return CommandResult::OK;
-	} else {
-		/* Database::Update() has returned 0 without setting
-		   the Error: the method is not implemented */
-		r.Error(ACK_ERROR_NO_EXIST, "Not implemented");
-		return CommandResult::ERROR;
 	}
+
+	/* Database::Update() has returned 0 without setting
+	   the Error: the method is not implemented */
+	r.Error(ACK_ERROR_NO_EXIST, "Not implemented");
+	return CommandResult::ERROR;
 }
 
 #endif

--- a/src/command/StickerCommands.cxx
+++ b/src/command/StickerCommands.cxx
@@ -74,8 +74,10 @@ handle_sticker_song(Response &r, Partition &partition,
 		sticker_print_value(r, args[3], value.c_str());
 
 		return CommandResult::OK;
+	}
+
 	/* list song song_id */
-	} else if (args.size == 3 && StringIsEqual(cmd, "list")) {
+	if (args.size == 3 && StringIsEqual(cmd, "list")) {
 		const LightSong *song = db.GetSong(args[2]);
 		assert(song != nullptr);
 		AtScopeExit(&db, song) { db.ReturnSong(song); };
@@ -84,8 +86,10 @@ handle_sticker_song(Response &r, Partition &partition,
 		sticker_print(r, sticker);
 
 		return CommandResult::OK;
+	}
+
 	/* set song song_id id key */
-	} else if (args.size == 5 && StringIsEqual(cmd, "set")) {
+	if (args.size == 5 && StringIsEqual(cmd, "set")) {
 		const LightSong *song = db.GetSong(args[2]);
 		assert(song != nullptr);
 		AtScopeExit(&db, song) { db.ReturnSong(song); };
@@ -93,8 +97,10 @@ handle_sticker_song(Response &r, Partition &partition,
 		sticker_song_set_value(sticker_database, *song,
 				       args[3], args[4]);
 		return CommandResult::OK;
+	}
+
 	/* delete song song_id [key] */
-	} else if ((args.size == 3 || args.size == 4) &&
+	if ((args.size == 3 || args.size == 4) &&
 		   StringIsEqual(cmd, "delete")) {
 		const LightSong *song = db.GetSong(args[2]);
 		assert(song != nullptr);
@@ -110,8 +116,10 @@ handle_sticker_song(Response &r, Partition &partition,
 		}
 
 		return CommandResult::OK;
+	}
+
 	/* find song dir key */
-	} else if ((args.size == 4 || args.size == 6) &&
+	if ((args.size == 4 || args.size == 6) &&
 		   StringIsEqual(cmd, "find")) {
 		/* "sticker find song a/directory name" */
 
@@ -148,10 +156,10 @@ handle_sticker_song(Response &r, Partition &partition,
 				  sticker_song_find_print_cb, &data);
 
 		return CommandResult::OK;
-	} else {
-		r.Error(ACK_ERROR_ARG, "bad request");
-		return CommandResult::ERROR;
 	}
+
+	r.Error(ACK_ERROR_ARG, "bad request");
+	return CommandResult::ERROR;
 }
 
 CommandResult
@@ -171,8 +179,7 @@ handle_sticker(Client &client, Request args, Response &r)
 		return handle_sticker_song(r, client.GetPartition(),
 					   sticker_database,
 					   args);
-	else {
-		r.Error(ACK_ERROR_ARG, "unknown sticker domain");
-		return CommandResult::ERROR;
-	}
+
+	r.Error(ACK_ERROR_ARG, "unknown sticker domain");
+	return CommandResult::ERROR;
 }

--- a/src/config/Path.cxx
+++ b/src/config/Path.cxx
@@ -119,12 +119,11 @@ ParsePath(const char *path)
 			return nullptr;
 
 		return home / AllocatedPath::FromUTF8Throw(path);
-	} else if (!PathTraitsUTF8::IsAbsolute(path)) {
+	}
+
+	if (!PathTraitsUTF8::IsAbsolute(path)) {
 		throw FormatRuntimeError("not an absolute path: %s", path);
-	} else {
-#endif
-		return AllocatedPath::FromUTF8Throw(path);
-#ifndef _WIN32
 	}
 #endif
+	return AllocatedPath::FromUTF8Throw(path);
 }

--- a/src/db/Configured.cxx
+++ b/src/db/Configured.cxx
@@ -43,26 +43,28 @@ CreateConfiguredDatabase(const ConfigData &config,
 		param->SetUsed();
 		return DatabaseGlobalInit(main_event_loop, io_event_loop,
 					  listener, *param);
-	} else if (path != nullptr) {
+	}
+
+	if (path != nullptr) {
 		ConfigBlock block(path->line);
 		block.AddBlockParam("path", path->value, path->line);
 		return DatabaseGlobalInit(main_event_loop, io_event_loop,
 					  listener, block);
-	} else {
-		/* if there is no override, use the cache directory */
-
-		const AllocatedPath cache_dir = GetUserCacheDir();
-		if (cache_dir.IsNull())
-			return nullptr;
-
-		const auto db_file = cache_dir / Path::FromFS(PATH_LITERAL("mpd.db"));
-		auto db_file_utf8 = db_file.ToUTF8();
-		if (db_file_utf8.empty())
-			return nullptr;
-
-		ConfigBlock block;
-		block.AddBlockParam("path", std::move(db_file_utf8), -1);
-		return DatabaseGlobalInit(main_event_loop, io_event_loop,
-					  listener, block);
 	}
+
+	/* if there is no override, use the cache directory */
+
+	const AllocatedPath cache_dir = GetUserCacheDir();
+	if (cache_dir.IsNull())
+		return nullptr;
+
+	const auto db_file = cache_dir / Path::FromFS(PATH_LITERAL("mpd.db"));
+	auto db_file_utf8 = db_file.ToUTF8();
+	if (db_file_utf8.empty())
+		return nullptr;
+
+	ConfigBlock block;
+	block.AddBlockParam("path", std::move(db_file_utf8), -1);
+	return DatabaseGlobalInit(main_event_loop, io_event_loop,
+				  listener, block);
 }

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -293,10 +293,9 @@ ThrowError(struct mpd_connection *connection)
 			mpd_connection_get_server_error(connection);
 		throw ProtocolError((enum ack)server_error,
 				    mpd_connection_get_error_message(connection));
-	} else {
-		throw LibmpdclientError(code,
-					mpd_connection_get_error_message(connection));
 	}
+
+	throw LibmpdclientError(code, mpd_connection_get_error_message(connection));
 }
 
 static void

--- a/src/db/plugins/simple/DirectorySave.cxx
+++ b/src/db/plugins/simple/DirectorySave.cxx
@@ -64,12 +64,12 @@ ParseTypeString(const char *type) noexcept
 {
 	if (StringIsEqual(type, "archive"))
 		return DEVICE_INARCHIVE;
-	else if (StringIsEqual(type, "container"))
+	if (StringIsEqual(type, "container"))
 		return DEVICE_CONTAINER;
-	else if (StringIsEqual(type, "playlist"))
+	if (StringIsEqual(type, "playlist"))
 		return DEVICE_PLAYLIST;
-	else
-		return 0;
+
+	return 0;
 }
 
 void

--- a/src/db/plugins/simple/Song.cxx
+++ b/src/db/plugins/simple/Song.cxx
@@ -39,10 +39,9 @@ Song::GetURI() const noexcept
 {
 	if (parent.IsRoot())
 		return filename;
-	else {
-		const char *path = parent.GetPath();
-		return PathTraitsUTF8::Build(path, filename.c_str());
-	}
+
+	const char *path = parent.GetPath();
+	return PathTraitsUTF8::Build(path, filename.c_str());
 }
 
 LightSong

--- a/src/db/plugins/upnp/Directory.cxx
+++ b/src/db/plugins/upnp/Directory.cxx
@@ -39,10 +39,10 @@ ParseItemClass(StringView name) noexcept
 {
 	if (name.Equals("object.item.audioItem.musicTrack"))
 		return UPnPDirObject::ItemClass::MUSIC;
-	else if (name.Equals("object.item.playlistItem"))
+	if (name.Equals("object.item.playlistItem"))
 		return UPnPDirObject::ItemClass::PLAYLIST;
-	else
-		return UPnPDirObject::ItemClass::UNKNOWN;
+
+	return UPnPDirObject::ItemClass::UNKNOWN;
 }
 
 gcc_pure

--- a/src/db/update/Walk.cxx
+++ b/src/db/update/Walk.cxx
@@ -248,7 +248,9 @@ UpdateWalk::SkipSymlink(const Directory *directory,
 	    !config.follow_outside_symlinks) {
 		/* ignore all symlinks */
 		return true;
-	} else if (config.follow_inside_symlinks &&
+	}
+
+	if (config.follow_inside_symlinks &&
 		   config.follow_outside_symlinks) {
 		/* consider all symlinks */
 		return false;

--- a/src/decoder/Thread.cxx
+++ b/src/decoder/Thread.cxx
@@ -285,12 +285,15 @@ TryDecoderFile(DecoderBridge &bridge, Path path_fs, const char *suffix,
 	if (plugin.file_decode != nullptr) {
 		const std::lock_guard<Mutex> protect(dc.mutex);
 		return decoder_file_decode(plugin, bridge, path_fs);
-	} else if (plugin.stream_decode != nullptr) {
+	}
+
+	if (plugin.stream_decode != nullptr) {
 		std::unique_lock<Mutex> lock(dc.mutex);
 		return decoder_stream_decode(plugin, bridge, input_stream,
 					     lock);
-	} else
-		return false;
+	}
+
+	return false;
 }
 
 /**

--- a/src/decoder/plugins/DsdiffDecoderPlugin.cxx
+++ b/src/decoder/plugins/DsdiffDecoderPlugin.cxx
@@ -179,9 +179,9 @@ dsdiff_read_prop(DecoderClient *client, InputStream &is,
 
 	if (prop_id.Equals("SND "))
 		return dsdiff_read_prop_snd(client, is, metadata, end_offset);
-	else
-		/* ignore unknown PROP chunk */
-		return dsdlib_skip_to(client, is, end_offset);
+
+	/* ignore unknown PROP chunk */
+	return dsdlib_skip_to(client, is, end_offset);
 }
 
 static void

--- a/src/decoder/plugins/FaadDecoderPlugin.cxx
+++ b/src/decoder/plugins/FaadDecoderPlugin.cxx
@@ -201,7 +201,9 @@ faad_song_duration(DecoderBuffer &buffer, InputStream &is)
 		buffer.Clear();
 
 		return song_length;
-	} else if (data.size >= 5 && memcmp(data.data, "ADIF", 4) == 0) {
+	}
+
+	if (data.size >= 5 && memcmp(data.data, "ADIF", 4) == 0) {
 		/* obtain the duration from the ADIF header */
 
 		if (!is.KnownSize())
@@ -224,8 +226,9 @@ faad_song_duration(DecoderBuffer &buffer, InputStream &is)
 			return SignedSongTime::Negative();
 
 		return SongTime::FromScale(size, bit_rate / 8);
-	} else
-		return SignedSongTime::Negative();
+	}
+
+	return SignedSongTime::Negative();
 }
 
 static NeAACDecHandle

--- a/src/decoder/plugins/FlacDecoderPlugin.cxx
+++ b/src/decoder/plugins/FlacDecoderPlugin.cxx
@@ -184,7 +184,9 @@ flac_decoder_loop(FlacDecoder *data, FLAC__StreamDecoder *flac_dec)
 			   decodes one frame and may have provided
 			   data to be submitted to the client */
 			continue;
-		} else if (cmd == DecoderCommand::STOP)
+		}
+
+		if (cmd == DecoderCommand::STOP)
 			break;
 
 		switch (FLAC__stream_decoder_get_state(flac_dec)) {

--- a/src/decoder/plugins/FlacInput.cxx
+++ b/src/decoder/plugins/FlacInput.cxx
@@ -37,8 +37,8 @@ FlacInput::Read(FLAC__byte buffer[], size_t *bytes)
 		    (client != nullptr &&
 		     client->GetCommand() != DecoderCommand::NONE))
 			return FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM;
-		else
-			return FLAC__STREAM_DECODER_READ_STATUS_ABORT;
+
+		return FLAC__STREAM_DECODER_READ_STATUS_ABORT;
 	}
 
 	return FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;

--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -533,7 +533,8 @@ parse_xing(struct xing *xing, struct mad_bitptr *ptr, int *oldbitlen) noexcept
 	const int bitsleft = 960 - (*oldbitlen - bitlen);
 	if (bitsleft < 0)
 		return false;
-	else if (bitsleft > 0) {
+
+	if (bitsleft > 0) {
 		mad_bit_skip(ptr, bitsleft);
 		bitlen -= bitsleft;
 	}
@@ -849,7 +850,9 @@ MadDecoder::SynthAndSubmit() noexcept
 	if (drop_start_frames > 0) {
 		drop_start_frames--;
 		return DecoderCommand::NONE;
-	} else if ((drop_end_frames > 0) &&
+	}
+
+	if ((drop_end_frames > 0) &&
 		   current_frame == max_frames - drop_end_frames) {
 		/* stop decoding, effectively dropping all remaining
 		   frames */

--- a/src/decoder/plugins/WavpackDecoderPlugin.cxx
+++ b/src/decoder/plugins/WavpackDecoderPlugin.cxx
@@ -332,9 +332,9 @@ struct WavpackInput {
 		if (last_byte == EOF) {
 			last_byte = c;
 			return c;
-		} else {
-			return EOF;
 		}
+
+		return EOF;
 	}
 
 	InputStream::offset_type GetLength() const {

--- a/src/filter/plugins/HdcdFilterPlugin.cxx
+++ b/src/filter/plugins/HdcdFilterPlugin.cxx
@@ -84,10 +84,10 @@ PreparedHdcdFilter::Open(AudioFormat &audio_format)
 {
 	if (MaybeHdcd(audio_format))
 		return OpenHdcdFilter(audio_format);
-	else
-		/* this cannot be HDCD, so let's copy as-is using
-		   NullFilter */
-		return std::make_unique<NullFilter>(audio_format);
+
+	/* this cannot be HDCD, so let's copy as-is using
+	   NullFilter */
+	return std::make_unique<NullFilter>(audio_format);
 }
 
 static std::unique_ptr<PreparedFilter>

--- a/src/fs/LookupFile.cxx
+++ b/src/fs/LookupFile.cxx
@@ -53,9 +53,9 @@ LookupFile(Path pathname)
 			if (file_info.IsRegular()) {
 				//so the upper should be file
 				return {AllocatedPath::FromFS(buffer.c_str()), AllocatedPath::FromFS(slash + 1)};
-			} else {
-				return {};
 			}
+
+			return {};
 		} catch (const std::system_error &e) {
 			if (!IsPathNotFound(e))
 				throw;

--- a/src/fs/io/FileOutputStream.cxx
+++ b/src/fs/io/FileOutputStream.cxx
@@ -244,7 +244,8 @@ FileOutputStream::Write(const void *data, size_t size)
 	ssize_t nbytes = fd.Write(data, size);
 	if (nbytes < 0)
 		throw FormatErrno("Failed to write to %s", GetPath().c_str());
-	else if ((size_t)nbytes < size)
+
+	if ((size_t)nbytes < size)
 		throw FormatErrno(ENOSPC, "Failed to write to %s",
 				  GetPath().c_str());
 }

--- a/src/fs/io/GunzipReader.cxx
+++ b/src/fs/io/GunzipReader.cxx
@@ -85,7 +85,9 @@ GunzipReader::Read(void *data, size_t size)
 		if (result == Z_STREAM_END) {
 			eof = true;
 			return size - z.avail_out;
-		} else if (result != Z_OK)
+		}
+
+		if (result != Z_OK)
 			throw ZlibError(result);
 
 		buffer.Consume(r.size - z.avail_in);

--- a/src/fs/io/GzipOutputStream.cxx
+++ b/src/fs/io/GzipOutputStream.cxx
@@ -72,7 +72,8 @@ GzipOutputStream::Flush()
 
 		if (result == Z_STREAM_END)
 			break;
-		else if (result != Z_OK)
+
+		if (result != Z_OK)
 			throw ZlibError(result);
 	}
 }

--- a/src/input/RewindInputStream.cxx
+++ b/src/input/RewindInputStream.cxx
@@ -92,27 +92,26 @@ RewindInputStream::Read(std::unique_lock<Mutex> &lock,
 		offset += read_size;
 
 		return read_size;
-	} else {
-		/* pass method call to underlying stream */
-
-		size_t nbytes = input->Read(lock, ptr, read_size);
-
-		if (input->GetOffset() > (offset_type)sizeof(buffer))
-			/* disable buffering */
-			tail = 0;
-		else if (tail == (size_t)offset) {
-			/* append to buffer */
-
-			memcpy(buffer + tail, ptr, nbytes);
-			tail += nbytes;
-
-			assert(tail == (size_t)input->GetOffset());
-		}
-
-		CopyAttributes();
-
-		return nbytes;
 	}
+
+	/* pass method call to underlying stream */
+
+	size_t nbytes = input->Read(lock, ptr, read_size);
+
+	if (input->GetOffset() > (offset_type)sizeof(buffer))
+		/* disable buffering */
+		tail = 0;
+	else if (tail == (size_t)offset) {
+		/* append to buffer */
+
+		memcpy(buffer + tail, ptr, nbytes);
+		tail += nbytes;
+
+		assert(tail == (size_t)input->GetOffset());
+	}
+
+	CopyAttributes();
+	return nbytes;
 }
 
 void

--- a/src/input/plugins/QobuzErrorParser.cxx
+++ b/src/input/plugins/QobuzErrorParser.cxx
@@ -55,8 +55,8 @@ QobuzErrorParser::OnEnd()
 	if (!message.empty())
 		throw FormatRuntimeError("Error from Qobuz: %s",
 					 message.c_str());
-	else
-		throw FormatRuntimeError("Status %u from Qobuz", status);
+
+	throw FormatRuntimeError("Status %u from Qobuz", status);
 }
 
 inline bool

--- a/src/lib/alsa/NonBlock.cxx
+++ b/src/lib/alsa/NonBlock.cxx
@@ -28,8 +28,8 @@ AlsaNonBlockPcm::PrepareSockets(MultiSocketMonitor &m, snd_pcm_t *pcm)
 	if (count <= 0) {
 		if (count == 0)
 			throw std::runtime_error("snd_pcm_poll_descriptors_count() failed");
-		else
-			throw FormatRuntimeError("snd_pcm_poll_descriptors_count() failed: %s",
+
+		throw FormatRuntimeError("snd_pcm_poll_descriptors_count() failed: %s",
 						 snd_strerror(-count));
 	}
 
@@ -39,8 +39,8 @@ AlsaNonBlockPcm::PrepareSockets(MultiSocketMonitor &m, snd_pcm_t *pcm)
 	if (count <= 0) {
 		if (count == 0)
 			throw std::runtime_error("snd_pcm_poll_descriptors() failed");
-		else
-			throw FormatRuntimeError("snd_pcm_poll_descriptors() failed: %s",
+
+		throw FormatRuntimeError("snd_pcm_poll_descriptors() failed: %s",
 						 snd_strerror(-count));
 	}
 

--- a/src/lib/nfs/Manager.cxx
+++ b/src/lib/nfs/Manager.cxx
@@ -95,9 +95,9 @@ NfsManager::GetConnection(const char *server, const char *export_name) noexcept
 					       server, export_name);
 		connections.insert_commit(*c, hint);
 		return *c;
-	} else {
-		return *result.first;
 	}
+
+	return *result.first;
 }
 
 void

--- a/src/lib/upnp/Util.cxx
+++ b/src/lib/upnp/Util.cxx
@@ -87,7 +87,9 @@ stringToTokens(const std::string &str,
 		if (pos == std::string::npos) {
 			tokens.emplace_back(str, startPos);
 			break;
-		} else if (pos == startPos) {
+		}
+
+		if (pos == startPos) {
 			// Dont' push empty tokens after first
 			if (tokens.empty())
 				tokens.emplace_back();

--- a/src/lib/xiph/OggFind.cxx
+++ b/src/lib/xiph/OggFind.cxx
@@ -31,7 +31,9 @@ OggFindEOS(OggSyncState &oy, ogg_stream_state &os, ogg_packet &packet)
 				return false;
 
 			continue;
-		} else if (r > 0 && packet.e_o_s)
+		}
+
+		if (r > 0 && packet.e_o_s)
 			return true;
 	}
 }

--- a/src/mixer/MixerType.cxx
+++ b/src/mixer/MixerType.cxx
@@ -31,12 +31,12 @@ mixer_type_parse(const char *input)
 
 	if (strcmp(input, "none") == 0 || strcmp(input, "disabled") == 0)
 		return MixerType::NONE;
-	else if (strcmp(input, "hardware") == 0)
+	if (strcmp(input, "hardware") == 0)
 		return MixerType::HARDWARE;
-	else if (strcmp(input, "software") == 0)
+	if (strcmp(input, "software") == 0)
 		return MixerType::SOFTWARE;
-	else if (strcmp(input, "null") == 0)
+	if (strcmp(input, "null") == 0)
 		return MixerType::NULL_;
-	else
-		throw std::runtime_error("Unrecognized mixer type");
+
+	throw std::runtime_error("Unrecognized mixer type");
 }

--- a/src/mixer/plugins/SoftwareMixerPlugin.cxx
+++ b/src/mixer/plugins/SoftwareMixerPlugin.cxx
@@ -72,11 +72,12 @@ PercentVolumeToSoftwareVolume(unsigned volume) noexcept
 
 	if (volume >= 100)
 		return PCM_VOLUME_1;
-	else if (volume > 0)
-		return pcm_float_to_volume((exp(volume / 25.0) - 1) /
+
+	if (volume > 0)
+		return pcm_float_to_volume((std::exp(volume / 25.0) - 1) /
 					   (54.5981500331F - 1));
-	else
-		return 0;
+
+	return 0;
 }
 
 void

--- a/src/mixer/plugins/volume_mapping.c
+++ b/src/mixer/plugins/volume_mapping.c
@@ -50,10 +50,10 @@ static long lrint_dir(double x, int dir)
 {
 	if (dir > 0)
 		return lrint(ceil(x));
-	else if (dir < 0)
+	if (dir < 0)
 		return lrint(floor(x));
-	else
-		return lrint(x);
+
+	return lrint(x);
 }
 
 enum ctl_dir { PLAYBACK, CAPTURE };
@@ -139,7 +139,8 @@ static int set_normalized_volume(snd_mixer_elem_t *elem,
 		   100% */
 		if (volume <= 0)
 			return set_raw[ctl_dir](elem, min);
-		else if (volume >= 1)
+
+		if (volume >= 1)
 			return set_raw[ctl_dir](elem, max);
 
 		value = lrint_dir(volume * (max - min), dir) + min;
@@ -150,7 +151,8 @@ static int set_normalized_volume(snd_mixer_elem_t *elem,
 	   100% */
 	if (volume <= 0)
 		return set_dB[ctl_dir](elem, min, dir);
-	else if (volume >= 1)
+
+	if (volume >= 1)
 		return set_dB[ctl_dir](elem, max, dir);
 
 	if (use_linear_dB_scale(min, max)) {

--- a/src/neighbor/plugins/UdisksNeighborPlugin.cxx
+++ b/src/neighbor/plugins/UdisksNeighborPlugin.cxx
@@ -237,13 +237,16 @@ UdisksNeighborExplorer::HandleMessage(DBusConnection *, DBusMessage *message) no
 			});
 
 		return DBUS_HANDLER_RESULT_HANDLED;
-	} else if (dbus_message_is_signal(message, DBUS_OM_INTERFACE,
+	}
+
+	if (dbus_message_is_signal(message, DBUS_OM_INTERFACE,
 					  "InterfacesRemoved") &&
 		   dbus_message_has_signature(message, InterfacesRemovedType::value)) {
 		Remove(ReadMessageIter(*message).GetString());
 		return DBUS_HANDLER_RESULT_HANDLED;
-	} else
-		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+	}
+
+	return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 }
 
 DBusHandlerResult

--- a/src/net/HostParser.cxx
+++ b/src/net/HostParser.cxx
@@ -102,9 +102,10 @@ ExtractHost(const char *src) noexcept
 					result.end = FindIPv6End(src + 1);
 					result.host = {hostname, result.end};
 					return result;
-				} else
-					/* remember the position of the first colon */
-					colon = src;
+				}
+
+				/* remember the position of the first colon */
+				colon = src;
 			}
 
 			++src;

--- a/src/output/MultipleOutputs.cxx
+++ b/src/output/MultipleOutputs.cxx
@@ -243,7 +243,9 @@ MultipleOutputs::Open(const AudioFormat audio_format)
 		/* close all devices if there was an error */
 		Close();
 		throw std::runtime_error("All audio outputs are disabled");
-	} else if (!ret) {
+	}
+
+	if (!ret) {
 		/* close all devices if there was an error */
 		Close();
 

--- a/src/output/SharedPipeConsumer.cxx
+++ b/src/output/SharedPipeConsumer.cxx
@@ -33,11 +33,11 @@ SharedPipeConsumer::Get() noexcept
 
 		consumed = false;
 		return chunk = chunk->next.get();
-	} else {
-		/* get the first chunk from the pipe */
-		consumed = false;
-		return chunk = pipe->Peek();
 	}
+
+	/* get the first chunk from the pipe */
+	consumed = false;
+	return chunk = pipe->Peek();
 }
 
 bool

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -485,8 +485,9 @@ alsa_test_default_device()
 			    "Error opening default ALSA device: %s",
 			    snd_strerror(-ret));
 		return false;
-	} else
-		snd_pcm_close(handle);
+	}
+
+	snd_pcm_close(handle);
 
 	return true;
 }
@@ -862,11 +863,12 @@ AlsaOutput::DrainInternal()
 
 	if (result == 0)
 		return true;
-	else if (result == -EAGAIN)
+
+	if (result == -EAGAIN)
 		return false;
-	else
-		throw FormatRuntimeError("snd_pcm_drain() failed: %s",
-					 snd_strerror(-result));
+
+	throw FormatRuntimeError("snd_pcm_drain() failed: %s",
+				 snd_strerror(-result));
 }
 
 void

--- a/src/output/plugins/ShoutOutputPlugin.cxx
+++ b/src/output/plugins/ShoutOutputPlugin.cxx
@@ -125,7 +125,8 @@ ShoutOutput::ShoutOutput(const ConfigBlock &block)
 		    !StringIsEqual(mime_type, "audio/mpeg"))
 			throw FormatRuntimeError("you cannot stream \"%s\" to shoutcast, use mp3",
 						 mime_type);
-		else if (StringIsEqual(value, "shoutcast"))
+
+		if (StringIsEqual(value, "shoutcast"))
 			protocol = SHOUT_PROTOCOL_ICY;
 		else if (StringIsEqual(value, "icecast1"))
 			protocol = SHOUT_PROTOCOL_XAUDIOCAST;

--- a/src/output/plugins/httpd/HttpdClient.cxx
+++ b/src/output/plugins/httpd/HttpdClient.cxx
@@ -108,24 +108,24 @@ HttpdClient::HandleLine(const char *line) noexcept
 		/* after the request line, request headers follow */
 		state = State::HEADERS;
 		return true;
-	} else {
-		if (*line == 0) {
-			/* empty line: request is finished */
+	}
 
-			BeginResponse();
-			return true;
-		}
+	if (*line == 0) {
+		/* empty line: request is finished */
 
-		if (StringEqualsCaseASCII(line, "Icy-MetaData: 1", 15) ||
-		    StringEqualsCaseASCII(line, "Icy-MetaData:1", 14)) {
-			/* Send icy metadata */
-			metadata_requested = metadata_supported;
-			return true;
-		}
-
-		/* expect more request headers */
+		BeginResponse();
 		return true;
 	}
+
+	if (StringEqualsCaseASCII(line, "Icy-MetaData: 1", 15) ||
+	    StringEqualsCaseASCII(line, "Icy-MetaData:1", 14)) {
+		/* Send icy metadata */
+		metadata_requested = metadata_supported;
+		return true;
+	}
+
+	/* expect more request headers */
+	return true;
 }
 
 /**

--- a/src/pcm/AudioParser.cxx
+++ b/src/pcm/AudioParser.cxx
@@ -44,7 +44,9 @@ ParseSampleRate(const char *src, bool mask, const char **endptr_r)
 	value = strtoul(src, &endptr, 10);
 	if (endptr == src) {
 		throw std::invalid_argument("Failed to parse the sample rate");
-	} else if (!audio_valid_sample_rate(value))
+	}
+
+	if (!audio_valid_sample_rate(value))
 		throw FormatInvalidArgument("Invalid sample rate: %lu", value);
 
 	*endptr_r = endptr;
@@ -123,7 +125,8 @@ ParseChannelCount(const char *src, bool mask, const char **endptr_r)
 	value = strtoul(src, &endptr, 10);
 	if (endptr == src)
 		throw std::invalid_argument("Failed to parse the channel count");
-	else if (!audio_valid_channel_count(value))
+
+	if (!audio_valid_channel_count(value))
 		throw FormatInvalidArgument("Invalid channel count: %u",
 					    value);
 

--- a/src/playlist/cue/CueParser.cxx
+++ b/src/playlist/cue/CueParser.cxx
@@ -80,8 +80,8 @@ cue_next_value(char **pp)
 
 	if (*p == '"')
 		return cue_next_quoted(p + 1, pp);
-	else
-		return cue_next_word(p, pp);
+
+	return cue_next_word(p, pp);
 }
 
 static void
@@ -110,10 +110,10 @@ CueParser::GetCurrentTag() noexcept
 {
 	if (state == HEADER)
 		return &header_tag;
-	else if (state == TRACK)
+	if (state == TRACK)
 		return &song_tag;
-	else
-		return nullptr;
+
+	return nullptr;
 }
 
 static int

--- a/src/queue/Playlist.cxx
+++ b/src/queue/Playlist.cxx
@@ -350,9 +350,11 @@ playlist::GetNextPosition() const noexcept
 
 	if (queue.single != SingleMode::OFF && queue.repeat)
 		return queue.OrderToPosition(current);
-	else if (queue.IsValidOrder(current + 1))
+
+	if (queue.IsValidOrder(current + 1))
 		return queue.OrderToPosition(current + 1);
-	else if (queue.repeat)
+
+	if (queue.repeat)
 		return queue.OrderToPosition(0);
 
 	return -1;

--- a/src/queue/PlaylistControl.cxx
+++ b/src/queue/PlaylistControl.cxx
@@ -67,15 +67,17 @@ playlist::MoveOrderToCurrent(unsigned old_order) noexcept
 		   current one (because the current one has already
 		   been playing and shall not be played again) */
 		return queue.MoveOrderAfter(old_order, current);
-	} else if (current >= 0) {
+	}
+
+	if (current >= 0) {
 		/* not playing: move the specified song before the
 		   current one, so it will be played eventually */
 		return queue.MoveOrderBefore(old_order, current);
-	} else {
-		/* not playing anything: move the specified song to
-		   the front */
-		return queue.MoveOrderBefore(old_order, 0);
 	}
+
+	/* not playing anything: move the specified song to
+	   the front */
+	return queue.MoveOrderBefore(old_order, 0);
 }
 
 void

--- a/src/queue/Queue.cxx
+++ b/src/queue/Queue.cxx
@@ -43,14 +43,16 @@ Queue::GetNextOrder(unsigned _order) const noexcept
 
 	if (single != SingleMode::OFF && repeat && !consume)
 		return _order;
-	else if (_order + 1 < length)
+
+	if (_order + 1 < length)
 		return _order + 1;
-	else if (repeat && (_order > 0 || !consume))
+
+	if (repeat && (_order > 0 || !consume))
 		/* restart at first song */
 		return 0;
-	else
-		/* end of queue */
-		return -1;
+
+	/* end of queue */
+	return -1;
 }
 
 void

--- a/src/song/Filter.cxx
+++ b/src/song/Filter.cxx
@@ -298,14 +298,18 @@ SongFilter::ParseExpression(const char *&s, bool fold_case)
 			throw std::runtime_error("')' expected");
 		s = StripLeft(s + 1);
 		return std::make_unique<ModifiedSinceSongFilter>(ParseTimeStamp(value_s.c_str()));
-	} else if (type == LOCATE_TAG_BASE_TYPE) {
+	}
+
+	if (type == LOCATE_TAG_BASE_TYPE) {
 		auto value = ExpectQuoted(s);
 		if (*s != ')')
 			throw std::runtime_error("')' expected");
 		s = StripLeft(s + 1);
 
 		return std::make_unique<BaseSongFilter>(std::move(value));
-	} else if (type == LOCATE_TAG_AUDIO_FORMAT) {
+	}
+
+	if (type == LOCATE_TAG_AUDIO_FORMAT) {
 		bool mask;
 		if (s[0] == '=' && s[1] == '=')
 			mask = false;
@@ -324,22 +328,22 @@ SongFilter::ParseExpression(const char *&s, bool fold_case)
 		s = StripLeft(s + 1);
 
 		return std::make_unique<AudioFormatSongFilter>(value);
-	} else {
-		auto string_filter = ParseStringFilter(s, fold_case);
-		if (*s != ')')
-			throw std::runtime_error("')' expected");
-
-		s = StripLeft(s + 1);
-
-		if (type == LOCATE_TAG_ANY_TYPE)
-			type = TAG_NUM_OF_ITEM_TYPES;
-
-		if (type == LOCATE_TAG_FILE_TYPE)
-			return std::make_unique<UriSongFilter>(std::move(string_filter));
-
-		return std::make_unique<TagSongFilter>(TagType(type),
-						       std::move(string_filter));
 	}
+
+	auto string_filter = ParseStringFilter(s, fold_case);
+	if (*s != ')')
+		throw std::runtime_error("')' expected");
+
+	s = StripLeft(s + 1);
+
+	if (type == LOCATE_TAG_ANY_TYPE)
+		type = TAG_NUM_OF_ITEM_TYPES;
+
+	if (type == LOCATE_TAG_FILE_TYPE)
+		return std::make_unique<UriSongFilter>(std::move(string_filter));
+
+	return std::make_unique<TagSongFilter>(TagType(type),
+					       std::move(string_filter));
 }
 
 void

--- a/src/song/StringFilter.cxx
+++ b/src/song/StringFilter.cxx
@@ -36,11 +36,11 @@ StringFilter::MatchWithoutNegation(const char *s) const noexcept
 		return substring
 			? fold_case.IsIn(s)
 			: fold_case == s;
-	} else {
-		return substring
-			? StringFind(s, value.c_str()) != nullptr
-			: value == s;
 	}
+
+	return substring
+		? StringFind(s, value.c_str()) != nullptr
+		: value == s;
 }
 
 bool

--- a/src/storage/CompositeStorage.cxx
+++ b/src/storage/CompositeStorage.cxx
@@ -90,10 +90,10 @@ NextSegment(const char *&uri_r)
 	if (slash == nullptr) {
 		uri_r += strlen(uri);
 		return std::string(uri);
-	} else {
-		uri_r = slash + 1;
-		return std::string(uri, slash);
 	}
+
+	uri_r = slash + 1;
+	return std::string(uri, slash);
 }
 
 const CompositeStorage::Directory *

--- a/src/storage/plugins/CurlStorage.cxx
+++ b/src/storage/plugins/CurlStorage.cxx
@@ -512,12 +512,13 @@ private:
 		if (slash == nullptr)
 			/* regular file */
 			return path;
-		else if (slash[1] == 0)
+
+		if (slash[1] == 0)
 			/* trailing slash: collection; strip the slash */
 			return {path, slash};
-		else
-			/* strange, better ignore it */
-			return nullptr;
+
+		/* strange, better ignore it */
+		return nullptr;
 	}
 
 protected:

--- a/src/system/FileDescriptor.cxx
+++ b/src/system/FileDescriptor.cxx
@@ -231,8 +231,9 @@ FileDescriptor::CheckDuplicate(FileDescriptor new_fd) noexcept
 	if (*this == new_fd) {
 		DisableCloseOnExec();
 		return true;
-	} else
-		return Duplicate(new_fd);
+	}
+
+	return Duplicate(new_fd);
 }
 
 #endif

--- a/src/tag/Id3Load.cxx
+++ b/src/tag/Id3Load.cxx
@@ -116,7 +116,9 @@ try {
 	auto tag = ReadId3Tag(is, lock);
 	if (!tag) {
 		return nullptr;
-	} else if (tag_is_id3v1(tag.get())) {
+	}
+
+	if (tag_is_id3v1(tag.get())) {
 		/* id3v1 tags don't belong here */
 		return nullptr;
 	}

--- a/src/tag/Pool.cxx
+++ b/src/tag/Pool.cxx
@@ -137,12 +137,12 @@ tag_pool_dup_item(TagItem *item) noexcept
 	if (slot->ref < TagPoolSlot::MAX_REF) {
 		++slot->ref;
 		return item;
-	} else {
-		/* the reference counter overflows above MAX_REF;
-		   obtain a reference to a different TagPoolSlot which
-		   isn't yet "full" */
-		return tag_pool_get_item(item->type, item->value);
 	}
+
+	/* the reference counter overflows above MAX_REF;
+	   obtain a reference to a different TagPoolSlot which
+	   isn't yet "full" */
+	return tag_pool_get_item(item->type, item->value);
 }
 
 void

--- a/src/tag/ReplayGain.cxx
+++ b/src/tag/ReplayGain.cxx
@@ -34,17 +34,24 @@ ParseReplayGainTagTemplate(ReplayGainInfo &info, const T t)
 	if ((value = t["replaygain_track_gain"]) != nullptr) {
 		info.track.gain = ParseFloat(value);
 		return true;
-	} else if ((value = t["replaygain_album_gain"]) != nullptr) {
+	}
+
+	if ((value = t["replaygain_album_gain"]) != nullptr) {
 		info.album.gain = ParseFloat(value);
 		return true;
-	} else if ((value = t["replaygain_track_peak"]) != nullptr) {
+	}
+
+	if ((value = t["replaygain_track_peak"]) != nullptr) {
 		info.track.peak = ParseFloat(value);
 		return true;
-	} else if ((value = t["replaygain_album_peak"]) != nullptr) {
+	}
+
+	if ((value = t["replaygain_album_peak"]) != nullptr) {
 		info.album.peak = ParseFloat(value);
 		return true;
-	} else
-		return false;
+	}
+
+	return false;
 
 }
 

--- a/src/time/ISO8601.cxx
+++ b/src/time/ISO8601.cxx
@@ -68,7 +68,9 @@ ParseTimeZoneOffsetRaw(const char *&s)
 	if (endptr == s + 4) {
 		s = endptr;
 		return std::make_pair(value / 100, value % 100);
-	} else if (endptr == s + 2) {
+	}
+
+	if (endptr == s + 2) {
 		s = endptr;
 
 		unsigned hours = value, minutes = 0;
@@ -82,8 +84,9 @@ ParseTimeZoneOffsetRaw(const char *&s)
 		}
 
 		return std::make_pair(hours, minutes);
-	} else
-		throw std::runtime_error("Failed to parse time zone offset");
+	}
+
+	throw std::runtime_error("Failed to parse time zone offset");
 }
 
 static std::chrono::system_clock::duration

--- a/src/util/Tokenizer.cxx
+++ b/src/util/Tokenizer.cxx
@@ -171,6 +171,6 @@ Tokenizer::NextParam()
 {
 	if (*input == '"')
 		return NextString();
-	else
-		return NextUnquoted();
+
+	return NextUnquoted();
 }

--- a/src/util/UTF8.cxx
+++ b/src/util/UTF8.cxx
@@ -173,25 +173,30 @@ SequenceLengthUTF8(char ch) noexcept
 {
 	if (IsASCII(ch))
 		return 1;
-	else if (IsLeading1(ch))
+
+	if (IsLeading1(ch))
 		/* 1 continuation */
 		return 2;
-	else if (IsLeading2(ch))
+
+	if (IsLeading2(ch))
 		/* 2 continuations */
 		return 3;
-	else if (IsLeading3(ch))
+
+	if (IsLeading3(ch))
 		/* 3 continuations */
 		return 4;
-	else if (IsLeading4(ch))
+
+	if (IsLeading4(ch))
 		/* 4 continuations */
 		return 5;
-	else if (IsLeading5(ch))
+
+	if (IsLeading5(ch))
 		/* 5 continuations */
 		return 6;
-	else
-		/* continuation without a prefix or some other illegal
-		   start byte */
-		return 0;
+
+	/* continuation without a prefix or some other illegal
+	   start byte */
+	return 0;
 
 }
 
@@ -227,25 +232,30 @@ SequenceLengthUTF8(const char *p) noexcept
 
 	if (IsASCII(ch))
 		return 1;
-	else if (IsLeading1(ch))
+
+	if (IsLeading1(ch))
 		/* 1 continuation */
 		return InnerSequenceLengthUTF8<1>(p);
-	else if (IsLeading2(ch))
+
+	if (IsLeading2(ch))
 		/* 2 continuations */
 		return InnerSequenceLengthUTF8<2>(p);
-	else if (IsLeading3(ch))
+
+	if (IsLeading3(ch))
 		/* 3 continuations */
 		return InnerSequenceLengthUTF8<3>(p);
-	else if (IsLeading4(ch))
+
+	if (IsLeading4(ch))
 		/* 4 continuations */
 		return InnerSequenceLengthUTF8<4>(p);
-	else if (IsLeading5(ch))
+
+	if (IsLeading5(ch))
 		/* 5 continuations */
 		return InnerSequenceLengthUTF8<5>(p);
-	else
-		/* continuation without a prefix or some other illegal
-		   start byte */
-		return 0;
+
+	/* continuation without a prefix or some other illegal
+	   start byte */
+	return 0;
 }
 
 gcc_pure


### PR DESCRIPTION
Found with readability-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>