### PR TITLE
lib/ffmpeg/Filter: Add define required for avutil

### DIFF
--- a/src/lib/ffmpeg/Filter.hxx
+++ b/src/lib/ffmpeg/Filter.hxx
@@ -20,6 +20,9 @@
 #ifndef MPD_FFMPEG_FILTER_HXX
 #define MPD_FFMPEG_FILTER_HXX
 
+/* necessary because libavutil/common.h uses UINT64_C */
+#define __STDC_CONSTANT_MACROS
+
 #include "Error.hxx"
 
 extern "C" {


### PR DESCRIPTION
Same problem reported in #861 , fixed in a different way.
Note that:

- `#define  __STDC_CONSTANT_MACROS` is already used among mpd codebase.
- this definition can be replaced by including `stdint.h` (or `cstdint`), because internally it includes this define (feel free to go ahead and read stdint.h source code under `/usr/include/c++/<gcc_ver>/cstdint`)

This is a mpd bug and I am looking forward to have it fixed :)