### PR TITLE
Fixes #994 - AudioOutputControl created from copy

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 ver 0.22.4 (not yet released)
 * decoder
   - dsdiff: apply padding to odd-sized chunks
+* output
+  - moveoutput: fix always_on and tag lost on move
 
 ver 0.22.3 (2020/11/06)
 * playlist

--- a/src/command/PartitionCommands.cxx
+++ b/src/command/PartitionCommands.cxx
@@ -183,9 +183,8 @@ handle_moveoutput(Client &client, Request request, Response &response)
 			existing_output->ReplaceDummy(output->Steal(),
 						      was_enabled);
 		else
-			/* add it to the output list */
-			dest_partition.outputs.Add(output->Steal(),
-						   was_enabled);
+			/* copy the AudioOutputControl and add it to the output list */
+			dest_partition.outputs.AddCopy(output,was_enabled);
 
 		instance.EmitIdle(IDLE_OUTPUT);
 		return CommandResult::OK;

--- a/src/output/Control.cxx
+++ b/src/output/Control.cxx
@@ -39,6 +39,17 @@ AudioOutputControl::AudioOutputControl(std::unique_ptr<FilteredAudioOutput> _out
 {
 }
 
+AudioOutputControl::AudioOutputControl(AudioOutputControl *_output,
+				       AudioOutputClient &_client) noexcept
+	:output(std::move(_output->Steal())),
+	 name(output->GetName()),
+	 client(_client),
+	 thread(BIND_THIS_METHOD(Task))
+{
+     tags =_output->tags;
+	 always_on=_output->always_on;
+}
+
 AudioOutputControl::~AudioOutputControl() noexcept
 {
 	StopThread();

--- a/src/output/Control.hxx
+++ b/src/output/Control.hxx
@@ -245,6 +245,9 @@ public:
 	AudioOutputControl(std::unique_ptr<FilteredAudioOutput> _output,
 			   AudioOutputClient &_client) noexcept;
 
+	AudioOutputControl(AudioOutputControl *_outputControl,
+			   AudioOutputClient &_client) noexcept;
+
 	~AudioOutputControl() noexcept;
 
 	AudioOutputControl(const AudioOutputControl &) = delete;

--- a/src/output/MultipleOutputs.cxx
+++ b/src/output/MultipleOutputs.cxx
@@ -141,6 +141,19 @@ MultipleOutputs::Add(std::unique_ptr<FilteredAudioOutput> output,
 }
 
 void
+MultipleOutputs::AddCopy(AudioOutputControl *outputControl,
+		     bool enable) noexcept
+{
+	// TODO: this operation needs to be protected with a mutex
+	outputs.emplace_back(std::make_unique<AudioOutputControl>(outputControl,
+								  client));
+
+	outputs.back()->LockSetEnabled(enable);
+
+	client.ApplyEnabled();
+}
+
+void
 MultipleOutputs::EnableDisable()
 {
 	/* parallel execution */

--- a/src/output/MultipleOutputs.hxx
+++ b/src/output/MultipleOutputs.hxx
@@ -128,6 +128,10 @@ public:
 	void Add(std::unique_ptr<FilteredAudioOutput> output,
 		 bool enable) noexcept;
 
+	void AddCopy(AudioOutputControl *outputControl,
+		     bool enable) noexcept;
+
+
 	void SetReplayGainMode(ReplayGainMode mode) noexcept;
 
 	/**


### PR DESCRIPTION
Added mentioned snippets of code #994 .
When moving an output to a partition, the configuration of the AudioOutputControl will be copied as well.
So tags and always_on setting are also copied over to the partition for this output.

This does not resolve the issue with replay_gain not being set to the correct value, this needs to be done in the newpartition command.