### PR TITLE
more clang-tidy

### DIFF
--- a/src/fs/io/FileOutputStream.cxx
+++ b/src/fs/io/FileOutputStream.cxx
@@ -270,12 +270,7 @@ FileOutputStream::Commit()
 #endif
 
 	if (!Close()) {
-#ifdef _WIN32
-		throw FormatLastError("Failed to commit %s",
-				      path.ToUTF8().c_str());
-#else
 		throw FormatErrno("Failed to commit %s", path.c_str());
-#endif
 	}
 }
 


### PR DESCRIPTION
This was done on Windows with Ubuntu 18.04 with clang-11 and more of MPD being compiled.