### PR TITLE
Math.hxx: fix wrong macro name

### DIFF
--- a/src/util/Math.hxx
+++ b/src/util/Math.hxx
@@ -36,7 +36,7 @@
  * C99 math can be optionally omitted with gcc's libstdc++.
  * Use boost if unavailable.
  */
-#if (defined(__GLIBCPP__) || defined(__GLIBCXX__)) && !defined(_GLIBCXX_USE_C99_MATH)
+#if (defined(__GLIBCPP__) || defined(__GLIBCXX__)) && !defined(_GLIBCXX_USE_C99_MATH_TR1)
 #include <boost/math/special_functions/round.hpp>
 using boost::math::lround;
 #else


### PR DESCRIPTION
_GLIBCXX_USE_C99_MATH_TR1 is the correct one.

_GLIBCXX_USE_C99_MATH is always defined.

This was a very stupid oversight by me. This now matches the define used in boost: https://github.com/boostorg/math/blob/develop/include/boost/math/tools/roots.hpp#L888