### PR TITLE
move ffmpeg include below the C++ ones

### DIFF
--- a/src/lib/ffmpeg/Filter.hxx
+++ b/src/lib/ffmpeg/Filter.hxx
@@ -22,12 +22,12 @@
 
 #include "Error.hxx"
 
+#include <new>
+#include <utility>
+
 extern "C" {
 #include <libavfilter/avfilter.h>
 }
-
-#include <new>
-#include <utility>
 
 struct AudioFormat;
 


### PR DESCRIPTION
Fixes the following error with libcxx:

/usr/include/ffmpeg/libavutil/common.h:30:2: error: missing -D__STDC_CONSTANT_MACROS / #define __STDC_CONSTANT_MACROS

Signed-off-by: Rosen Penev <rosenp@gmail.com>