### PR TITLE
Explicitly remove socket FDs from EventLoop before closing

### DIFF
--- a/src/event/SocketEvent.cxx
+++ b/src/event/SocketEvent.cxx
@@ -44,7 +44,7 @@ SocketEvent::Close() noexcept
 		return;
 
 	if (std::exchange(scheduled_flags, 0) != 0)
-		loop.AbandonFD(*this);
+		loop.RemoveFD(fd.Get(), *this);
 	fd.Close();
 }
 


### PR DESCRIPTION
`SocketEvent` knows the socket is open and registered so it seems unnecessary to rely on `AbandonFD` and assume the kernel will remove the fd from the epoll list when it can be done explicitly.

### Why this is relevant

- `AbandonFD` assumes that upon closing the socket, the FD will be automatically removed from the epoll list. That fd is associated with a reference to the `SocketEvent`, so this is an important and dangerous assumption to get wrong. In the case that the FD isn't immediately removed from the list by the kernel, the event loop can crash due to the `SocketEvent` being destroyed and it being a use-after-free bug at that point.
- If a socket FD happens to be duplicated, then closing the SocketEvent FD will not automatically remove it from epoll, and will trigger said bug/crash. It is only automatically removed when all FD references to the underlying socket/resource are closed?
- A `fork()` is one example where a socket FD can be duplicated and result in this situation.
    - `CLOEXEC` might be considered mitigation for this but also introduces a race condition where the crash can occur between a `fork()` and `exec()` without additional synchronization to freeze the event loop.

One could argue the mpd event loop isn't fork-safe, and thus should be allowed to use `AbandonFD` however it likes. A decision on whether this is intended should probably be declared; but either way this fix seems appropriate in cases where `Abandon` isn't actually necessary. It also might be possible to fix `AbandonFD` to mark the `SocketEvent` as removed without using `EPOLL_CTL_DEL`?

(I can add some of these details to the commit message if you like?)
