### PR TITLE
Support opus header gain

### DIFF
--- a/src/decoder/plugins/OpusDecoderPlugin.cxx
+++ b/src/decoder/plugins/OpusDecoderPlugin.cxx
@@ -76,6 +76,12 @@ class MPDOpusDecoder final : public OggDecoder {
 	opus_int16 *output_buffer = nullptr;
 
 	/**
+	 * The output gain from the Opus header. Initialized by
+	 * OnOggBeginning().
+	 */
+	signed output_gain;
+
+	/**
 	 * The pre-skip value from the Opus header.  Initialized by
 	 * OnOggBeginning().
 	 */
@@ -164,7 +170,7 @@ MPDOpusDecoder::OnOggBeginning(const ogg_packet &packet)
 		throw std::runtime_error("BOS packet must be OpusHead");
 
 	unsigned channels;
-	if (!ScanOpusHeader(packet.packet, packet.bytes, channels, pre_skip) ||
+	if (!ScanOpusHeader(packet.packet, packet.bytes, channels, output_gain, pre_skip) ||
 	    !audio_valid_channel_count(channels))
 		throw std::runtime_error("Malformed BOS packet");
 
@@ -238,6 +244,15 @@ MPDOpusDecoder::HandleTags(const ogg_packet &packet)
 {
 	ReplayGainInfo rgi;
 	rgi.Clear();
+
+	/**
+	 * Output gain is a Q7.8 fixed point number in dB that should be,
+	 * applied unconditionally, but is often used specifically for
+	 * ReplayGain. Add 5dB to compensate for the different
+	 * reference levels between ReplayGain (89dB) and EBU R128 (-23 LUFS).
+	 */
+	rgi.track.gain = float(output_gain) / 256.0f + 5;
+	rgi.album.gain = float(output_gain) / 256.0f + 5;
 
 	TagBuilder tag_builder;
 	AddTagHandler h(tag_builder);
@@ -384,14 +399,14 @@ mpd_opus_stream_decode(DecoderClient &client,
 
 bool
 ReadAndParseOpusHead(OggSyncState &sync, OggStreamState &stream,
-		     unsigned &channels, unsigned &pre_skip)
+		     unsigned &channels, signed &output_gain, unsigned &pre_skip)
 {
 	ogg_packet packet;
 
 	return OggReadPacket(sync, stream, packet) && packet.b_o_s &&
 		IsOpusHead(packet) &&
 		ScanOpusHeader(packet.packet, packet.bytes, channels,
-			       pre_skip) &&
+			       output_gain, pre_skip) &&
 		audio_valid_channel_count(channels);
 }
 
@@ -436,7 +451,8 @@ mpd_opus_scan_stream(InputStream &is, TagHandler &handler)
 	OggStreamState os(first_page);
 
 	unsigned channels, pre_skip;
-	if (!ReadAndParseOpusHead(oy, os, channels, pre_skip) ||
+	signed output_gain;
+	if (!ReadAndParseOpusHead(oy, os, channels, output_gain, pre_skip) ||
 	    !ReadAndVisitOpusTags(oy, os, handler))
 		return false;
 

--- a/src/decoder/plugins/OpusHead.cxx
+++ b/src/decoder/plugins/OpusHead.cxx
@@ -27,7 +27,7 @@ struct OpusHead {
 	uint8_t version, channels;
 	uint16_t pre_skip;
 	uint32_t sample_rate;
-	int16_t output_gain;
+	uint16_t output_gain;
 	uint8_t channel_mapping;
 };
 
@@ -39,8 +39,10 @@ ScanOpusHeader(const void *data, size_t size, unsigned &channels_r,
 	if (size < 19 || (h->version & 0xf0) != 0)
 		return false;
 
+	uint16_t gain_bits = FromLE16(h->output_gain);
+	output_gain_r = (gain_bits & 0x8000) ? gain_bits - 0x10000 : gain_bits;
+
 	channels_r = h->channels;
-	output_gain_r = h->output_gain;
 	pre_skip_r = FromLE16(h->pre_skip);
 	return true;
 }

--- a/src/decoder/plugins/OpusHead.cxx
+++ b/src/decoder/plugins/OpusHead.cxx
@@ -27,19 +27,20 @@ struct OpusHead {
 	uint8_t version, channels;
 	uint16_t pre_skip;
 	uint32_t sample_rate;
-	uint16_t output_gain;
+	int16_t output_gain;
 	uint8_t channel_mapping;
 };
 
 bool
 ScanOpusHeader(const void *data, size_t size, unsigned &channels_r,
-	       unsigned &pre_skip_r)
+	       signed &output_gain_r, unsigned &pre_skip_r)
 {
 	const auto *h = (const OpusHead *)data;
 	if (size < 19 || (h->version & 0xf0) != 0)
 		return false;
 
 	channels_r = h->channels;
+	output_gain_r = h->output_gain;
 	pre_skip_r = FromLE16(h->pre_skip);
 	return true;
 }

--- a/src/decoder/plugins/OpusHead.hxx
+++ b/src/decoder/plugins/OpusHead.hxx
@@ -24,6 +24,6 @@
 
 bool
 ScanOpusHeader(const void *data, size_t size, unsigned &channels_r,
-	       unsigned &pre_skip_r);
+	       signed &output_gain_r, unsigned &pre_skip_r);
 
 #endif

--- a/src/decoder/plugins/OpusTags.cxx
+++ b/src/decoder/plugins/OpusTags.cxx
@@ -61,7 +61,7 @@ ScanOneOpusTag(StringView name, StringView value,
 		const char *endptr;
 		const auto l = ParseInt64(value, &endptr, 10);
 		if (endptr > value.begin() && endptr == value.end())
-			rgi->track.gain = float(l) / 256.0f;
+			rgi->track.gain += float(l) / 256.0f;
 	} else if (rgi != nullptr &&
 		   name.EqualsIgnoreCase("R128_ALBUM_GAIN")) {
 		/* R128_ALBUM_GAIN is a Q7.8 fixed point number in
@@ -70,7 +70,7 @@ ScanOneOpusTag(StringView name, StringView value,
 		const char *endptr;
 		const auto l = ParseInt64(value, &endptr, 10);
 		if (endptr > value.begin() && endptr == value.end())
-			rgi->album.gain = float(l) / 256.0f;
+			rgi->album.gain += float(l) / 256.0f;
 	}
 
 	handler.OnPair(name, value);


### PR DESCRIPTION
This fixes #957 and makes volumes of tracks match between formats in MPD with every replaygain scanner I've tried.