### PR TITLE
clang-tidy: remove pointless std::move

### DIFF
--- a/src/storage/CompositeStorage.cxx
+++ b/src/storage/CompositeStorage.cxx
@@ -120,8 +120,7 @@ CompositeStorage::Directory::Make(std::string_view uri)
 		if (name.empty())
 			continue;
 
-		auto i = directory->children.emplace(std::move(name),
-						     Directory());
+		auto i = directory->children.emplace(name, Directory());
 		directory = &i.first->second;
 	}
 


### PR DESCRIPTION
Found with performance-move-const-arg

Signed-off-by: Rosen Penev <rosenp@gmail.com>