### PR TITLE
remove GCC5 hacks

### DIFF
--- a/src/lib/upnp/ContentDirectoryService.cxx
+++ b/src/lib/upnp/ContentDirectoryService.cxx
@@ -69,9 +69,7 @@ ContentDirectoryService::getSearchCapabilities(UpnpClient_Handle hdl) const
 	const char *s = ixmlwrap::getFirstElementValue(response.get(),
 						       "SearchCaps");
 	if (s == nullptr || *s == 0)
-		/* we could just "return {}" here, but GCC 5 doesn't
-		   understand that */
-		return std::forward_list<std::string>();
+		return {};
 
 	std::forward_list<std::string> result;
 	for (const auto &i : IterableSplitString(s, ','))

--- a/src/net/IPv6Address.hxx
+++ b/src/net/IPv6Address.hxx
@@ -178,7 +178,7 @@ public:
 	/**
 	 * Is this an IPv4 address mapped inside struct sockaddr_in6?
 	 */
-#if defined(__linux__) && !GCC_OLDER_THAN(5,0)
+#if defined(__linux__)
 	constexpr
 #endif
 	bool IsV4Mapped() const noexcept {


### PR DESCRIPTION
GCC5 cannot build mpd.

Signed-off-by: Rosen Penev <rosenp@gmail.com>