### PR TITLE
Fix: Separate Conductor from Performer

### DIFF
--- a/src/tag/Id3Scan.cxx
+++ b/src/tag/Id3Scan.cxx
@@ -352,7 +352,7 @@ scan_id3_tag(const struct id3_tag *tag, TagHandler &handler) noexcept
 			    handler);
 	tag_id3_import_text(tag, ID3_FRAME_COMPOSER, TAG_COMPOSER,
 			    handler);
-	tag_id3_import_text(tag, "TPE3", TAG_PERFORMER,
+	tag_id3_import_text(tag, "TPE3", TAG_CONDUCTOR,
 			    handler);
 	tag_id3_import_text(tag, "TPE4", TAG_PERFORMER, handler);
 	tag_id3_import_text(tag, "TIT1", TAG_GROUPING, handler);


### PR DESCRIPTION
Conductor was incorrectly saved to Performer tag in MPD database