### PR TITLE
clang-tidy: mark a bunch of variables constexpr

### DIFF
--- a/src/archive/ArchiveList.cxx
+++ b/src/archive/ArchiveList.cxx
@@ -30,7 +30,7 @@
 
 #include <string.h>
 
-const ArchivePlugin *const archive_plugins[] = {
+constexpr const ArchivePlugin *archive_plugins[] = {
 #ifdef ENABLE_BZ2
 	&bz2_archive_plugin,
 #endif

--- a/src/db/Registry.cxx
+++ b/src/db/Registry.cxx
@@ -26,7 +26,7 @@
 
 #include <string.h>
 
-const DatabasePlugin *const database_plugins[] = {
+constexpr const DatabasePlugin *database_plugins[] = {
 	&simple_db_plugin,
 #ifdef ENABLE_LIBMPDCLIENT
 	&proxy_db_plugin,

--- a/src/db/plugins/simple/SimpleDatabasePlugin.cxx
+++ b/src/db/plugins/simple/SimpleDatabasePlugin.cxx
@@ -479,7 +479,7 @@ SimpleDatabase::Unmount(const char *uri) noexcept
 	return true;
 }
 
-const DatabasePlugin simple_db_plugin = {
+constexpr DatabasePlugin simple_db_plugin = {
 	"simple",
 	DatabasePlugin::FLAG_REQUIRE_STORAGE,
 	SimpleDatabase::Create,

--- a/src/decoder/DecoderList.cxx
+++ b/src/decoder/DecoderList.cxx
@@ -53,7 +53,7 @@
 
 #include <string.h>
 
-const struct DecoderPlugin *const decoder_plugins[] = {
+constexpr const struct DecoderPlugin *decoder_plugins[] = {
 #ifdef ENABLE_MAD
 	&mad_decoder_plugin,
 #endif

--- a/src/encoder/EncoderList.cxx
+++ b/src/encoder/EncoderList.cxx
@@ -33,7 +33,7 @@
 
 #include <string.h>
 
-const EncoderPlugin *const encoder_plugins[] = {
+constexpr const EncoderPlugin *encoder_plugins[] = {
 	&null_encoder_plugin,
 #ifdef ENABLE_VORBISENC
 	&vorbis_encoder_plugin,

--- a/src/filter/Registry.cxx
+++ b/src/filter/Registry.cxx
@@ -28,7 +28,7 @@
 
 #include <string.h>
 
-static const FilterPlugin *const filter_plugins[] = {
+static constexpr const FilterPlugin *filter_plugins[] = {
 	&null_filter_plugin,
 	&route_filter_plugin,
 	&normalize_filter_plugin,

--- a/src/input/Registry.cxx
+++ b/src/input/Registry.cxx
@@ -52,7 +52,7 @@
 #include "plugins/CdioParanoiaInputPlugin.hxx"
 #endif
 
-const InputPlugin *const input_plugins[] = {
+constexpr const InputPlugin *input_plugins[] = {
 #ifdef ENABLE_ALSA
 	&input_plugin_alsa,
 #endif

--- a/src/neighbor/Registry.cxx
+++ b/src/neighbor/Registry.cxx
@@ -26,7 +26,7 @@
 
 #include <string.h>
 
-const NeighborPlugin *const neighbor_plugins[] = {
+constexpr const NeighborPlugin *neighbor_plugins[] = {
 #ifdef ENABLE_SMBCLIENT
 	&smbclient_neighbor_plugin,
 #endif

--- a/src/output/Registry.cxx
+++ b/src/output/Registry.cxx
@@ -46,7 +46,7 @@
 #endif
 #include "util/StringAPI.hxx"
 
-const AudioOutputPlugin *const audio_output_plugins[] = {
+constexpr const AudioOutputPlugin *audio_output_plugins[] = {
 #ifdef HAVE_SHOUT
 	&shout_output_plugin,
 #endif

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -1181,7 +1181,7 @@ try {
 	LockCaughtError();
 }
 
-const struct AudioOutputPlugin alsa_output_plugin = {
+constexpr struct AudioOutputPlugin alsa_output_plugin = {
 	"alsa",
 	alsa_test_default_device,
 	&AlsaOutput::Create,

--- a/src/output/plugins/PulseOutputPlugin.cxx
+++ b/src/output/plugins/PulseOutputPlugin.cxx
@@ -913,7 +913,7 @@ pulse_output_test_default_device()
 	return PulseOutput::TestDefaultDevice();
 }
 
-const struct AudioOutputPlugin pulse_output_plugin = {
+constexpr struct AudioOutputPlugin pulse_output_plugin = {
 	"pulse",
 	pulse_output_test_default_device,
 	PulseOutput::Create,

--- a/src/playlist/PlaylistRegistry.cxx
+++ b/src/playlist/PlaylistRegistry.cxx
@@ -43,7 +43,7 @@
 #include <cassert>
 #include <iterator>
 
-const PlaylistPlugin *const playlist_plugins[] = {
+constexpr const PlaylistPlugin *playlist_plugins[] = {
 	&extm3u_playlist_plugin,
 	&m3u_playlist_plugin,
 	&pls_playlist_plugin,

--- a/src/playlist/plugins/ExtM3uPlaylistPlugin.cxx
+++ b/src/playlist/plugins/ExtM3uPlaylistPlugin.cxx
@@ -147,7 +147,7 @@ static const char *const extm3u_mime_types[] = {
 	nullptr
 };
 
-const PlaylistPlugin extm3u_playlist_plugin =
+constexpr PlaylistPlugin extm3u_playlist_plugin =
 	PlaylistPlugin("extm3u", extm3u_open_stream)
 	.WithSuffixes(extm3u_suffixes)
 	.WithMimeTypes(extm3u_mime_types);

--- a/src/storage/Registry.cxx
+++ b/src/storage/Registry.cxx
@@ -29,7 +29,7 @@
 
 #include <string.h>
 
-const StoragePlugin *const storage_plugins[] = {
+constexpr const StoragePlugin *storage_plugins[] = {
 	&local_storage_plugin,
 #ifdef ENABLE_SMBCLIENT
 	&smbclient_storage_plugin,

--- a/src/storage/plugins/LocalStorage.cxx
+++ b/src/storage/plugins/LocalStorage.cxx
@@ -170,7 +170,7 @@ CreateLocalStorage(Path base_fs)
 	return std::make_unique<LocalStorage>(base_fs);
 }
 
-const StoragePlugin local_storage_plugin = {
+constexpr StoragePlugin local_storage_plugin = {
 	"local",
 	nullptr,
 };


### PR DESCRIPTION
Found with cppcoreguidelines-interfaces-global-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>