### PR TITLE
[clang-tidy] use nodiscard

### DIFF
--- a/src/archive/plugins/Bzip2ArchivePlugin.cxx
+++ b/src/archive/plugins/Bzip2ArchivePlugin.cxx
@@ -72,7 +72,7 @@ public:
 	~Bzip2InputStream() override;
 
 	/* virtual methods from InputStream */
-	bool IsEOF() const noexcept override;
+	[[nodiscard]] bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,
 		    void *ptr, size_t size) override;
 

--- a/src/archive/plugins/Iso9660ArchivePlugin.cxx
+++ b/src/archive/plugins/Iso9660ArchivePlugin.cxx
@@ -167,7 +167,7 @@ public:
 	}
 
 	/* virtual methods from InputStream */
-	bool IsEOF() const noexcept override;
+	[[nodiscard]] bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,
 		    void *ptr, size_t size) override;
 

--- a/src/archive/plugins/ZzipArchivePlugin.cxx
+++ b/src/archive/plugins/ZzipArchivePlugin.cxx
@@ -111,7 +111,7 @@ public:
 	}
 
 	/* virtual methods from InputStream */
-	bool IsEOF() const noexcept override;
+	[[nodiscard]] bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,
 		    void *ptr, size_t size) override;
 	void Seek(std::unique_lock<Mutex> &lock, offset_type offset) override;

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -61,7 +61,7 @@ public:
 	LibmpdclientError(enum mpd_error _code, const char *_msg)
 		:std::runtime_error(_msg), code(_code) {}
 
-	enum mpd_error GetCode() const {
+	[[nodiscard]] enum mpd_error GetCode() const {
 		return code;
 	}
 };

--- a/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
+++ b/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
@@ -95,12 +95,12 @@ public:
 		   VisitSong visit_song,
 		   VisitPlaylist visit_playlist) const override;
 
-	RecursiveMap<std::string> CollectUniqueTags(const DatabaseSelection &selection,
+	[[nodiscard]] RecursiveMap<std::string> CollectUniqueTags(const DatabaseSelection &selection,
 						    ConstBuffer<TagType> tag_types) const override;
 
-	DatabaseStats GetStats(const DatabaseSelection &selection) const override;
+	[[nodiscard]] DatabaseStats GetStats(const DatabaseSelection &selection) const override;
 
-	std::chrono::system_clock::time_point GetUpdateStamp() const noexcept override {
+	[[nodiscard]] std::chrono::system_clock::time_point GetUpdateStamp() const noexcept override {
 		return std::chrono::system_clock::time_point::min();
 	}
 
@@ -139,7 +139,7 @@ private:
 	 * except easier cause our inodes have a parent id. Not used
 	 * any more actually (see comments in SearchSongs).
 	 */
-	std::string BuildPath(const ContentDirectoryService &server,
+	[[nodiscard]] std::string BuildPath(const ContentDirectoryService &server,
 			      const UPnPDirObject& dirent) const;
 };
 

--- a/src/db/update/InotifyUpdate.cxx
+++ b/src/db/update/InotifyUpdate.cxx
@@ -61,10 +61,10 @@ struct WatchDirectory {
 	WatchDirectory(const WatchDirectory &) = delete;
 	WatchDirectory &operator=(const WatchDirectory &) = delete;
 
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	unsigned GetDepth() const noexcept;
 
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	AllocatedPath GetUriFS() const noexcept;
 };
 

--- a/src/decoder/plugins/DsdiffDecoderPlugin.cxx
+++ b/src/decoder/plugins/DsdiffDecoderPlugin.cxx
@@ -51,7 +51,7 @@ struct DsdiffChunkHeader {
 	 * Read the "size" attribute from the specified header, converting it
 	 * to the host byte order if needed.
 	 */
-	constexpr
+	[[nodiscard]] constexpr
 	uint64_t GetSize() const {
 		return size.Read();
 	}

--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -146,10 +146,10 @@ private:
 	void ParseId3(size_t tagsize, Tag *tag) noexcept;
 	MadDecoderAction DecodeNextFrame(bool skip, Tag *tag) noexcept;
 
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	offset_type ThisFrameOffset() const noexcept;
 
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	offset_type RestIncludingThisFrame() const noexcept;
 
 	/**
@@ -168,7 +168,7 @@ private:
 		times = new mad_timer_t[max_frames];
 	}
 
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	size_t TimeToFrame(SongTime t) const noexcept;
 
 	/**

--- a/src/decoder/plugins/OpusDecoderPlugin.cxx
+++ b/src/decoder/plugins/OpusDecoderPlugin.cxx
@@ -94,7 +94,7 @@ public:
 	/**
 	 * Has DecoderClient::Ready() been called yet?
 	 */
-	bool IsInitialized() const {
+	[[nodiscard]] bool IsInitialized() const {
 		return previous_channels != 0;
 	}
 

--- a/src/decoder/plugins/VorbisDecoderPlugin.cxx
+++ b/src/decoder/plugins/VorbisDecoderPlugin.cxx
@@ -86,7 +86,7 @@ public:
 		return ::CheckAudioFormat(vi.rate, sample_format, vi.channels);
 	}
 
-	AudioFormat CheckAudioFormat() const {
+	[[nodiscard]] AudioFormat CheckAudioFormat() const {
 		return CheckAudioFormat(vi);
 	}
 

--- a/src/decoder/plugins/WavpackDecoderPlugin.cxx
+++ b/src/decoder/plugins/WavpackDecoderPlugin.cxx
@@ -291,7 +291,7 @@ struct WavpackInput {
 
 	int32_t ReadBytes(void *data, size_t bcount);
 
-	InputStream::offset_type GetPos() const {
+	[[nodiscard]] InputStream::offset_type GetPos() const {
 		return is.GetOffset();
 	}
 
@@ -337,14 +337,14 @@ struct WavpackInput {
 		}
 	}
 
-	InputStream::offset_type GetLength() const {
+	[[nodiscard]] InputStream::offset_type GetLength() const {
 		if (!is.KnownSize())
 			return 0;
 
 		return is.GetSize();
 	}
 
-	bool CanSeek() const {
+	[[nodiscard]] bool CanSeek() const {
 		return is.IsSeekable();
 	}
 };

--- a/src/encoder/plugins/FlacEncoderPlugin.cxx
+++ b/src/encoder/plugins/FlacEncoderPlugin.cxx
@@ -87,7 +87,7 @@ public:
 	/* virtual methods from class PreparedEncoder */
 	Encoder *Open(AudioFormat &audio_format) override;
 
-	const char *GetMimeType() const noexcept override {
+	[[nodiscard]] const char *GetMimeType() const noexcept override {
 		return  "audio/flac";
 	}
 };

--- a/src/encoder/plugins/LameEncoderPlugin.cxx
+++ b/src/encoder/plugins/LameEncoderPlugin.cxx
@@ -62,7 +62,7 @@ public:
 	/* virtual methods from class PreparedEncoder */
 	Encoder *Open(AudioFormat &audio_format) override;
 
-	const char *GetMimeType() const noexcept override {
+	[[nodiscard]] const char *GetMimeType() const noexcept override {
 		return "audio/mpeg";
 	}
 };

--- a/src/encoder/plugins/OpusEncoderPlugin.cxx
+++ b/src/encoder/plugins/OpusEncoderPlugin.cxx
@@ -84,7 +84,7 @@ public:
 	/* virtual methods from class PreparedEncoder */
 	Encoder *Open(AudioFormat &audio_format) override;
 
-	const char *GetMimeType() const noexcept override {
+	[[nodiscard]] const char *GetMimeType() const noexcept override {
 		return "audio/ogg";
 	}
 };

--- a/src/encoder/plugins/TwolameEncoderPlugin.cxx
+++ b/src/encoder/plugins/TwolameEncoderPlugin.cxx
@@ -78,7 +78,7 @@ public:
 	/* virtual methods from class PreparedEncoder */
 	Encoder *Open(AudioFormat &audio_format) override;
 
-	const char *GetMimeType() const noexcept override {
+	[[nodiscard]] const char *GetMimeType() const noexcept override {
 		return  "audio/mpeg";
 	}
 };

--- a/src/encoder/plugins/VorbisEncoderPlugin.cxx
+++ b/src/encoder/plugins/VorbisEncoderPlugin.cxx
@@ -70,7 +70,7 @@ public:
 	/* virtual methods from class PreparedEncoder */
 	Encoder *Open(AudioFormat &audio_format) override;
 
-	const char *GetMimeType() const noexcept override {
+	[[nodiscard]] const char *GetMimeType() const noexcept override {
 		return "audio/ogg";
 	}
 };

--- a/src/encoder/plugins/WaveEncoderPlugin.cxx
+++ b/src/encoder/plugins/WaveEncoderPlugin.cxx
@@ -49,7 +49,7 @@ class PreparedWaveEncoder final : public PreparedEncoder {
 		return new WaveEncoder(audio_format);
 	}
 
-	const char *GetMimeType() const noexcept override {
+	[[nodiscard]] const char *GetMimeType() const noexcept override {
 		return "audio/wav";
 	}
 };

--- a/src/event/ServerSocket.cxx
+++ b/src/event/ServerSocket.cxx
@@ -77,7 +77,7 @@ public:
 			Close();
 	}
 
-	unsigned GetSerial() const noexcept {
+	[[nodiscard]] unsigned GetSerial() const noexcept {
 		return serial;
 	}
 
@@ -94,7 +94,7 @@ public:
 	using SocketMonitor::IsDefined;
 	using SocketMonitor::Close;
 
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	std::string ToString() const noexcept {
 		return ::ToString(address);
 	}

--- a/src/filter/plugins/VolumeFilterPlugin.cxx
+++ b/src/filter/plugins/VolumeFilterPlugin.cxx
@@ -34,7 +34,7 @@ public:
 						  true);
 	}
 
-	unsigned GetVolume() const noexcept {
+	[[nodiscard]] unsigned GetVolume() const noexcept {
 		return pv.GetVolume();
 	}
 

--- a/src/input/RewindInputStream.cxx
+++ b/src/input/RewindInputStream.cxx
@@ -56,7 +56,7 @@ public:
 			ProxyInputStream::Update();
 	}
 
-	bool IsEOF() const noexcept override {
+	[[nodiscard]] bool IsEOF() const noexcept override {
 		return !ReadingFromBuffer() && ProxyInputStream::IsEOF();
 	}
 
@@ -69,7 +69,7 @@ private:
 	 * Are we currently reading from the buffer, and does the
 	 * buffer contain more data for the next read operation?
 	 */
-	bool ReadingFromBuffer() const noexcept {
+	[[nodiscard]] bool ReadingFromBuffer() const noexcept {
 		return tail > 0 && offset < input->GetOffset();
 	}
 };

--- a/src/input/plugins/AlsaInputPlugin.cxx
+++ b/src/input/plugins/AlsaInputPlugin.cxx
@@ -160,22 +160,22 @@ public:
 				audio_format = ParseAudioFormat(format_string, false);
 		}
 	}
-	bool IsValidScheme() const noexcept {
+	[[nodiscard]] bool IsValidScheme() const noexcept {
 		return device_name != nullptr;
 	}
-	bool IsValid() const noexcept {
+	[[nodiscard]] bool IsValid() const noexcept {
 		return (device_name != nullptr) && (format_string != nullptr);
 	}
-	const char *GetURI() const noexcept {
+	[[nodiscard]] const char *GetURI() const noexcept {
 		return uri;
 	}
-	const char *GetDeviceName() const noexcept {
+	[[nodiscard]] const char *GetDeviceName() const noexcept {
 		return device_name;
 	}
-	const char *GetFormatString() const noexcept {
+	[[nodiscard]] const char *GetFormatString() const noexcept {
 		return format_string;
 	}
-	AudioFormat GetAudioFormat() const noexcept {
+	[[nodiscard]] AudioFormat GetAudioFormat() const noexcept {
 		return audio_format;
 	}
 };

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -88,7 +88,7 @@ class CdioParanoiaInputStream final : public InputStream {
 	}
 
 	/* virtual methods from InputStream */
-	bool IsEOF() const noexcept override;
+	[[nodiscard]] bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,
 		    void *ptr, size_t size) override;
 	void Seek(std::unique_lock<Mutex> &lock, offset_type offset) override;

--- a/src/input/plugins/FfmpegInputPlugin.cxx
+++ b/src/input/plugins/FfmpegInputPlugin.cxx
@@ -47,7 +47,7 @@ public:
 	}
 
 	/* virtual methods from InputStream */
-	bool IsEOF() const noexcept override;
+	[[nodiscard]] bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,
 		    void *ptr, size_t size) override;
 	void Seek(std::unique_lock<Mutex> &lock,

--- a/src/input/plugins/FileInputPlugin.cxx
+++ b/src/input/plugins/FileInputPlugin.cxx
@@ -43,7 +43,7 @@ public:
 
 	/* virtual methods from InputStream */
 
-	bool IsEOF() const noexcept override {
+	[[nodiscard]] bool IsEOF() const noexcept override {
 		return GetOffset() >= GetSize();
 	}
 

--- a/src/input/plugins/SmbclientInputPlugin.cxx
+++ b/src/input/plugins/SmbclientInputPlugin.cxx
@@ -51,7 +51,7 @@ public:
 
 	/* virtual methods from InputStream */
 
-	bool IsEOF() const noexcept override {
+	[[nodiscard]] bool IsEOF() const noexcept override {
 		return offset >= size;
 	}
 

--- a/src/neighbor/plugins/SmbclientNeighborPlugin.cxx
+++ b/src/neighbor/plugins/SmbclientNeighborPlugin.cxx
@@ -50,7 +50,7 @@ class SmbclientNeighborExplorer final : public NeighborExplorer {
 			return name == other.name;
 		}
 
-		gcc_pure
+		[[nodiscard]] gcc_pure
 		NeighborInfo Export() const noexcept {
 			return { "smb://" + name + "/", comment };
 		}

--- a/src/neighbor/plugins/UpnpNeighborPlugin.cxx
+++ b/src/neighbor/plugins/UpnpNeighborPlugin.cxx
@@ -44,7 +44,7 @@ class UpnpNeighborExplorer final
 			return name == other.name;
 		}
 
-		gcc_pure
+		[[nodiscard]] gcc_pure
 		NeighborInfo Export() const noexcept {
 			return { "smb://" + name + "/", comment };
 		}
@@ -62,7 +62,7 @@ public:
 	/* virtual methods from class NeighborExplorer */
 	void Open() override;
 	void Close() noexcept override;
-	List GetList() const noexcept override;
+	[[nodiscard]] List GetList() const noexcept override;
 
 private:
 	/* virtual methods from class UPnPDiscoveryListener */

--- a/src/output/plugins/FifoOutputPlugin.cxx
+++ b/src/output/plugins/FifoOutputPlugin.cxx
@@ -64,7 +64,7 @@ private:
 	void Open(AudioFormat &audio_format) override;
 	void Close() noexcept override;
 
-	std::chrono::steady_clock::duration Delay() const noexcept override;
+	[[nodiscard]] std::chrono::steady_clock::duration Delay() const noexcept override;
 	size_t Play(const void *chunk, size_t size) override;
 	void Cancel() noexcept override;
 };

--- a/src/output/plugins/NullOutputPlugin.cxx
+++ b/src/output/plugins/NullOutputPlugin.cxx
@@ -47,7 +47,7 @@ private:
 			delete timer;
 	}
 
-	std::chrono::steady_clock::duration Delay() const noexcept override {
+	[[nodiscard]] std::chrono::steady_clock::duration Delay() const noexcept override {
 		return sync && timer->IsStarted()
 			? timer->GetDelay()
 			: std::chrono::steady_clock::duration::zero();

--- a/src/output/plugins/OpenALOutputPlugin.cxx
+++ b/src/output/plugins/OpenALOutputPlugin.cxx
@@ -56,7 +56,7 @@ private:
 	void Open(AudioFormat &audio_format) override;
 	void Close() noexcept override;
 
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	std::chrono::steady_clock::duration Delay() const noexcept override {
 		return filled < NUM_BUFFERS || HasProcessed()
 			? std::chrono::steady_clock::duration::zero()
@@ -71,19 +71,19 @@ private:
 	void Cancel() noexcept override;
 
 private:
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	ALint GetSourceI(ALenum param) const noexcept {
 		ALint value;
 		alGetSourcei(source, param, &value);
 		return value;
 	}
 
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	bool HasProcessed() const noexcept {
 		return GetSourceI(AL_BUFFERS_PROCESSED) > 0;
 	}
 
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	bool IsPlaying() const noexcept {
 		return GetSourceI(AL_SOURCE_STATE) == AL_PLAYING;
 	}

--- a/src/output/plugins/PulseOutputPlugin.cxx
+++ b/src/output/plugins/PulseOutputPlugin.cxx
@@ -99,7 +99,7 @@ public:
 	void Open(AudioFormat &audio_format) override;
 	void Close() noexcept override;
 
-	std::chrono::steady_clock::duration Delay() const noexcept override;
+	[[nodiscard]] std::chrono::steady_clock::duration Delay() const noexcept override;
 	size_t Play(const void *chunk, size_t size) override;
 	void Cancel() noexcept override;
 	bool Pause() override;

--- a/src/output/plugins/RecorderOutputPlugin.cxx
+++ b/src/output/plugins/RecorderOutputPlugin.cxx
@@ -88,7 +88,7 @@ private:
 	size_t Play(const void *chunk, size_t size) override;
 
 private:
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	bool HasDynamicPath() const noexcept {
 		return !format_path.empty();
 	}

--- a/src/output/plugins/ShoutOutputPlugin.cxx
+++ b/src/output/plugins/ShoutOutputPlugin.cxx
@@ -57,7 +57,7 @@ struct ShoutOutput final : AudioOutput {
 	void Open(AudioFormat &audio_format) override;
 	void Close() noexcept override;
 
-	std::chrono::steady_clock::duration Delay() const noexcept override;
+	[[nodiscard]] std::chrono::steady_clock::duration Delay() const noexcept override;
 	void SendTag(const Tag &tag) override;
 	size_t Play(const void *chunk, size_t size) override;
 	void Cancel() noexcept override;

--- a/src/pcm/Mix.hxx
+++ b/src/pcm/Mix.hxx
@@ -44,7 +44,7 @@ class PcmDither;
  *
  * @return true on success, false if the format is not supported
  */
-gcc_warn_unused_result
+[[nodiscard]]
 bool
 pcm_mix(PcmDither &dither, void *buffer1, const void *buffer2, size_t size,
 	SampleFormat format, float portion1) noexcept;

--- a/src/player/Thread.cxx
+++ b/src/player/Thread.cxx
@@ -252,7 +252,7 @@ private:
 	 * Note: this function does not check if the decoder is already
 	 * finished.
 	 */
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	bool IsDecoderAtCurrentSong() const noexcept {
 		assert(pipe != nullptr);
 
@@ -264,7 +264,7 @@ private:
 	 * decoding it, or has finished doing it), and the player hasn't
 	 * switched to that song yet.
 	 */
-	gcc_pure
+	[[nodiscard]] gcc_pure
 	bool IsDecoderAtNextSong() const noexcept {
 		return dc.pipe != nullptr && !IsDecoderAtCurrentSong();
 	}

--- a/src/storage/plugins/CurlStorage.cxx
+++ b/src/storage/plugins/CurlStorage.cxx
@@ -169,7 +169,7 @@ struct DavResponse {
 		std::chrono::system_clock::time_point::min();
 	uint64_t length = 0;
 
-	bool Check() const {
+	[[nodiscard]] bool Check() const {
 		return !href.empty();
 	}
 };

--- a/src/storage/plugins/NfsStorage.cxx
+++ b/src/storage/plugins/NfsStorage.cxx
@@ -129,7 +129,7 @@ public:
 	}
 
 private:
-	EventLoop &GetEventLoop() const noexcept {
+	[[nodiscard]] EventLoop &GetEventLoop() const noexcept {
 		return defer_connect.GetEventLoop();
 	}
 
@@ -276,7 +276,7 @@ public:
 		:BlockingNfsOperation(_connection), path(_path),
 		 follow(_follow) {}
 
-	const StorageFileInfo &GetInfo() const {
+	[[nodiscard]] const StorageFileInfo &GetInfo() const {
 		return info;
 	}
 


### PR DESCRIPTION
Introduced in C++17. It replaces gcc's warn_unused_result.

Found with modernize-use-nodiscard.