### PR TITLE
clang-tidy: convert to all/any_of

### DIFF
--- a/src/command/FileCommands.cxx
+++ b/src/command/FileCommands.cxx
@@ -113,12 +113,9 @@ IsValidName(const StringView s) noexcept
 	if (s.empty() || !IsAlphaASCII(s.front()))
 		return false;
 
-	for (const char ch : s) {
-		if (!IsAlphaASCII(ch) && ch != '_' && ch != '-')
-			return false;
-	}
-
-	return true;
+	return std::none_of(s.begin(), s.end(), [=](const auto &ch) {
+		return !IsAlphaASCII(ch) && ch != '_' && ch != '-';
+	});
 }
 
 gcc_pure

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -356,11 +356,9 @@ SendConstraints(mpd_connection *connection, const SongFilter &filter)
 						 filter.ToExpression().c_str());
 #endif
 
-	for (const auto &i : filter.GetItems())
-		if (!SendConstraints(connection, *i))
-			return false;
-
-	return true;
+	return std::all_of(
+		filter.GetItems().begin(), filter.GetItems().end(),
+		[=](const auto &item) { return SendConstraints(connection, *item); });
 }
 
 static bool
@@ -896,11 +894,8 @@ IsFilterFullySupported(const SongFilter &filter,
 	(void)connection;
 #endif
 
-	for (const auto &i : filter.GetItems())
-		if (!IsFilterSupported(*i))
-			return false;
-
-	return true;
+	return std::all_of(filter.GetItems().begin(), filter.GetItems().end(),
+			   [](const auto &item) { return IsFilterSupported(*item); });
 }
 
 gcc_pure

--- a/src/song/Filter.cxx
+++ b/src/song/Filter.cxx
@@ -429,29 +429,27 @@ SongFilter::Match(const LightSong &song) const noexcept
 bool
 SongFilter::HasFoldCase() const noexcept
 {
-	for (const auto &i : and_filter.GetItems()) {
-		if (auto t = dynamic_cast<const TagSongFilter *>(i.get())) {
-			if (t->GetFoldCase())
-				return true;
-		} else if (auto u = dynamic_cast<const UriSongFilter *>(i.get())) {
-			if (u->GetFoldCase())
-				return true;
-		}
-	}
+	return std::any_of(
+		and_filter.GetItems().begin(), and_filter.GetItems().end(),
+		[](const auto &item) {
+			if (auto t = dynamic_cast<const TagSongFilter *>(item.get()))
+				return t->GetFoldCase();
 
-	return false;
+			if (auto u = dynamic_cast<const UriSongFilter *>(item.get()))
+				return u->GetFoldCase();
+
+			return false;
+		});
 }
 
 bool
 SongFilter::HasOtherThanBase() const noexcept
 {
-	for (const auto &i : and_filter.GetItems()) {
-		const auto *f = dynamic_cast<const BaseSongFilter *>(i.get());
-		if (f == nullptr)
-			return true;
-	}
-
-	return false;
+	return std::any_of(and_filter.GetItems().begin(), and_filter.GetItems().end(),
+			   [=](const auto &item) {
+				   return !dynamic_cast<const BaseSongFilter *>(
+					   item.get());
+			   });
 }
 
 const char *


### PR DESCRIPTION
Found with readability-use-anyofallof

Signed-off-by: Rosen Penev <rosenp@gmail.com>