### PR TITLE
doc/user.rst: document include_optional directive

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -219,6 +219,13 @@ another file; the given file name is relative to the current file:
 
   include "other.conf"
 
+You can use :code:`include_optional` instead if you want the included file
+to be optional; the directive will be ignored if the file does not exist:
+
+.. code-block:: none
+
+  include_optional "may_not_exist.conf"
+
 Configuring the music directory
 -------------------------------
 


### PR DESCRIPTION
Taken from [here](https://github.com/MusicPlayerDaemon/MPD/commit/09f743dc1a03217186fbb3408bffacee659b442c#diff-b121d9954d5394bce0c50b7cbbb5bd50R422-R428), seems it was lost during conversion from DocBook.