### PR TITLE
macos: change CI xcode to 10.3 for c++17 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
         - MATRIX_EVAL="export CC='ccache gcc-8' CXX='ccache g++-8' LDFLAGS=-fuse-ld=gold PATH=\$HOME/.local/bin:\$PATH"
 
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.3
       addons:
         homebrew:
           packages:


### PR DESCRIPTION
c++17 is offered by default with Xcode 10
https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes