### PR TITLE
queue/PlaylistEdit: MoveRange fix for large end

### DIFF
--- a/src/queue/PlaylistEdit.cxx
+++ b/src/queue/PlaylistEdit.cxx
@@ -323,7 +323,8 @@ void
 playlist::MoveRange(PlayerControl &pc,
 		    unsigned start, unsigned end, int to)
 {
-	if (!queue.IsValidPosition(start) || !queue.IsValidPosition(end - 1))
+	end = GetLength() < end ? GetLength() : end;
+	if (!queue.IsValidPosition(start))
 		throw PlaylistError::BadRange();
 
 	if ((to >= 0 && to + end - start - 1 >= GetLength()) ||


### PR DESCRIPTION
"playlist::MoveRange" now sets "end" to be the playlist length if it's
larger than that (previously threw an error).
Fixes commands like "move 5: 1" failing due to partial ranges getting
parsed as having "end" be the numerical limit.