### PR TITLE
WIP: Continue work on input_cache

### DIFF
--- a/src/Partition.cxx
+++ b/src/Partition.cxx
@@ -80,7 +80,7 @@ PrefetchSong(InputCacheManager &cache, const char *uri) noexcept
 static void
 PrefetchSong(InputCacheManager &cache, const DetachedSong &song) noexcept
 {
-	PrefetchSong(cache, song.GetURI());
+	PrefetchSong(cache, song.GetRealURI());
 }
 
 inline void

--- a/src/Partition.cxx
+++ b/src/Partition.cxx
@@ -91,7 +91,7 @@ Partition::PrefetchQueue() noexcept
 
 	auto &cache = *instance.input_cache;
 
-	int next = playlist.GetNextPosition();
+	int next = playlist.GetNextPosition(1);
 	if (next >= 0)
 		PrefetchSong(cache, playlist.queue.Get(next));
 

--- a/src/Partition.cxx
+++ b/src/Partition.cxx
@@ -91,11 +91,14 @@ Partition::PrefetchQueue() noexcept
 
 	auto &cache = *instance.input_cache;
 
-	int next = playlist.GetNextPosition(1);
-	if (next >= 0)
-		PrefetchSong(cache, playlist.queue.Get(next));
-
-	// TODO: prefetch more songs
+	// TODO: Find better way to guess how many songs to try to prefetch, this implementation could flush a cached file that is needed earlier when the most recent cached file.
+	for (int i = 1; i < 5; i++) {
+		int next = playlist.GetNextPosition(i);
+		if (next >= 0)
+			PrefetchSong(cache, playlist.queue.Get(next));
+		else
+			break;
+	}
 }
 
 void
@@ -225,6 +228,7 @@ Partition::OnIdleMonitor(unsigned mask) noexcept
 void
 Partition::OnGlobalEvent(unsigned mask) noexcept
 {
+	// TODO This doesn't seam to trigger when the random property of the queue is changed, this is needed for the pre caching
 	if ((mask & SYNC_WITH_PLAYER) != 0)
 		SyncWithPlayer();
 

--- a/src/command/PlayerCommands.cxx
+++ b/src/command/PlayerCommands.cxx
@@ -205,7 +205,7 @@ handle_status(Client &client, [[maybe_unused]] Request args, Response &r)
 			 GetFullMessage(std::current_exception()).c_str());
 	}
 
-	song = playlist.GetNextPosition();
+	song = playlist.GetNextPosition(1);
 	if (song >= 0)
 		r.Format(COMMAND_STATUS_NEXTSONG ": %i\n"
 			 COMMAND_STATUS_NEXTSONGID ": %u\n",

--- a/src/queue/Playlist.cxx
+++ b/src/queue/Playlist.cxx
@@ -343,15 +343,15 @@ playlist::GetCurrentPosition() const noexcept
 }
 
 int
-playlist::GetNextPosition() const noexcept
+playlist::GetNextPosition(unsigned index) const noexcept
 {
 	if (current < 0)
 		return -1;
 
 	if (queue.single != SingleMode::OFF && queue.repeat)
 		return queue.OrderToPosition(current);
-	else if (queue.IsValidOrder(current + 1))
-		return queue.OrderToPosition(current + 1);
+	else if (queue.IsValidOrder(current + index))
+		return queue.OrderToPosition(current + index);
 	else if (queue.repeat)
 		return queue.OrderToPosition(0);
 

--- a/src/queue/Playlist.hxx
+++ b/src/queue/Playlist.hxx
@@ -114,7 +114,7 @@ struct playlist {
 	int GetCurrentPosition() const noexcept;
 
 	gcc_pure
-	int GetNextPosition() const noexcept;
+	int GetNextPosition(unsigned index) const noexcept;
 
 	/**
 	 * Returns the song object which is currently queued.  Returns


### PR DESCRIPTION
(This pr is mostly for seeing what this fork is doing since that is hard to see on github.)

My fixes are mostly wip, see the TODOs for further information.
In my tests I was able to use an unstable sshfs connection (make shure to use the timeout options so that the fs calls actually fail).
I also tested with curl / webdav (Remove [/src/input/cache/Manager.cxx:97-98](https://github.com/TilCreator/MPD/blob/695a0d851c226aeed836fcb113734219d89f5704/src/input/cache/Manager.cxx#L97-L98) for that), but that somehow still fails even if cached, didn't look further into it.

I will continue working on this, but probably not fast. So help with the TODOs (also ideas how to fix them) and more are welcome.