### PR TITLE
[0.21.x]treewide: use boost::lround when std::round is unavailable

### DIFF
--- a/src/Stats.cxx
+++ b/src/Stats.cxx
@@ -29,9 +29,9 @@
 #include "system/Clock.hxx"
 #include "Log.hxx"
 #include "time/ChronoUtil.hxx"
+#include "util/Math.hxx"
 
 #include <chrono>
-#include <cmath>
 
 #ifndef _WIN32
 /**
@@ -121,7 +121,7 @@ stats_print(Response &r, const Partition &partition)
 #else
 		 (unsigned)std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - start_time).count(),
 #endif
-		 std::lround(partition.pc.GetTotalPlayTime().count()));
+		 lround(partition.pc.GetTotalPlayTime().count()));
 
 #ifdef ENABLE_DATABASE
 	const Database *db = partition.instance.GetDatabase();

--- a/src/command/PlayerCommands.cxx
+++ b/src/command/PlayerCommands.cxx
@@ -34,12 +34,11 @@
 #include "util/StringBuffer.hxx"
 #include "util/ScopeExit.hxx"
 #include "util/Exception.hxx"
+#include "util/Math.hxx"
 
 #ifdef ENABLE_DATABASE
 #include "db/update/Service.hxx"
 #endif
-
-#include <cmath>
 
 #define COMMAND_STATUS_STATE            "state"
 #define COMMAND_STATUS_REPEAT           "repeat"
@@ -154,7 +153,7 @@ handle_status(Client &client, gcc_unused Request args, Response &r)
 
 	if (pc.GetCrossFade() > FloatDuration::zero())
 		r.Format(COMMAND_STATUS_CROSSFADE ": %lu\n",
-			 std::lround(pc.GetCrossFade().count()));
+			 lround(pc.GetCrossFade().count()));
 
 	if (pc.GetMixRampDelay() > FloatDuration::zero())
 		r.Format(COMMAND_STATUS_MIXRAMPDELAY ": %f\n",

--- a/src/decoder/plugins/FaadDecoderPlugin.cxx
+++ b/src/decoder/plugins/FaadDecoderPlugin.cxx
@@ -26,11 +26,11 @@
 #include "util/ScopeExit.hxx"
 #include "util/ConstBuffer.hxx"
 #include "util/Domain.hxx"
+#include "util/Math.hxx"
 #include "Log.hxx"
 
 #include <neaacdec.h>
 
-#include <cmath>
 #include <exception>
 
 #include <assert.h>

--- a/src/mixer/plugins/WinmmMixerPlugin.cxx
+++ b/src/mixer/plugins/WinmmMixerPlugin.cxx
@@ -20,13 +20,13 @@
 #include "mixer/MixerInternal.hxx"
 #include "output/OutputAPI.hxx"
 #include "output/plugins/WinmmOutputPlugin.hxx"
+#include "util/Math.hxx"
 
 #include <mmsystem.h>
 
 #include <stdexcept>
 
 #include <assert.h>
-#include <math.h>
 #include <windows.h>
 
 class WinmmMixer final : public Mixer {

--- a/src/output/plugins/HaikuOutputPlugin.cxx
+++ b/src/output/plugins/HaikuOutputPlugin.cxx
@@ -22,6 +22,7 @@
 #include "../OutputAPI.hxx"
 #include "mixer/MixerList.hxx"
 #include "util/Domain.hxx"
+#include "util/Math.hxx"
 #include "system/Error.hxx"
 #include "Log.hxx"
 
@@ -36,8 +37,6 @@
 #include <Resources.h>
 #include <StringList.h>
 #include <SoundPlayer.h>
-
-#include <cmath>
 
 #include <string.h>
 

--- a/src/pcm/PcmMix.cxx
+++ b/src/pcm/PcmMix.cxx
@@ -22,10 +22,9 @@
 #include "Clamp.hxx"
 #include "Traits.hxx"
 #include "util/Clamp.hxx"
+#include "util/Math.hxx"
 
 #include "PcmDither.cxx" // including the .cxx file to get inlined templates
-
-#include <cmath>
 
 #include <assert.h>
 
@@ -225,7 +224,7 @@ pcm_mix(PcmDither &dither, void *buffer1, const void *buffer2, size_t size,
 	s = sin(M_PI_2 * portion1);
 	s *= s;
 
-	int vol1 = std::lround(s * PCM_VOLUME_1S);
+	int vol1 = lround(s * PCM_VOLUME_1S);
 	vol1 = Clamp<int>(vol1, 0, PCM_VOLUME_1S);
 
 	return pcm_add_vol(dither, buffer1, buffer2, size,

--- a/src/player/CrossFade.cxx
+++ b/src/player/CrossFade.cxx
@@ -23,9 +23,8 @@
 #include "AudioFormat.hxx"
 #include "util/NumberParser.hxx"
 #include "util/Domain.hxx"
+#include "util/Math.hxx"
 #include "Log.hxx"
-
-#include <cmath>
 
 #include <assert.h>
 
@@ -112,7 +111,7 @@ CrossFadeSettings::Calculate(SignedSongTime total_time,
 
 	if (mixramp_delay <= FloatDuration::zero() ||
 	    !mixramp_start || !mixramp_prev_end) {
-		chunks = std::lround(duration / chunk_duration);
+		chunks = lround(duration / chunk_duration);
 	} else {
 		/* Calculate mixramp overlap. */
 		const auto mixramp_overlap_current =

--- a/src/util/Math.hxx
+++ b/src/util/Math.hxx
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Max Kellermann <max.kellermann@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the
+ * distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * FOUNDATION OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MATH_HXX
+#define MATH_HXX
+
+#if (defined(__GLIBCPP__) || defined(__GLIBCXX__)) && !defined(_GLIBCXX_USE_C99_MATH)
+#include <boost/math/special_functions/round.hpp>
+using boost::math::lround;
+#else
+#include <cmath>
+using std::lround;
+#endif
+
+#endif


### PR DESCRIPTION
This is the case with uClibc-ng currently.

Signed-off-by: Rosen Penev <rosenp@gmail.com>
(cherry picked from commit 769cd0ee9f0cf8ceb026aa751b5d4a390bb5dbdc)
(changed define to match master)