### PR TITLE
replace exit and _exit with std variants

### DIFF
--- a/src/CommandLine.cxx
+++ b/src/CommandLine.cxx
@@ -66,9 +66,6 @@
 #include "archive/ArchivePlugin.hxx"
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
-
 namespace {
 #ifdef _WIN32
 constexpr auto CONFIG_FILE_LOCATION = Path::FromFS(PATH_LITERAL("mpd\\mpd.conf"));
@@ -256,7 +253,7 @@ static void version()
 #endif
 	       "\n");
 
-	exit(EXIT_SUCCESS);
+	std::exit(EXIT_SUCCESS);
 }
 
 static void PrintOption(const OptionDef &opt)
@@ -286,7 +283,7 @@ static void help()
 		if(i.HasDescription()) // hide hidden options from help print
 			PrintOption(i);
 
-	exit(EXIT_SUCCESS);
+	std::exit(EXIT_SUCCESS);
 }
 
 class ConfigLoader

--- a/src/system/FatalError.cxx
+++ b/src/system/FatalError.cxx
@@ -22,11 +22,9 @@
 #include "LogV.hxx"
 
 #include <cstdarg>
-
-#include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -40,7 +38,7 @@ static constexpr Domain fatal_error_domain("fatal_error");
 static void
 Abort()
 {
-	_exit(EXIT_FAILURE);
+	std::_Exit(EXIT_FAILURE);
 }
 
 void
@@ -82,7 +80,7 @@ FatalSystemError(const char *msg)
 #ifdef _WIN32
 	FatalSystemError(msg, GetLastError());
 #else
-	const char *system_error = strerror(errno);
+	auto system_error = std::strerror(errno);
 	FormatError(fatal_error_domain, "%s: %s", msg, system_error);
 	Abort();
 #endif
@@ -94,7 +92,7 @@ FormatFatalSystemError(const char *fmt, ...)
 	char buffer[1024];
 	std::va_list ap;
 	va_start(ap, fmt);
-	vsnprintf(buffer, sizeof(buffer), fmt, ap);
+	std::vsnprintf(buffer, sizeof(buffer), fmt, ap);
 	va_end(ap);
 
 	FatalSystemError(buffer);

--- a/src/unix/Daemon.cxx
+++ b/src/unix/Daemon.cxx
@@ -27,8 +27,6 @@
 #include "PidFile.hxx"
 #endif
 
-#include <stdlib.h>
-#include <unistd.h>
 #include <fcntl.h>
 
 #ifndef _WIN32
@@ -81,7 +79,7 @@ daemonize_kill()
 	if (kill(pid, SIGTERM) < 0)
 		throw FormatErrno("unable to kill process %i", int(pid));
 
-	exit(EXIT_SUCCESS);
+	std::exit(EXIT_SUCCESS);
 }
 
 void
@@ -180,7 +178,7 @@ daemonize_begin(bool detach)
 	if (nbytes == (ssize_t)sizeof(result)) {
 		/* the child process was successful */
 		pidfile2.Write(pid);
-		exit(EXIT_SUCCESS);
+		std::exit(EXIT_SUCCESS);
 	}
 
 	/* something bad happened in the child process */
@@ -196,7 +194,7 @@ daemonize_begin(bool detach)
 		throw FormatErrno("MPD died from signal %d%s", WTERMSIG(status),
 				  WCOREDUMP(status) ? " (core dumped)" : "");
 
-	exit(WEXITSTATUS(status));
+	std::exit(WEXITSTATUS(status));
 }
 
 void

--- a/src/util/Alloc.cxx
+++ b/src/util/Alloc.cxx
@@ -21,8 +21,8 @@
 #include "Alloc.hxx"
 #include "ConcatString.hxx"
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstring>
+
 #include <unistd.h>
 
 [[noreturn]]
@@ -30,13 +30,13 @@ static void
 oom()
 {
 	(void)write(STDERR_FILENO, "Out of memory\n", 14);
-	_exit(1);
+	std::_Exit(1);
 }
 
 void *
 xalloc(size_t size)
 {
-	void *p = malloc(size);
+	auto p = std::malloc(size);
 	if (gcc_unlikely(p == nullptr))
 		oom();
 
@@ -46,8 +46,8 @@ xalloc(size_t size)
 void *
 xmemdup(const void *s, size_t size)
 {
-	void *p = xalloc(size);
-	memcpy(p, s, size);
+	auto p = xalloc(size);
+	std::memcpy(p, s, size);
 	return p;
 }
 
@@ -69,8 +69,8 @@ xstrndup(const char *s, size_t n)
 	if (gcc_unlikely(p == nullptr))
 		oom();
 #else
-	char *p = (char *)xalloc(n + 1);
-	memcpy(p, s, n);
+	auto p = (char *)xalloc(n + 1);
+	std::memcpy(p, s, n);
 	p[n] = 0;
 #endif
 
@@ -87,7 +87,7 @@ t_xstrcatdup(Args&&... args)
 	size_t lengths[n];
 	const size_t total = FillLengths(lengths, args...);
 
-	char *p = (char *)xalloc(total + 1);
+	auto p = (char *)xalloc(total + 1);
 	*StringCat(p, lengths, args...) = 0;
 	return p;
 }


### PR DESCRIPTION
_exit and std::_Exit are identical, expect the latter is standard C++.

Added several functions to the std namespace as a result of headers.

Signed-off-by: Rosen Penev <rosenp@gmail.com>