### PR TITLE
doc/protocol.rst: fix mistake in footnotes

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -543,7 +543,7 @@ Playback options
 
 :command:`single {STATE}` [#since_0_15]_
     Sets single state to ``STATE``,
-    ``STATE`` should be ``0``, ``1`` or ``oneshot`` [#since_0_20]_.
+    ``STATE`` should be ``0``, ``1`` or ``oneshot`` [#since_0_21]_.
     When single is activated, playback is stopped after current song, or
     song is repeated if the 'repeat' mode is enabled.
 

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1578,6 +1578,6 @@ client-to-client messages are local to the current partition.
 .. [#since_0_14] Since :program:`MPD` 0.14
 .. [#since_0_15] Since :program:`MPD` 0.15
 .. [#since_0_16] Since :program:`MPD` 0.16
-.. [#since_0_19] Since :program:`MPD` 0.20
+.. [#since_0_19] Since :program:`MPD` 0.19
 .. [#since_0_20] Since :program:`MPD` 0.20
 .. [#since_0_21] Since :program:`MPD` 0.21


### PR DESCRIPTION
The link is called `[#since_0_19]` but the text says `0.20`.

Edit: I also noticed that one of the places the `oneshot` option for `single` was still listed as `0.20` instead of `0.21`.