### PR TITLE
doc: Document required order of currentsong response

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -389,7 +389,9 @@ Querying :program:`MPD`'s status
 
 :command:`currentsong`
     Displays the song info of the current song (same song that
-    is identified in status).
+    is identified in status). Information about the current song
+    is represented by key-value pairs, one on each line. The first
+    pair must be the `file` key-value pair.
 
 .. _command_idle:
 


### PR DESCRIPTION
As per #658, you are actually interested in improvements of the protocol specification. Therefore, I thought you might be interested in documentation this edge case regarding the currentsong response format. 

---

The parser implemented in libmpdclient requires the first key-value pair
of the server response to be the file pair. This is due to the fact that
libmpdclient scan pairs sequentially and first attempts to extract the
file pair before parsing the currentsong response further. See:

https://github.com/MusicPlayerDaemon/libmpdclient/blob/5c751a761ec9f71a43ee0e41cfff3208f31a58b8/src/song.c#L559-L563

Meta data encoded as pairs in the currentsong response will be ignored
if they are placed before the file pair in the response.