### PR TITLE
remove std::bind usage as much as possible

### DIFF
--- a/src/db/Count.cxx
+++ b/src/db/Count.cxx
@@ -89,10 +89,8 @@ GroupCountVisitor(TagCountMap &map, TagType group,
 		  const LightSong &song) noexcept
 {
 	const Tag &tag = song.tag;
-	VisitTagWithFallbackOrEmpty(tag, group,
-				    std::bind(CollectGroupCounts, std::ref(map),
-					      std::cref(tag),
-					      std::placeholders::_1));
+	VisitTagWithFallbackOrEmpty(tag, group, [&](const auto &val)
+		{ return CollectGroupCounts(map, tag, val);  });
 }
 
 void
@@ -109,9 +107,9 @@ PrintSongCount(Response &r, const Partition &partition, const char *name,
 
 		SearchStats stats;
 
-		using namespace std::placeholders;
-		const auto f = std::bind(stats_visitor_song, std::ref(stats),
-					 _1);
+		const auto f = [&](const auto &song)
+			{ return stats_visitor_song(stats, song); };
+
 		db.Visit(selection, f);
 
 		PrintSearchStats(r, stats);
@@ -121,9 +119,9 @@ PrintSongCount(Response &r, const Partition &partition, const char *name,
 
 		TagCountMap map;
 
-		using namespace std::placeholders;
-		const auto f = std::bind(GroupCountVisitor, std::ref(map),
-					 group, _1);
+		const auto f = [&map,group](const auto &song)
+			{ return GroupCountVisitor(map, group, song); };
+
 		db.Visit(selection, f);
 
 		Print(r, group, map);

--- a/src/db/DatabasePlaylist.cxx
+++ b/src/db/DatabasePlaylist.cxx
@@ -38,7 +38,6 @@ search_add_to_playlist(const Database &db, const Storage *storage,
 		       const char *playlist_path_utf8,
 		       const DatabaseSelection &selection)
 {
-	using namespace std::placeholders;
 	const auto f = [=](auto && arg1) { return AddSong(storage, playlist_path_utf8, arg1); };
 	db.Visit(selection, f);
 }

--- a/src/db/DatabasePrint.cxx
+++ b/src/db/DatabasePrint.cxx
@@ -146,16 +146,23 @@ db_selection_print(Response &r, Partition &partition,
 {
 	const Database &db = partition.GetDatabaseOrThrow();
 
-	using namespace std::placeholders;
 	const auto d = selection.filter == nullptr
-		? std::bind(full ? PrintDirectoryFull : PrintDirectoryBrief,
-			    std::ref(r), base, _1)
+		? [&,base](const auto &dir)
+			{ return full ?
+				PrintDirectoryFull(r, base, dir) :
+				PrintDirectoryBrief(r, base, dir); }
 		: VisitDirectory();
-	VisitSong s = std::bind(full ? PrintSongFull : PrintSongBrief,
-				std::ref(r), base, _1);
+
+	VisitSong s = [&,base](const auto &song)
+		{ return full ?
+			PrintSongFull(r, base, song) :
+			PrintSongBrief(r, base, song); };
+
 	const auto p = selection.filter == nullptr
-		? std::bind(full ? PrintPlaylistFull : PrintPlaylistBrief,
-			    std::ref(r), base, _1, _2)
+		? [&,base](const auto &playlist, const auto &dir)
+			{ return full ?
+				PrintPlaylistFull(r, base, playlist, dir) :
+				PrintPlaylistBrief(r, base, playlist, dir); }
 		: VisitPlaylist();
 
 	db.Visit(selection, d, s, p);
@@ -175,9 +182,9 @@ PrintSongUris(Response &r, Partition &partition,
 
 	const DatabaseSelection selection("", true, filter);
 
-	using namespace std::placeholders;
-	const auto f = std::bind(PrintSongURIVisitor,
-				 std::ref(r), _1);
+	const auto f = [&](const auto &song)
+		{ return PrintSongURIVisitor(r, song); };
+
 	db.Visit(selection, f);
 }
 

--- a/src/db/DatabaseQueue.cxx
+++ b/src/db/DatabaseQueue.cxx
@@ -40,7 +40,7 @@ AddFromDatabase(Partition &partition, const DatabaseSelection &selection)
 {
 	const Database &db = partition.instance.GetDatabaseOrThrow();
 
-	using namespace std::placeholders;
-	const auto f = std::bind(AddToQueue, std::ref(partition), _1);
+	const auto f = [&](const auto &song)
+		{ return AddToQueue(partition, song); };
 	db.Visit(selection, f);
 }

--- a/src/db/Helpers.cxx
+++ b/src/db/Helpers.cxx
@@ -75,10 +75,9 @@ GetStats(const Database &db, const DatabaseSelection &selection)
 	stats.Clear();
 
 	StringSet artists, albums;
-	using namespace std::placeholders;
-	const auto f = std::bind(StatsVisitSong,
-				 std::ref(stats), std::ref(artists),
-				 std::ref(albums), _1);
+	const auto f = [&](const auto &song)
+		{ return StatsVisitSong(stats, artists, albums, song); };
+
 	db.Visit(selection, f);
 
 	stats.artist_count = artists.size();

--- a/src/db/plugins/simple/Mount.cxx
+++ b/src/db/plugins/simple/Mount.cxx
@@ -70,22 +70,20 @@ WalkMount(std::string_view base, const Database &db,
 	  const VisitDirectory &visit_directory, const VisitSong &visit_song,
 	  const VisitPlaylist &visit_playlist)
 {
-	using namespace std::placeholders;
-
 	VisitDirectory vd;
 	if (visit_directory)
-		vd = std::bind(PrefixVisitDirectory,
-			       base, std::ref(visit_directory), _1);
+		vd = [base,&visit_directory](const auto &dir)
+			{ return PrefixVisitDirectory(base, visit_directory, dir); };
 
 	VisitSong vs;
 	if (visit_song)
-		vs = std::bind(PrefixVisitSong,
-			       base, std::ref(visit_song), _1);
+		vs = [base,&visit_song](const auto &song)
+			{ return PrefixVisitSong(base, visit_song, song); };
 
 	VisitPlaylist vp;
 	if (visit_playlist)
-		vp = std::bind(PrefixVisitPlaylist,
-			       base, std::ref(visit_playlist), _1, _2);
+		vp = [base,&visit_playlist](const auto &playlist, const auto &dir)
+			{ return PrefixVisitPlaylist(base, visit_playlist, playlist, dir); };
 
 	DatabaseSelection selection(old_selection);
 	selection.uri = uri;

--- a/src/decoder/DecoderPrint.cxx
+++ b/src/decoder/DecoderPrint.cxx
@@ -47,7 +47,7 @@ decoder_plugin_print(Response &r,
 void
 decoder_list_print(Response &r)
 {
-	using namespace std::placeholders;
-	const auto f = std::bind(decoder_plugin_print, std::ref(r), _1);
+	const auto f = [&](const auto &plugin)
+		{ return decoder_plugin_print(r, plugin); };
 	decoder_plugins_for_each_enabled(f);
 }

--- a/src/decoder/Thread.cxx
+++ b/src/decoder/Thread.cxx
@@ -183,11 +183,9 @@ decoder_run_stream_locked(DecoderBridge &bridge, InputStream &is,
 	UriSuffixBuffer suffix_buffer;
 	const char *const suffix = uri_get_suffix(uri, suffix_buffer);
 
-	using namespace std::placeholders;
-	const auto f = std::bind(decoder_run_stream_plugin,
-				 std::ref(bridge), std::ref(is), std::ref(lock),
-				 suffix,
-				 _1, std::ref(tried_r));
+	const auto f = [&,suffix](const auto &plugin)
+		{ return decoder_run_stream_plugin(bridge, is, lock, suffix, plugin, tried_r); };
+
 	return decoder_plugins_try(f);
 }
 

--- a/src/pcm/Dop.cxx
+++ b/src/pcm/Dop.cxx
@@ -91,7 +91,6 @@ DsdToDopConverter::Open(unsigned _channels) noexcept
 ConstBuffer<uint32_t>
 DsdToDopConverter::Convert(ConstBuffer<uint8_t> src) noexcept
 {
-	using namespace std::placeholders;
 	return rest_buffer.Process<uint32_t>(buffer, src, 2 * channels,
-					     [=](auto && arg1, auto && arg2, auto && arg3) { return DsdToDop(arg1, arg2, arg3, channels); });
+		[=](auto && arg1, auto && arg2, auto && arg3) { return DsdToDop(arg1, arg2, arg3, channels); });
 }

--- a/src/pcm/Dsd16.cxx
+++ b/src/pcm/Dsd16.cxx
@@ -63,7 +63,6 @@ Dsd16Converter::Open(unsigned _channels) noexcept
 ConstBuffer<uint16_t>
 Dsd16Converter::Convert(ConstBuffer<uint8_t> src) noexcept
 {
-	using namespace std::placeholders;
 	return rest_buffer.Process<uint16_t>(buffer, src, channels,
 					     [=](auto && arg1, auto && arg2, auto && arg3) { return Dsd8To16(arg1, arg2, arg3, channels); });
 }

--- a/src/pcm/Dsd32.cxx
+++ b/src/pcm/Dsd32.cxx
@@ -65,7 +65,6 @@ Dsd32Converter::Open(unsigned _channels) noexcept
 ConstBuffer<uint32_t>
 Dsd32Converter::Convert(ConstBuffer<uint8_t> src) noexcept
 {
-	using namespace std::placeholders;
 	return rest_buffer.Process<uint32_t>(buffer, src, channels,
 					     [=](auto && arg1, auto && arg2, auto && arg3) { return Dsd8To32(arg1, arg2, arg3, channels); });
 }


### PR DESCRIPTION
Reduces unstripped size. stripped size is the same.

Also took the time to remove using std::placeholders.

Signed-off-by: Rosen Penev <rosenp@gmail.com>