### PR TITLE
Math.hxx: move cmath include out of define

### DIFF
--- a/src/util/Math.hxx
+++ b/src/util/Math.hxx
@@ -30,6 +30,8 @@
 #ifndef MATH_HXX
 #define MATH_HXX
 
+#include <cmath>
+
 /*
  * C99 math can be optionally omitted with gcc's libstdc++.
  * Use boost if unavailable.
@@ -38,7 +40,6 @@
 #include <boost/math/special_functions/round.hpp>
 using boost::math::lround;
 #else
-#include <cmath>
 using std::lround;
 #endif
 


### PR DESCRIPTION
The _GLIBCXX_USE_C99_MATH macro is defined in glibcxx by c++config.h, which
gets included by every header. Which means a header needs to be present.