### PR TITLE
zeroconf/ZeroconfBonjour: Fix compile errors resulting from "refactor to SocketEvent" and reenable bonjour for darwin build

### DIFF
--- a/src/zeroconf/ZeroconfBonjour.cxx
+++ b/src/zeroconf/ZeroconfBonjour.cxx
@@ -40,8 +40,8 @@ public:
 	BonjourMonitor(EventLoop &_loop, DNSServiceRef _service_ref)
 		:service_ref(_service_ref),
 		 socket_event(_loop,
-			    	  BIND_THIS_METHOD(OnSocketReady),
-					  SocketDescriptor(DNSServiceRefSockFD(service_ref)))
+			      BIND_THIS_METHOD(OnSocketReady),
+			      SocketDescriptor(DNSServiceRefSockFD(service_ref)))
 	{
 		socket_event.ScheduleRead();
 	}

--- a/src/zeroconf/ZeroconfBonjour.cxx
+++ b/src/zeroconf/ZeroconfBonjour.cxx
@@ -39,9 +39,9 @@ class BonjourMonitor final {
 public:
 	BonjourMonitor(EventLoop &_loop, DNSServiceRef _service_ref)
 		:service_ref(_service_ref),
-		 socket_event(SocketDescriptor(DNSServiceRefSockFD(service_ref)),
-			      BIND_THIS_METHOD(OnSocketReady),
-			      _loop)
+		 socket_event(_loop,
+			    	  BIND_THIS_METHOD(OnSocketReady),
+					  SocketDescriptor(DNSServiceRefSockFD(service_ref)))
 	{
 		socket_event.ScheduleRead();
 	}
@@ -50,9 +50,13 @@ public:
 		DNSServiceRefDeallocate(service_ref);
 	}
 
+	void Cancel() noexcept {
+		socket_event.Cancel();
+	}
+
 protected:
 	/* virtual methods from class SocketMonitor */
-	void OnSocketReady([[maybe_unused]] unsigned flags) noexcept override {
+	void OnSocketReady([[maybe_unused]] unsigned flags) noexcept {
 		DNSServiceProcessResult(service_ref);
 	}
 };

--- a/src/zeroconf/meson.build
+++ b/src/zeroconf/meson.build
@@ -4,9 +4,7 @@ libavahi_client_dep = dependency('', required: false)
 
 if zeroconf_option == 'auto'
   if is_darwin
-    # Bonjour disabled for now because its build is broken
-    #zeroconf_option = 'bonjour'
-    zeroconf_option = 'disabled'
+    zeroconf_option = 'bonjour'
   elif is_android or is_windows
     zeroconf_option = 'disabled'
   elif dbus_dep.found()
@@ -31,10 +29,12 @@ if zeroconf_option == 'bonjour'
     error('dns_sd.h not found')
   endif
 
-  if is_darwin
-    bonjour_dep = declare_dependency(link_args: ['-framework', 'dnssd'])
-  else
-    bonjour_dep = declare_dependency(link_args: ['-ldns_sd'])
+  bonjour_deps = [
+    log_dep,
+  ]
+
+  if not is_darwin
+    bonjour_deps += declare_dependency(link_args: ['-ldns_sd'])
   endif
   conf.set('HAVE_BONJOUR', true)
 
@@ -47,10 +47,7 @@ if zeroconf_option == 'bonjour'
 
   zeroconf_dep = declare_dependency(
     link_with: zeroconf,
-    dependencies: [
-      bonjour_dep,
-      log_dep,
-    ],
+    dependencies: bonjour_deps,
   )
 else
   if not libavahi_client_dep.found()


### PR DESCRIPTION
The changes for made to ZeroconfBonjour.cxx for "refactor to SocketEvent" didn't actually compile. 

Also I've reenabled bonjour for the darwin build. dnssd is now in the System framework so there is no need for an additional link_arg.