### PR TITLE
Android tv support

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -7,6 +7,11 @@
 
   <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28"/>
 
+  <uses-feature android:name="android.software.leanback"
+                android:required="false" />
+  <uses-feature android:name="android.hardware.touchscreen"
+                android:required="false" />
+
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.INTERNET"/>
@@ -15,6 +20,7 @@
 
   <application android:allowBackup="true"
                android:icon="@drawable/icon"
+               android:banner="@drawable/icon"
                android:label="@string/app_name">
     <activity android:name=".Settings"
               android:label="@string/app_name">
@@ -23,6 +29,14 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
+    <activity android:name=".Settings"
+              android:label="@string/app_name" >
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+      </intent-filter>
+    </activity>
+
     <receiver android:name=".Receiver">
       <intent-filter>
         <action android:name="android.intent.action.BOOT_COMPLETED" />

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -11,6 +11,7 @@
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
   <application android:allowBackup="true"
                android:icon="@drawable/icon"

--- a/android/src/Settings.java
+++ b/android/src/Settings.java
@@ -105,12 +105,13 @@ public class Settings extends Activity {
 				else
 					mRunButton.setChecked(false);
 				mFirstRun = true;
+				mTextStatus.setText("");
 				break;
 			case MSG_STARTED:
 				Log.d(TAG, "onStarted");
 				mRunButton.setChecked(true);
 				mFirstRun = true;
-				mTextStatus.setText("CAUTION: this version is EXPERIMENTAL!"); // XXX
+				mTextStatus.setText("MPD service started");
 				break;
 			case MSG_LOG:
 				if (mLogListArray.size() > MAX_LOGS)


### PR DESCRIPTION
I'm using MPD from an Android TV (a Shield) and the MPD UI settings was hidden in system preferences. These commits make the MPD launcher available from TV apps and fix the foreground permission that is needed on recent devices.