### PR TITLE
system/FileDescriptor: fix Duplicate result

### DIFF
--- a/src/io/FileDescriptor.hxx
+++ b/src/io/FileDescriptor.hxx
@@ -178,7 +178,7 @@ public:
 	 * Duplicate the file descriptor onto the given file descriptor.
 	 */
 	bool Duplicate(FileDescriptor new_fd) const noexcept {
-		return ::dup2(Get(), new_fd.Get()) == 0;
+		return ::dup2(Get(), new_fd.Get()) != -1;
 	}
 
 	/**


### PR DESCRIPTION
`dup2` returns `new_fd`, so assuming the intention was for `true` to indicate success, this needs to check for `== new_fd.Get()` or `>= 0` or `!= -1` instead.