### PR TITLE
clang-tidy: replace std::bind with lambdas

### DIFF
--- a/src/lib/dbus/UDisks2.cxx
+++ b/src/lib/dbus/UDisks2.cxx
@@ -120,19 +120,20 @@ static void
 ParseInterface(Object &o, const char *interface,
 	       ODBus::ReadMessageIter &&i) noexcept
 {
-	using namespace std::placeholders;
 	if (StringIsEqual(interface, "org.freedesktop.UDisks2.Drive")) {
-		i.ForEachProperty(std::bind(ParseDriveDictEntry,
-					    std::ref(o), _1, _2));
+		i.ForEachProperty([&](auto n, auto v) {
+			return ParseDriveDictEntry(o, n, std::move(v));
+		});
 	} else if (StringIsEqual(interface, "org.freedesktop.UDisks2.Block")) {
-		i.ForEachProperty(std::bind(ParseBlockDictEntry,
-					    std::ref(o), _1, _2));
+		i.ForEachProperty([&](auto n, auto v) {
+			return ParseBlockDictEntry(o, n, std::move(v));
+		});
 	} else if (StringIsEqual(interface, "org.freedesktop.UDisks2.Filesystem")) {
 		o.is_filesystem = true;
 
-		i.ForEachProperty(std::bind(ParseFileesystemDictEntry,
-					    std::ref(o), _1, _2));
-
+		i.ForEachProperty([&](auto n, auto v) {
+			return ParseFileesystemDictEntry(o, n, std::move(v));
+		});
 	}
 }
 

--- a/src/neighbor/plugins/UdisksNeighborPlugin.cxx
+++ b/src/neighbor/plugins/UdisksNeighborPlugin.cxx
@@ -128,9 +128,9 @@ UdisksNeighborExplorer::DoOpen()
 								  UDISKS2_PATH,
 								  DBUS_OM_INTERFACE,
 								  "GetManagedObjects");
-				list_request.Send(connection, *msg.Get(),
-						  std::bind(&UdisksNeighborExplorer::OnListNotify,
-							    this, std::placeholders::_1));
+				list_request.Send(connection, *msg.Get(), [this](auto o) {
+					return OnListNotify(std::move(o));
+				});
 			} catch (...) {
 				dbus_connection_remove_filter(connection,
 							      HandleMessage,
@@ -229,9 +229,8 @@ inline void
 UdisksNeighborExplorer::OnListNotify(ODBus::Message reply) noexcept
 {
 	try{
-		ParseObjects(reply,
-			     std::bind(&UdisksNeighborExplorer::Insert,
-				       this, std::placeholders::_1));
+		UDisks2::ParseObjects(reply,
+				      [this](auto p) { return Insert(std::move(p)); });
 	} catch (...) {
 		LogError(std::current_exception(),
 			 "Failed to parse GetManagedObjects reply");

--- a/src/storage/plugins/UdisksStorage.cxx
+++ b/src/storage/plugins/UdisksStorage.cxx
@@ -227,8 +227,7 @@ try {
 						  DBUS_OM_INTERFACE,
 						  "GetManagedObjects");
 		list_request.Send(connection, *msg.Get(),
-				  std::bind(&UdisksStorage::OnListReply,
-					    this, std::placeholders::_1));
+				  [this](auto o) { return OnListReply(std::move(o)); });
 		return;
 	}
 
@@ -239,8 +238,7 @@ try {
 	AppendMessageIter(*msg.Get()).AppendEmptyArray<DictEntryTypeTraits<StringTypeTraits, VariantTypeTraits>>();
 
 	mount_request.Send(connection, *msg.Get(),
-			   std::bind(&UdisksStorage::OnMountNotify,
-				     this, std::placeholders::_1));
+			   [this](auto o) { return OnMountNotify(std::move(o)); });
 } catch (...) {
 	const std::lock_guard<Mutex> lock(mutex);
 	mount_error = std::current_exception();
@@ -297,8 +295,7 @@ try {
 	AppendMessageIter(*msg.Get()).AppendEmptyArray<DictEntryTypeTraits<StringTypeTraits, VariantTypeTraits>>();
 
 	mount_request.Send(connection, *msg.Get(),
-			   std::bind(&UdisksStorage::OnUnmountNotify,
-				     this, std::placeholders::_1));
+			   [this](auto u) { return OnUnmountNotify(std::move(u)); });
 } catch (...) {
 	const std::lock_guard<Mutex> lock(mutex);
 	mount_error = std::current_exception();


### PR DESCRIPTION
Found with modernize-avoid-bind

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Reduces size from

```
29134736
3538352
```

to

```
29067848
3534256
```

compiled without optimization of course.