### PR TITLE
fix missing overrides

### DIFF
--- a/src/input/IcyInputStream.hxx
+++ b/src/input/IcyInputStream.hxx
@@ -58,7 +58,7 @@ public:
 	 */
 	IcyInputStream(InputStreamPtr _input,
 		       std::shared_ptr<IcyMetaDataParser> _parser);
-	virtual ~IcyInputStream() noexcept;
+	~IcyInputStream() noexcept override;
 
 	IcyInputStream(const IcyInputStream &) = delete;
 	IcyInputStream &operator=(const IcyInputStream &) = delete;

--- a/src/input/ProxyInputStream.hxx
+++ b/src/input/ProxyInputStream.hxx
@@ -52,7 +52,7 @@ public:
 			 Mutex &_mutex) noexcept
 		:InputStream(_uri, _mutex) {}
 
-	virtual ~ProxyInputStream() noexcept;
+	~ProxyInputStream() noexcept override;
 
 	ProxyInputStream(const ProxyInputStream &) = delete;
 	ProxyInputStream &operator=(const ProxyInputStream &) = delete;

--- a/src/storage/CompositeStorage.hxx
+++ b/src/storage/CompositeStorage.hxx
@@ -87,7 +87,7 @@ class CompositeStorage final : public Storage {
 
 public:
 	CompositeStorage() noexcept;
-	virtual ~CompositeStorage();
+	~CompositeStorage() override;
 
 	/**
 	 * Get the #Storage at the specified mount point.  Returns


### PR DESCRIPTION
Found with clang's -Winconsistent-missing-destructor-override

Signed-off-by: Rosen Penev <rosenp@gmail.com>