### PR TITLE
Add "archive_path" and "delete_after_record" options (feature request 800)

### DIFF
--- a/src/output/Control.cxx
+++ b/src/output/Control.cxx
@@ -452,3 +452,14 @@ AudioOutputControl::StopThread() noexcept
 
 	assert(IsCommandFinished());
 }
+
+void
+AudioOutputControl::Signal(intptr_t sig) noexcept
+{
+	const std::lock_guard<Mutex> protect(mutex);
+
+	signal = sig;
+
+	if (IsOpen())
+		CommandAsync(Command::SIGNAL);
+}

--- a/src/output/Control.hxx
+++ b/src/output/Control.hxx
@@ -144,7 +144,9 @@ class AudioOutputControl {
 		DRAIN,
 
 		CANCEL,
-		KILL
+		KILL,
+
+		SIGNAL,
 	} command = Command::NONE;
 
 	/**
@@ -226,6 +228,11 @@ class AudioOutputControl {
 	 * Protected by #mutex.
 	 */
 	bool killed;
+
+	/** 
+	 * The signal sent with Signal()
+	 */
+	intptr_t signal = 0;
 
 public:
 	/**
@@ -477,6 +484,11 @@ public:
 	 */
 	void LockAllowPlay() noexcept;
 
+	/**
+	 * Send an output specific signal
+	 */
+	void Signal(intptr_t info = 0) noexcept;
+
 private:
 	/**
 	 * An error has occurred and this output is defunct.
@@ -585,6 +597,9 @@ private:
 	void InternalDrain() noexcept;
 
 	void StopThread() noexcept;
+
+	bool InternalSignal(intptr_t info) noexcept;
+
 
 	/**
 	 * The OutputThread.

--- a/src/output/Filtered.cxx
+++ b/src/output/Filtered.cxx
@@ -68,6 +68,12 @@ FilteredAudioOutput::Disable() noexcept
 	output->Disable();
 }
 
+bool
+FilteredAudioOutput::Signal(intptr_t info) noexcept
+{
+	return output->Signal(info);
+}
+
 void
 FilteredAudioOutput::ConfigureConvertFilter()
 {

--- a/src/output/Filtered.hxx
+++ b/src/output/Filtered.hxx
@@ -216,6 +216,8 @@ public:
 	 */
 	void CloseSoftwareMixer() noexcept;
 
+	bool Signal(intptr_t info = 0) noexcept;
+
 	gcc_pure
 	std::chrono::steady_clock::duration Delay() noexcept;
 

--- a/src/output/Interface.hxx
+++ b/src/output/Interface.hxx
@@ -187,6 +187,8 @@ public:
 		/* fail because this method is not implemented */
 		return false;
 	}
+
+	virtual bool Signal(intptr_t sig = 0) {(void)sig; return false;}
 };
 
 #endif


### PR DESCRIPTION
delete_after_record: Save and discard current song, unless a child plugin instance signals to store it persistently in archive_path when title ends.
Implemented via new Signal() method on output controller.