### PR TITLE
remove clocale test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,8 +147,6 @@ add_global_arguments(common_cppflags, language: 'cpp')
 enable_daemon = not is_windows and not is_android and get_option('daemon')
 conf.set('ENABLE_DAEMON', enable_daemon)
 
-conf.set('HAVE_CLOCALE', compiler.has_header('clocale'))
-
 conf.set('HAVE_GETPWNAM_R', compiler.has_function('getpwnam_r'))
 conf.set('HAVE_GETPWUID_R', compiler.has_function('getpwuid_r'))
 conf.set('HAVE_INITGROUPS', compiler.has_function('initgroups'))

--- a/src/Main.cxx
+++ b/src/Main.cxx
@@ -111,7 +111,7 @@
 
 #include <climits>
 
-#ifdef HAVE_CLOCALE
+#ifndef ANDROID
 #include <clocale>
 #endif
 
@@ -358,11 +358,9 @@ MainConfigured(const struct options &options, const ConfigData &raw_config)
 #endif
 
 #ifndef ANDROID
-#ifdef HAVE_CLOCALE
 	/* initialize locale */
 	std::setlocale(LC_CTYPE,"");
 	std::setlocale(LC_COLLATE, "");
-#endif
 #endif
 
 	const ScopeIcuInit icu_init;


### PR DESCRIPTION
clocale is part of C++11.

In practical terms, gcc's libstdc++ comes with its own locale defines
when the libc does not have them.

Also reworked to be dependent on !ANDROID.

Signed-off-by: Rosen Penev <rosenp@gmail.com>