### PR TITLE
icu/meson: link against iconv when used externally

### DIFF
--- a/src/lib/icu/meson.build
+++ b/src/lib/icu/meson.build
@@ -18,8 +18,18 @@ if icu_dep.found()
     'Init.cxx',
   ]
 elif not get_option('iconv').disabled()
-  have_iconv = compiler.has_function('iconv', prefix : '#include <iconv.h>')
-  conf.set('HAVE_ICONV', have_iconv)
+  have_iconv = c_compiler.has_header_symbol('iconv.h', 'iconv')
+  if have_iconv
+    libiconv = c_compiler.find_library('iconv', required : false)
+    conf.set('HAVE_ICONV', have_iconv)
+    libiconv_dep = static_library('iconv', icu_sources, include_directories: inc, dependencies: libiconv)
+    icu_dep = declare_dependency(link_with: libiconv_dep, dependencies: util_dep)
+  endif
+  if not have_iconv and c_compiler.has_function('iconv')
+    libiconv = []
+    have_iconv = true
+    conf.set('HAVE_ICONV', have_iconv)
+  endif
   if not have_iconv and get_option('iconv').enabled()
     error('iconv() not available')
   endif


### PR DESCRIPTION
This basically adds -liconv to LDFLAGS, fixing a linking issue when
iconv is missing in the libc.

The previous commit fixed finding iconv but did not fix linking.

Signed-off-by: Rosen Penev <rosenp@gmail.com>