### PR TITLE
doc/protocol.rst: fix playlist(find|search)

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -727,7 +727,7 @@ Whenever possible, ids should be used.
 
 .. _command_playlistfind:
 
-:command:`playlistfind {TAG} {NEEDLE}`
+:command:`playlistfind {FILTER}`
     Finds songs in the queue with strict
     matching.
 
@@ -748,7 +748,7 @@ Whenever possible, ids should be used.
 
 .. _command_playlistsearch:
 
-:command:`playlistsearch {TAG} {NEEDLE}`
+:command:`playlistsearch {FILTER}`
     Searches case-insensitively for partial matches in the
     queue.
 


### PR DESCRIPTION
The `{TAG} {NEEDLE}` input format documented seems to be a holdover
of pre-0.21 filters, and the commands support the new format.