### PR TITLE
[0.21.x]Math.hxx: move cmath include out of define

### DIFF
--- a/src/util/Math.hxx
+++ b/src/util/Math.hxx
@@ -30,11 +30,16 @@
 #ifndef MATH_HXX
 #define MATH_HXX
 
+#include <cmath>
+
+/*
+ * C99 math can be optionally omitted with gcc's libstdc++.
+ * Use boost if unavailable.
+ */
 #if (defined(__GLIBCPP__) || defined(__GLIBCXX__)) && !defined(_GLIBCXX_USE_C99_MATH)
 #include <boost/math/special_functions/round.hpp>
 using boost::math::lround;
 #else
-#include <cmath>
 using std::lround;
 #endif
 


### PR DESCRIPTION
The _GLIBCXX_USE_C99_MATH macro is defined in glibcxx by c++config.h, which
gets included by every header. Which means a header needs to be present.

(cherry picked from commit 79e9aff3382d8b7521318c44835a6dd6b284e2c1)