### PR TITLE
Removed duplicate check for negative song time

### DIFF
--- a/src/queue/PlaylistControl.cxx
+++ b/src/queue/PlaylistControl.cxx
@@ -276,8 +276,6 @@ playlist::SeekCurrent(PlayerControl &pc,
 			throw PlaylistError::NotPlaying();
 
 		seek_time += status.elapsed_time;
-		if (seek_time.IsNegative())
-			seek_time = SignedSongTime::zero();
 	}
 
 	if (seek_time.IsNegative())


### PR DESCRIPTION
removal of duplicate code, i.e., check and correct only once, if seeking results in negative positions