### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:focal
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install -y \
+    g++ \
+    meson \
+    libpcre3-dev \
+    libmad0-dev libmpg123-dev libid3tag0-dev \
+    libflac-dev libvorbis-dev libopus-dev \
+    libadplug-dev libaudiofile-dev libsndfile1-dev libfaad-dev \
+    libfluidsynth-dev libgme-dev libmikmod2-dev libmodplug-dev \
+    libmpcdec-dev libwavpack-dev libwildmidi-dev \
+    libsidplay2-dev libsidutils-dev libresid-builder-dev \
+    libavcodec-dev libavformat-dev \
+    libmp3lame-dev libtwolame-dev libshine-dev \
+    libsamplerate0-dev libsoxr-dev \
+    libbz2-dev libcdio-paranoia-dev libiso9660-dev libmms-dev \
+    libzzip-dev \
+    libcurl4-gnutls-dev libyajl-dev libexpat-dev \
+    libasound2-dev libao-dev libjack-jackd2-dev libopenal-dev \
+    libpulse-dev libshout3-dev \
+    libsndio-dev \
+    libmpdclient-dev \
+    libnfs-dev libsmbclient-dev \
+    libupnp-dev \
+    libavahi-client-dev \
+    libsqlite3-dev \
+    libsystemd-dev \
+    libgtest-dev \
+    libboost-dev \
+    libicu-dev \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
+COPY . /usr/src/mpd/
+WORKDIR /usr/src/mpd/
+
+RUN \
+  meson . output/release --buildtype=debugoptimized -Db_ndebug=true && \
+  meson configure output/release
+
+RUN \
+  ninja -C output/release install
+
+RUN mpd --version
+
+ENTRYPOINT [ "mpd", "--no-daemon" ]


### PR DESCRIPTION
Add Dockerfile to enable image building. Just install deps, add code and build as per docs. Entrypoint calls `mpd` command (in foreground as per Docker requirement).
Built on Ubuntu Focal, which features Boost 1.71 (as opposed to Debian Buster, which ships 1.69 and outputs warnings).
As of now, it's just a binary build image, with no config other than available on the source build (but not even used by default). It aims to be 'as less opinionated as possible' by now. It is targeted to developers and to help with development, so it has some implied tradeoffs:
* Fat version, not as slim as it could be (ie. debug symbols, etc)
* Not configured (you need to add/mount your own config) 
* With more advanced knowledge of the build tools, build time on repeated builds can be shortened by taking advantage of Docker's build layer caching (ie, each modified file invalidates previous builds cache from the step it's added onwards).
Obviously, this is subject to feedback and community needs. It can even end as a final distribution method, with slimmer and more ready-to-go images. But being such unopinionanted allows to derive more specific images for other use cases, ie. a custom configured image based on this one. Also, it can be used as an automatic 'latest head' build image using Docker Hub's [Automated Build](https://docs.docker.com/docker-hub/builds/) (think of it as a 'daily build'). 

Build:

```
$ docker build -t mpd .
```

Run:

```
$ docker run --rm -it --device /dev/snd -p 6600:6600 -v [YOUR_CONF_FILE]:/etc/mpd.conf:ro -v [YOUR_MUSIC_DIR]:/data/music/:ro mpd --verbose [options...]
```

FYI, there's a still quicker to test, already built image [on my Docker Hub](https://hub.docker.com/r/pataquets/mpd-src). Test it by running:

```
$ docker run --rm -it --device /dev/snd -p 6600:6600 -v [YOUR_CONF_FILE]:/etc/mpd.conf:ro -v [YOUR_MUSIC_DIR]:/data/music/:ro pataquets/mpd-src:focal --verbose [options...]
```

Using `--rm` instead of `-d` makes the container not go background and it to be deleted after stop. Should stop by `CTRL+C`'ing it.
Note: use `--net=host` for sharing Docker host network stack instead of port mapping `-p 6600:6600` if you want UPnP neighbor discovery to work.

I guess it may be something to add that I could miss, but merging can provide a base image (with hopefully an [Automated Build](https://docs.docker.com/docker-hub/builds/)) in the meantime for others to base on and contribute and improve further. But that can be dealt with in different issues later.