### PR TITLE
Support podcast RSS feeds with application/xml MIME-type

### DIFF
--- a/src/playlist/plugins/RssPlaylistPlugin.cxx
+++ b/src/playlist/plugins/RssPlaylistPlugin.cxx
@@ -160,6 +160,7 @@ static const char *const rss_suffixes[] = {
 
 static const char *const rss_mime_types[] = {
 	"application/rss+xml",
+	"application/xml",
 	"text/xml",
 	nullptr
 };


### PR DESCRIPTION
Unfortunately some podcasts RSS feeds return `content-type: application/xml`.
At present `mpd` does not support this MIME-Type, thus when attempting to load such a feed into playlist you'll get `No such playlist` error.

Steps to reproduce:
```shell
mpc load --range=0:5 https://changelog.com/gotime/feed
loading: https://changelog.com/gotime/feed
MPD error: No such playlist
```

A list of example podcast feeds that return `content-type: application/xml`:
- https://changelog.com/gotime/feed
- https://feeds.megaphone.fm/PP6777513342
- https://feeds.megaphone.fm/darknetdiaries
- https://linuxactionnews.com/rss
- https://liquidsoundzdnb.podomatic.com/rss2.xml
- https://ninjatune.net/solidsteel/rss.xml
- https://feeds.fireside.fm/smashingsecurity/rss
