### PR TITLE
fix implicit-fallthrough warnings under clang

### DIFF
--- a/src/input/plugins/AlsaInputPlugin.cxx
+++ b/src/input/plugins/AlsaInputPlugin.cxx
@@ -289,7 +289,7 @@ AlsaInputStream::Recover(int err)
 		if (err == -EAGAIN)
 			return 0;
 		/* fall-through to snd_pcm_prepare: */
-#if GCC_CHECK_VERSION(7,0)
+#if CLANG_OR_GCC_VERSION(7,0)
 		[[fallthrough]];
 #endif
 	case SND_PCM_STATE_OPEN:

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -763,7 +763,7 @@ AlsaOutput::Recover(int err) noexcept
 		if (err == -EAGAIN)
 			return 0;
 		/* fall-through to snd_pcm_prepare: */
-#if GCC_CHECK_VERSION(7,0)
+#if CLANG_OR_GCC_VERSION(7,0)
 		[[fallthrough]];
 #endif
 	case SND_PCM_STATE_OPEN:

--- a/src/player/Thread.cxx
+++ b/src/player/Thread.cxx
@@ -1176,7 +1176,9 @@ try {
 			}
 
 			/* fall through */
-			gcc_fallthrough;
+#if CLANG_OR_GCC_VERSION(7,0)
+			[[fallthrough]];
+#endif
 
 		case PlayerCommand::PAUSE:
 			next_song.reset();


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>