### PR TITLE
Fixed Webdav storage scanning to be more RFC compliant

### DIFF
--- a/src/storage/plugins/CurlStorage.cxx
+++ b/src/storage/plugins/CurlStorage.cxx
@@ -516,7 +516,6 @@ private:
 	 */
 	gcc_pure
 	StringView HrefToEscapedName(const char *href) const noexcept {
-		StringView relative_path;
 		StringView path = uri_get_path(href);
 		if (path == nullptr)
 			return nullptr;
@@ -524,23 +523,23 @@ private:
 		/* kludge: ignoring case in this comparison to avoid
 		   false negatives if the web server uses a different
 		   case */
-		relative_path = StringAfterPrefixIgnoreCase(path, base_path.c_str());
-		if (relative_path == nullptr || relative_path.empty()) {
-			// try relative base path
-			relative_path = StringAfterPrefixIgnoreCase(path, base_path_relative.c_str());
+		if (uri_has_scheme(path)) {
+			path = StringAfterPrefixIgnoreCase(path, base_path.c_str());
+		} else {
+			path = StringAfterPrefixIgnoreCase(path, base_path_relative.c_str());
 		}
 
-		if (relative_path == nullptr || relative_path.empty()) {
+		if (path == nullptr || path.empty()) {
 			return nullptr;
 		}
 
-		const char *slash = relative_path.Find('/');
+		const char *slash = path.Find('/');
 		if (slash == nullptr)
 			/* regular file */
-			return relative_path;
-		else if (slash == &relative_path.back())
+			return path;
+		else if (slash == &path.back())
 			/* trailing slash: collection; strip the slash */
-			return {relative_path.data, slash};
+			return {path.data, slash};
 		else
 			/* strange, better ignore it */
 			return nullptr;

--- a/src/storage/plugins/CurlStorage.cxx
+++ b/src/storage/plugins/CurlStorage.cxx
@@ -262,18 +262,19 @@ public:
 		request.SetOption(CURLOPT_MAXREDIRS, 1L);
 
 		request_headers.Append(StringFormat<40>("depth: %u", depth));
+		request_headers.Append("content-type: text/xml");
 
 		request.SetOption(CURLOPT_HTTPHEADER, request_headers.Get());
 
 		request.SetOption(CURLOPT_POSTFIELDS,
 				  "<?xml version=\"1.0\"?>\n"
 				  "<a:propfind xmlns:a=\"DAV:\">"
-				  "<a:prop><a:resourcetype/></a:prop>"
-				  "<a:prop><a:getcontenttype/></a:prop>"
-				  "<a:prop><a:getcontentlength/></a:prop>"
+				  "<a:prop>"
+				  "<a:resourcetype/>"
+				  "<a:getcontenttype/>"
+				  "<a:getcontentlength/>"
+				  "</a:prop>"
 				  "</a:propfind>");
-
-		// TODO: send request body
 	}
 
 	using BlockingHttpRequest::GetEasy;

--- a/src/util/UriExtract.cxx
+++ b/src/util/UriExtract.cxx
@@ -85,7 +85,7 @@ uri_after_scheme(std::string_view uri) noexcept
 }
 
 bool
-uri_has_scheme(const char *uri) noexcept
+uri_has_scheme(std::string_view uri) noexcept
 {
 	return !uri_get_scheme(uri).empty();
 }

--- a/src/util/UriExtract.hxx
+++ b/src/util/UriExtract.hxx
@@ -40,7 +40,7 @@
  */
 gcc_pure
 bool
-uri_has_scheme(const char *uri) noexcept;
+uri_has_scheme(std::string_view uri) noexcept;
 
 /**
  * Returns the scheme name of the specified URI, or an empty string.


### PR DESCRIPTION
### Changes

- Removed additional "a:prop" in PROPFIND request to match [RFC 4918 section 9.1.3](https://tools.ietf.org/html/rfc4918#section-9.1.3). (bug)
- Added Content-Type header as the body is not a true multipart POST.
- Fixed parsing propstat so that the correct propstat block is used when extracting relevant property values
- Added support for scheme-less URI in response href

### Ticket

Fixes https://github.com/MusicPlayerDaemon/MPD/issues/1039

### Motivation

The above were needed to make scanning work with Nextcloud which implements Webdav in a stricter way.

### Tests

Tested against a Nextcloud 20 instance which also contained file names with Chinese characters.
Scanning worked in deeper directory trees and music could be played.

### Notes

Some of the code might be slightly clumsy as it's my first time with C++11
and due to my struggles with strings I didn't try and add further hardening in the code (like in case of accidental double slashes)

I've only tested this with Nextcloud, not sure what Webdav server was used when testing the original implementation. I didn't find anything related in .travis.yml, might be good to add some scanning tests with various storage backends at some point :sweat_smile: 