### PR TITLE
decoder/sidplay: support new song length format with libsidplayfp 2.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,7 @@ ver 0.22 (not yet released)
   - mad: remove option "gapless", always do gapless
   - sidplay: add option "default_genre"
   - sidplay: map SID name field to "Album" tag
+  - sidplay: add support for new song length format with libsidplayfp 2.0
   - vorbis, opus: improve seeking accuracy
 * playlist
   - flac: support reading CUE sheets from remote FLAC files

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -475,7 +475,7 @@ C64 SID decoder based on `libsidplayfp <https://sourceforge.net/projects/sidplay
    * - Setting
      - Description
    * - **songlength_database PATH**
-     - Location of your songlengths file, as distributed with the HVSC. The sidplay plugin checks this for matching MD5 fingerprints. See http://www.hvsc.c64.org/download/C64Music/DOCUMENTS/Songlengths.faq.
+     - Location of your songlengths file, as distributed with the HVSC. The sidplay plugin checks this for matching MD5 fingerprints. See http://www.hvsc.c64.org/download/C64Music/DOCUMENTS/Songlengths.faq. New songlength format support requires libsidplayfp 2.0 or later.
    * - **default_songlength SECONDS**
      - This is the default playing time in seconds for songs not in the songlength database, or in case you're not using a database. A value of 0 means play indefinitely.
    * - **default_genre GENRE**

--- a/src/decoder/plugins/SidplayDecoderPlugin.cxx
+++ b/src/decoder/plugins/SidplayDecoderPlugin.cxx
@@ -219,11 +219,24 @@ get_song_length(T &tune) noexcept
 	if (sidplay_global->songlength_database == nullptr)
 		return SignedSongTime::Negative();
 
-	const auto length = sidplay_global->songlength_database->length(tune);
-	if (length < 0)
+#if LIBSIDPLAYFP_VERSION_MAJ >= 2
+	const auto lengthms =
+		sidplay_global->songlength_database->lengthMs(tune);
+	/* check for new song length format since HVSC#68 or later */
+	if (lengthms < 0)
+	{
+#endif
+		/* old song lenghth format */
+		const auto length =
+			sidplay_global->songlength_database->length(tune);
+		if (length >= 0)
+			return SignedSongTime::FromS(length);
 		return SignedSongTime::Negative();
 
-	return SignedSongTime::FromS(length);
+#if LIBSIDPLAYFP_VERSION_MAJ >= 2
+	}
+	return SignedSongTime::FromMS(lengthms);
+#endif
 }
 
 static void


### PR DESCRIPTION
High Voltage SID Collection introduces new song length database. PR adds support for new libsidplayfp 2.0 feature while being compatible to older versions of library and format. No need to convert the database any longer :)