### PR TITLE
[cppcheck] convert several functions to use std::any_of

### DIFF
--- a/src/command/FileCommands.cxx
+++ b/src/command/FileCommands.cxx
@@ -127,12 +127,7 @@ gcc_pure
 static bool
 IsValidValue(const StringView s) noexcept
 {
-	for (const char ch : s) {
-		if ((unsigned char)ch < 0x20)
-			return false;
-	}
-
-	return true;
+	return std::none_of(s.begin(), s.end(), [](const auto &ch) { return (unsigned char)ch < 0x20; });
 }
 
 class PrintCommentHandler final : public NullTagHandler {

--- a/src/input/InputPlugin.cxx
+++ b/src/input/InputPlugin.cxx
@@ -33,11 +33,8 @@ InputPlugin::SupportsUri(const char *uri) const noexcept
 			if (StringStartsWithIgnoreCase(uri, *i))
 				return true;
 	} else {
-		for (const auto& schema : protocols()) {
-			if (StringStartsWithIgnoreCase(uri, schema.c_str())){
-				return true;
-			}
-		}
+		return std::any_of(protocols().begin(), protocols().end(), [uri](const auto &schema)
+			{ return StringStartsWithIgnoreCase(uri, schema.c_str()); } );
 	}
 	return false;
 }

--- a/src/lib/nfs/Cancellable.hxx
+++ b/src/lib/nfs/Cancellable.hxx
@@ -113,11 +113,7 @@ public:
 #ifndef NDEBUG
 	gcc_pure
 	bool IsEmpty() const noexcept {
-		for (const auto &c : list)
-			if (!c.IsCancelled())
-				return false;
-
-		return true;
+		return std::all_of(list.begin(), list.end(), [](const auto &c) { return c.IsCancelled(); });
 	}
 #endif
 

--- a/src/output/MultipleOutputs.cxx
+++ b/src/output/MultipleOutputs.cxx
@@ -258,11 +258,8 @@ MultipleOutputs::Open(const AudioFormat audio_format)
 bool
 MultipleOutputs::IsChunkConsumed(const MusicChunk *chunk) const noexcept
 {
-	for (const auto &ao : outputs)
-		if (!ao->LockIsChunkConsumed(*chunk))
-			return false;
-
-	return true;
+	return std::all_of(outputs.begin(), outputs.end(), [chunk](const auto &ao) {
+		return ao->LockIsChunkConsumed(*chunk); });
 }
 
 unsigned

--- a/src/output/MultipleOutputs.hxx
+++ b/src/output/MultipleOutputs.hxx
@@ -28,6 +28,7 @@
 #include "Chrono.hxx"
 #include "util/Compiler.h"
 
+#include <algorithm>
 #include <cassert>
 #include <memory>
 #include <vector>
@@ -106,11 +107,7 @@ public:
 	 */
 	gcc_pure
 	bool IsDummy() const noexcept {
-		for (const auto &i : outputs)
-			if (!i->IsDummy())
-				return false;
-
-		return true;
+		return std::all_of(outputs.begin(), outputs.end(), [](const auto &i) { return i->IsDummy(); });
 	}
 
 	/**

--- a/src/song/AndSongFilter.cxx
+++ b/src/song/AndSongFilter.cxx
@@ -19,6 +19,8 @@
 
 #include "AndSongFilter.hxx"
 
+#include <algorithm>
+
 ISongFilterPtr
 AndSongFilter::Clone() const noexcept
 {
@@ -54,9 +56,5 @@ AndSongFilter::ToExpression() const noexcept
 bool
 AndSongFilter::Match(const LightSong &song) const noexcept
 {
-	for (const auto &i : items)
-		if (!i->Match(song))
-			return false;
-
-	return true;
+	return std::all_of(items.begin(), items.end(), [&song](const auto &i) { return i->Match(song); });
 }

--- a/src/tag/Builder.cxx
+++ b/src/tag/Builder.cxx
@@ -154,11 +154,7 @@ TagBuilder::CommitNew() noexcept
 bool
 TagBuilder::HasType(TagType type) const noexcept
 {
-	for (auto i : items)
-		if (i->type == type)
-			return true;
-
-	return false;
+	return std::any_of(items.begin(), items.end(), [type](const auto &i) { return i->type == type; });
 }
 
 void


### PR DESCRIPTION
std::any_of becomes constexpr in C++20. I'm not sure it results in better
performance.

Found with useStlAlgorithm

Signed-off-by: Rosen Penev <rosenp@gmail.com>