### PR TITLE
clang-tidy: change several bind calls to lambdas

### DIFF
--- a/src/lib/dbus/Message.hxx
+++ b/src/lib/dbus/Message.hxx
@@ -48,6 +48,8 @@ class Message {
 public:
 	Message() noexcept = default;
 
+	Message(const Message &src) = default;
+
 	Message(Message &&src) noexcept
 		:msg(std::exchange(src.msg, nullptr)) {}
 

--- a/src/storage/plugins/UdisksStorage.cxx
+++ b/src/storage/plugins/UdisksStorage.cxx
@@ -226,9 +226,9 @@ try {
 						  UDISKS2_PATH,
 						  DBUS_OM_INTERFACE,
 						  "GetManagedObjects");
-		list_request.Send(connection, *msg.Get(),
-				  std::bind(&UdisksStorage::OnListReply,
-					    this, std::placeholders::_1));
+		list_request.Send(connection, *msg.Get(), [this](const auto &r) {
+			return UdisksStorage::OnListReply(r);
+		});
 		return;
 	}
 
@@ -238,9 +238,9 @@ try {
 					  "Mount");
 	AppendMessageIter(*msg.Get()).AppendEmptyArray<DictEntryTypeTraits<StringTypeTraits, VariantTypeTraits>>();
 
-	mount_request.Send(connection, *msg.Get(),
-			   std::bind(&UdisksStorage::OnMountNotify,
-				     this, std::placeholders::_1));
+	mount_request.Send(connection, *msg.Get(), [this](const auto &r) {
+		return UdisksStorage::OnMountNotify(r);
+	});
 } catch (...) {
 	const std::lock_guard<Mutex> lock(mutex);
 	mount_error = std::current_exception();
@@ -296,9 +296,9 @@ try {
 					  "Unmount");
 	AppendMessageIter(*msg.Get()).AppendEmptyArray<DictEntryTypeTraits<StringTypeTraits, VariantTypeTraits>>();
 
-	mount_request.Send(connection, *msg.Get(),
-			   std::bind(&UdisksStorage::OnUnmountNotify,
-				     this, std::placeholders::_1));
+	mount_request.Send(connection, *msg.Get(), [this](const auto &r) {
+		return UdisksStorage::OnUnmountNotify(r);
+	});
 } catch (...) {
 	const std::lock_guard<Mutex> lock(mutex);
 	mount_error = std::current_exception();


### PR DESCRIPTION
Found with modernize-avoid-bind.

The defaulted constructor is needed as normally, an implicitly deleted
one is used.

Signed-off-by: Rosen Penev <rosenp@gmail.com>