### PR TITLE
Feature - add cacert for curl plugin

### DIFF
--- a/src/input/plugins/CurlInputPlugin.cxx
+++ b/src/input/plugins/CurlInputPlugin.cxx
@@ -377,7 +377,7 @@ input_curl_init(EventLoop &event_loop, const ConfigBlock &block)
 #else
 	constexpr bool default_verify = true;
 #endif
-        cacert = block.GetBlockValue("cacert");
+	cacert = block.GetBlockValue("cacert");
 	verify_peer = block.GetBlockValue("verify_peer", default_verify);
 	verify_host = block.GetBlockValue("verify_host", default_verify);
 }
@@ -434,8 +434,8 @@ CurlInputStream::InitEasy()
 				   StringFormat<1024>("%s:%s", proxy_user,
 						      proxy_password).c_str());
 
-        if (cacert != nullptr)
-            request->SetOption(CURLOPT_CAINFO, cacert);
+	if (cacert != nullptr)
+		request->SetOption(CURLOPT_CAINFO, cacert);
 	request->SetVerifyPeer(verify_peer);
 	request->SetVerifyHost(verify_host);
 	request->SetOption(CURLOPT_HTTPHEADER, request_headers.Get());


### PR DESCRIPTION
Currently it is not possible to set cacert for curl plugin, thus this setting may be hard to find. 

In my case, neither ~/.curlrc nor /etc/curlrc does not affect MPD curl plugin and https streams fail.
With this option, I have set cacert option in mpd.conf and https stream plays properly