### PR TITLE
doc: document neighbor and mount idle subsystems

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -413,6 +413,8 @@ Querying :program:`MPD`'s status
     - ``sticker``: the sticker database has been modified.
     - ``subscription``: a client has subscribed or unsubscribed to a channel
     - ``message``: a message was received on a channel this client is subscribed to; this event is only emitted when the queue is empty
+    - ``neighbor``: a neighbor was found or lost
+    - ``mount``: the mount list has changed
 
     Change events accumulate, even while the connection is not in
     "idle" mode; no events gets lost while the client is doing


### PR DESCRIPTION
I've used the descriptions from: https://github.com/MusicPlayerDaemon/MPD/blob/759f4231d257122cf9dba858ca04de5f835c0859/src/IdleFlags.hxx#L64-L68.