### PR TITLE
clang-tidy: add explicit deleted constructors

### DIFF
--- a/src/archive/plugins/Bzip2ArchivePlugin.cxx
+++ b/src/archive/plugins/Bzip2ArchivePlugin.cxx
@@ -71,6 +71,9 @@ public:
 			 Mutex &mutex);
 	~Bzip2InputStream() noexcept override;
 
+	Bzip2InputStream(const Bzip2InputStream &) = delete;
+	Bzip2InputStream &operator=(const Bzip2InputStream &) = delete;
+
 	/* virtual methods from InputStream */
 	[[nodiscard]] bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,

--- a/src/archive/plugins/ZzipArchivePlugin.cxx
+++ b/src/archive/plugins/ZzipArchivePlugin.cxx
@@ -116,6 +116,9 @@ public:
 		zzip_file_close(file);
 	}
 
+	ZzipInputStream(const ZzipInputStream &) = delete;
+	ZzipInputStream &operator=(const ZzipInputStream &) = delete;
+
 	/* virtual methods from InputStream */
 	[[nodiscard]] bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -83,6 +83,9 @@ public:
 	~AllocatedProxySong() {
 		mpd_song_free(song);
 	}
+
+	AllocatedProxySong(const AllocatedProxySong &) = delete;
+	AllocatedProxySong &operator=(const AllocatedProxySong &) = delete;
 };
 
 class ProxyDatabase final : public Database {

--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -138,6 +138,9 @@ public:
 	MadDecoder(DecoderClient *client, InputStream &input_stream) noexcept;
 	~MadDecoder() noexcept;
 
+	MadDecoder(const MadDecoder &) = delete;
+	MadDecoder &operator=(const MadDecoder &) = delete;
+
 	void RunDecoder() noexcept;
 	bool RunScan(TagHandler &handler) noexcept;
 

--- a/src/decoder/plugins/OpusDecoderPlugin.cxx
+++ b/src/decoder/plugins/OpusDecoderPlugin.cxx
@@ -137,6 +137,9 @@ public:
 
 	~MPDOpusDecoder();
 
+	MPDOpusDecoder(const MPDOpusDecoder &) = delete;
+	MPDOpusDecoder &operator=(const MPDOpusDecoder &) = delete;
+
 	/**
 	 * Has DecoderClient::Ready() been called yet?
 	 */

--- a/src/decoder/plugins/VorbisDecoderPlugin.cxx
+++ b/src/decoder/plugins/VorbisDecoderPlugin.cxx
@@ -80,6 +80,9 @@ public:
 		DeinitVorbis();
 	}
 
+	VorbisDecoder(const VorbisDecoder &) = delete;
+	VorbisDecoder &operator=(const VorbisDecoder &) = delete;
+
 	bool Seek(uint64_t where_frame);
 
 	static AudioFormat CheckAudioFormat(const vorbis_info &vi) {

--- a/src/encoder/EncoderInterface.hxx
+++ b/src/encoder/EncoderInterface.hxx
@@ -35,7 +35,7 @@ class Encoder {
 public:
 	explicit Encoder(bool _implements_tag) noexcept
 		:implements_tag(_implements_tag) {}
-	virtual ~Encoder() noexcept {}
+	virtual ~Encoder() noexcept = default;
 
 	bool ImplementsTag() const noexcept {
 		return implements_tag;
@@ -111,7 +111,7 @@ public:
 
 class PreparedEncoder {
 public:
-	virtual ~PreparedEncoder() noexcept {}
+	virtual ~PreparedEncoder() noexcept = default;
 
 	/**
 	 * Opens the object.  You must call this prior to using it.

--- a/src/encoder/plugins/FlacEncoderPlugin.cxx
+++ b/src/encoder/plugins/FlacEncoderPlugin.cxx
@@ -54,6 +54,9 @@ public:
 		FLAC__stream_encoder_delete(fse);
 	}
 
+	FlacEncoder(const FlacEncoder &) = delete;
+	FlacEncoder &operator=(const FlacEncoder &) = delete;
+
 	/* virtual methods from class Encoder */
 	void End() override {
 		(void) FLAC__stream_encoder_finish(fse);

--- a/src/encoder/plugins/LameEncoderPlugin.cxx
+++ b/src/encoder/plugins/LameEncoderPlugin.cxx
@@ -47,6 +47,9 @@ public:
 
 	~LameEncoder() noexcept override;
 
+	LameEncoder(const LameEncoder &) = delete;
+	LameEncoder &operator=(const LameEncoder &) = delete;
+
 	/* virtual methods from class Encoder */
 	void Write(const void *data, size_t length) override;
 	size_t Read(void *dest, size_t length) noexcept override;

--- a/src/encoder/plugins/OpusEncoderPlugin.cxx
+++ b/src/encoder/plugins/OpusEncoderPlugin.cxx
@@ -56,6 +56,9 @@ public:
 	OpusEncoder(AudioFormat &_audio_format, ::OpusEncoder *_enc, bool _chaining);
 	~OpusEncoder() noexcept override;
 
+	OpusEncoder(const OpusEncoder &) = delete;
+	OpusEncoder &operator=(const OpusEncoder &) = delete;
+
 	/* virtual methods from class Encoder */
 	void End() override;
 	void Write(const void *data, size_t length) override;

--- a/src/encoder/plugins/TwolameEncoderPlugin.cxx
+++ b/src/encoder/plugins/TwolameEncoderPlugin.cxx
@@ -54,6 +54,9 @@ public:
 		 audio_format(_audio_format), options(_options) {}
 	~TwolameEncoder() noexcept override;
 
+	TwolameEncoder(const TwolameEncoder &) = delete;
+	TwolameEncoder &operator=(const TwolameEncoder &) = delete;
+
 	/* virtual methods from class Encoder */
 
 	void End() override {

--- a/src/encoder/plugins/VorbisEncoderPlugin.cxx
+++ b/src/encoder/plugins/VorbisEncoderPlugin.cxx
@@ -44,6 +44,9 @@ public:
 		vorbis_info_clear(&vi);
 	}
 
+	VorbisEncoder(const VorbisEncoder &) = delete;
+	VorbisEncoder &operator=(const VorbisEncoder &) = delete;
+
 	/* virtual methods from class Encoder */
 	void End() override {
 		PreTag();

--- a/src/filter/Filter.hxx
+++ b/src/filter/Filter.hxx
@@ -36,7 +36,7 @@ protected:
 	}
 
 public:
-	virtual ~Filter() noexcept {}
+	virtual ~Filter() noexcept = default;
 
 	/**
 	 * Returns the #AudioFormat produced by FilterPCM().

--- a/src/filter/Observer.cxx
+++ b/src/filter/Observer.cxx
@@ -43,6 +43,9 @@ public:
 		observer.proxy = nullptr;
 	}
 
+	PreparedProxy(const PreparedProxy &) = delete;
+	PreparedProxy &operator=(const PreparedProxy &) = delete;
+
 	void Clear([[maybe_unused]] Proxy *_child) noexcept {
 		assert(child == _child);
 		child = nullptr;
@@ -66,6 +69,9 @@ public:
 	~Proxy() noexcept override {
 		parent.Clear(this);
 	}
+
+	Proxy(const Proxy &) = delete;
+	Proxy &operator=(const Proxy &) = delete;
 
 	Filter *Get() noexcept {
 		return filter.get();

--- a/src/filter/Prepared.hxx
+++ b/src/filter/Prepared.hxx
@@ -27,7 +27,7 @@ class Filter;
 
 class PreparedFilter {
 public:
-	virtual ~PreparedFilter() {}
+	virtual ~PreparedFilter() = default;
 
 	/**
 	 * Opens the filter, preparing it for FilterPCM().

--- a/src/filter/plugins/NormalizeFilterPlugin.cxx
+++ b/src/filter/plugins/NormalizeFilterPlugin.cxx
@@ -42,6 +42,10 @@ public:
 		Compressor_delete(compressor);
 	}
 
+
+	NormalizeFilter(const NormalizeFilter &) = delete;
+	NormalizeFilter &operator=(const NormalizeFilter &) = delete;
+
 	/* virtual methods from class Filter */
 	ConstBuffer<void> FilterPCM(ConstBuffer<void> src) override;
 };

--- a/src/input/InputStream.hxx
+++ b/src/input/InputStream.hxx
@@ -107,6 +107,9 @@ public:
 	 */
 	virtual ~InputStream() noexcept;
 
+	InputStream(const InputStream &) = delete;
+	InputStream &operator=(const InputStream &) = delete;
+
 	/**
 	 * Opens a new input stream.  You may not access it until the "ready"
 	 * flag is set.

--- a/src/input/plugins/AlsaInputPlugin.cxx
+++ b/src/input/plugins/AlsaInputPlugin.cxx
@@ -99,6 +99,9 @@ public:
 		snd_pcm_close(capture_handle);
 	}
 
+	AlsaInputStream(const AlsaInputStream &) = delete;
+	AlsaInputStream &operator=(const AlsaInputStream &) = delete;
+
 	static InputStreamPtr Create(EventLoop &event_loop, const char *uri,
 				     Mutex &mutex);
 

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -88,6 +88,9 @@ class CdioParanoiaInputStream final : public InputStream {
 		cdio_destroy(cdio);
 	}
 
+	CdioParanoiaInputStream(const CdioParanoiaInputStream &) = delete;
+	CdioParanoiaInputStream &operator=(const CdioParanoiaInputStream &) = delete;
+
 	/* virtual methods from InputStream */
 	[[nodiscard]] bool IsEOF() const noexcept override;
 	size_t Read(std::unique_lock<Mutex> &lock,

--- a/src/input/plugins/MmsInputPlugin.cxx
+++ b/src/input/plugins/MmsInputPlugin.cxx
@@ -41,6 +41,9 @@ public:
 		Stop();
 	}
 
+	MmsInputStream(const MmsInputStream &) = delete;
+	MmsInputStream &operator=(const MmsInputStream &) = delete;
+
 protected:
 	void Open() override;
 	size_t ThreadRead(void *ptr, size_t size) override;

--- a/src/input/plugins/NfsInputPlugin.cxx
+++ b/src/input/plugins/NfsInputPlugin.cxx
@@ -51,6 +51,9 @@ public:
 		DeferClose();
 	}
 
+	NfsInputStream(const NfsInputStream &) = delete;
+	NfsInputStream &operator=(const NfsInputStream &) = delete;
+
 	void Open() {
 		assert(!IsReady());
 

--- a/src/input/plugins/QobuzInputPlugin.cxx
+++ b/src/input/plugins/QobuzInputPlugin.cxx
@@ -57,6 +57,9 @@ public:
 		qobuz_client->RemoveLoginHandler(*this);
 	}
 
+	QobuzInputStream(const QobuzInputStream &) = delete;
+	QobuzInputStream &operator=(const QobuzInputStream &) = delete;
+
 	/* virtual methods from InputStream */
 
 	void Check() override {

--- a/src/input/plugins/TidalInputPlugin.cxx
+++ b/src/input/plugins/TidalInputPlugin.cxx
@@ -70,6 +70,9 @@ public:
 		tidal_session->RemoveLoginHandler(*this);
 	}
 
+	TidalInputStream(const TidalInputStream &) = delete;
+	TidalInputStream &operator=(const TidalInputStream &) = delete;
+
 	/* virtual methods from InputStream */
 
 	void Check() override {

--- a/src/lib/curl/Global.cxx
+++ b/src/lib/curl/Global.cxx
@@ -57,6 +57,9 @@ public:
 		   better solution? */
 	}
 
+	CurlSocket(const CurlSocket &) = delete;
+	CurlSocket &operator=(const CurlSocket &) = delete;
+
 	auto &GetEventLoop() const noexcept {
 		return socket_event.GetEventLoop();
 	}

--- a/src/mixer/MixerInternal.hxx
+++ b/src/mixer/MixerInternal.hxx
@@ -57,7 +57,7 @@ public:
 
 	Mixer(const Mixer &) = delete;
 
-	virtual ~Mixer() {}
+	virtual ~Mixer() = default;
 
 	bool IsPlugin(const MixerPlugin &other) const noexcept {
 		return &plugin == &other;

--- a/src/mixer/plugins/AlsaMixerPlugin.cxx
+++ b/src/mixer/plugins/AlsaMixerPlugin.cxx
@@ -63,6 +63,9 @@ public:
 			});
 	}
 
+	AlsaMixerMonitor(const AlsaMixerMonitor &) = delete;
+	AlsaMixerMonitor &operator=(const AlsaMixerMonitor &) = delete;
+
 private:
 	Event::Duration PrepareSockets() noexcept override;
 	void DispatchSockets() noexcept override;
@@ -86,6 +89,9 @@ public:
 		 event_loop(_event_loop) {}
 
 	~AlsaMixer() override;
+
+	AlsaMixer(const AlsaMixer &) = delete;
+	AlsaMixer &operator=(const AlsaMixer &) = delete;
 
 	void Configure(const ConfigBlock &block);
 	void Setup();

--- a/src/mixer/plugins/PulseMixerPlugin.cxx
+++ b/src/mixer/plugins/PulseMixerPlugin.cxx
@@ -55,6 +55,9 @@ public:
 
 	~PulseMixer() override;
 
+	PulseMixer(const PulseMixer &) = delete;
+	PulseMixer &operator=(const PulseMixer &) = delete;
+
 	void Offline();
 	void VolumeCallback(const pa_sink_input_info *i, int eol);
 	void Update(pa_context *context, pa_stream *stream);

--- a/src/neighbor/Explorer.hxx
+++ b/src/neighbor/Explorer.hxx
@@ -49,7 +49,7 @@ public:
 	/**
 	 * Free instance data.
          */
-	virtual ~NeighborExplorer() noexcept {}
+	virtual ~NeighborExplorer() noexcept = default;
 
 	/**
          * Start exploring the neighborhood.

--- a/src/neighbor/plugins/UpnpNeighborPlugin.cxx
+++ b/src/neighbor/plugins/UpnpNeighborPlugin.cxx
@@ -38,6 +38,7 @@ class UpnpNeighborExplorer final
 			:name(std::move(_name)), comment(std::move(_comment)),
 			 alive(true) {}
 		Server(const Server &) = delete;
+		Server &operator=(const Server &) = delete;
 
 		gcc_pure
 		bool operator==(const Server &other) const noexcept {

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -226,6 +226,9 @@ public:
 		snd_config_update_free_global();
 	}
 
+	AlsaOutput(const AlsaOutput &) = delete;
+	AlsaOutput &operator=(const AlsaOutput &) = delete;
+
 	using MultiSocketMonitor::GetEventLoop;
 
 	gcc_pure

--- a/src/output/plugins/AoOutputPlugin.cxx
+++ b/src/output/plugins/AoOutputPlugin.cxx
@@ -42,6 +42,9 @@ public:
 	~AoInit() noexcept {
 		ao_shutdown();
 	}
+
+	AoInit(const AoInit &) = delete;
+	AoInit &operator=(const AoInit &) = delete;
 };
 
 class AoOutput final : AudioOutput, SafeSingleton<AoInit> {
@@ -54,6 +57,9 @@ class AoOutput final : AudioOutput, SafeSingleton<AoInit> {
 
 	explicit AoOutput(const ConfigBlock &block);
 	~AoOutput() override;
+
+	AoOutput(const AoOutput &) = delete;
+	AoOutput &operator=(const AoOutput &) = delete;
 
 public:
 	static AudioOutput *Create(EventLoop &, const ConfigBlock &block) {

--- a/src/output/plugins/FifoOutputPlugin.cxx
+++ b/src/output/plugins/FifoOutputPlugin.cxx
@@ -49,6 +49,9 @@ public:
 		CloseFifo();
 	}
 
+	FifoOutput(const FifoOutput &) = delete;
+	FifoOutput &operator=(const FifoOutput &) = delete;
+
 	static AudioOutput *Create(EventLoop &,
 				   const ConfigBlock &block) {
 		return new FifoOutput(block);

--- a/src/output/plugins/ShoutOutputPlugin.cxx
+++ b/src/output/plugins/ShoutOutputPlugin.cxx
@@ -51,6 +51,9 @@ struct ShoutOutput final : AudioOutput {
 	explicit ShoutOutput(const ConfigBlock &block);
 	~ShoutOutput() override;
 
+	ShoutOutput(const ShoutOutput &) = delete;
+	ShoutOutput &operator=(const ShoutOutput &) = delete;
+
 	static AudioOutput *Create(EventLoop &event_loop,
 				   const ConfigBlock &block);
 

--- a/src/pcm/Resampler.hxx
+++ b/src/pcm/Resampler.hxx
@@ -31,7 +31,7 @@ struct AudioFormat;
  */
 class PcmResampler {
 public:
-	virtual ~PcmResampler() {}
+	virtual ~PcmResampler() = default;
 
 	/**
 	 * Opens the resampler, preparing it for Resample().

--- a/src/playlist/SongEnumerator.hxx
+++ b/src/playlist/SongEnumerator.hxx
@@ -30,7 +30,7 @@ class DetachedSong;
  */
 class SongEnumerator {
 public:
-	virtual ~SongEnumerator() noexcept {}
+	virtual ~SongEnumerator() noexcept = default;
 
 	/**
 	 * Obtain the next song.  Returns nullptr if there are no more

--- a/src/song/ISongFilter.hxx
+++ b/src/song/ISongFilter.hxx
@@ -31,7 +31,7 @@ using ISongFilterPtr = std::unique_ptr<ISongFilter>;
 
 class ISongFilter {
 public:
-	virtual ~ISongFilter() noexcept {}
+	virtual ~ISongFilter() noexcept = default;
 
 	virtual ISongFilterPtr Clone() const noexcept = 0;
 

--- a/src/storage/StorageInterface.hxx
+++ b/src/storage/StorageInterface.hxx
@@ -33,7 +33,7 @@ class StorageDirectoryReader {
 public:
 	StorageDirectoryReader() = default;
 	StorageDirectoryReader(const StorageDirectoryReader &) = delete;
-	virtual ~StorageDirectoryReader() noexcept {}
+	virtual ~StorageDirectoryReader() noexcept = default;
 
 	virtual const char *Read() noexcept = 0;
 
@@ -47,7 +47,7 @@ class Storage {
 public:
 	Storage() = default;
 	Storage(const Storage &) = delete;
-	virtual ~Storage() noexcept {}
+	virtual ~Storage() noexcept = default;
 
 	/**
 	 * Throws #std::runtime_error on error.

--- a/src/storage/plugins/NfsStorage.cxx
+++ b/src/storage/plugins/NfsStorage.cxx
@@ -85,6 +85,9 @@ public:
 		nfs_finish();
 	}
 
+	NfsStorage(const NfsStorage &) = delete;
+	NfsStorage &operator=(const NfsStorage &) = delete;
+
 	/* virtual methods from class Storage */
 	StorageFileInfo GetInfo(std::string_view uri_utf8, bool follow) override;
 

--- a/src/storage/plugins/UdisksStorage.cxx
+++ b/src/storage/plugins/UdisksStorage.cxx
@@ -93,6 +93,9 @@ public:
 		}
 	}
 
+	UdisksStorage(const UdisksStorage &) = delete;
+	UdisksStorage &operator=(const UdisksStorage &) = delete;
+
 	EventLoop &GetEventLoop() const noexcept {
 		return defer_mount.GetEventLoop();
 	}


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>