### PR TITLE
lib/icu: fix build without libc iconv support

### DIFF
--- a/src/lib/icu/meson.build
+++ b/src/lib/icu/meson.build
@@ -18,7 +18,7 @@ if icu_dep.found()
     'Init.cxx',
   ]
 elif not get_option('iconv').disabled()
-  have_iconv = compiler.has_function('iconv')
+  have_iconv = compiler.has_function('iconv', prefix : '#include <iconv.h>')
   conf.set('HAVE_ICONV', have_iconv)
   if not have_iconv and get_option('iconv').enabled()
     error('iconv() not available')


### PR DESCRIPTION
Need to check for it in iconv.h. Otherwise meson prefixes a __builtin variant in the check.