### PR TITLE
Add cacert option for Curl plugin. Allows to set cacert for curl lib

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -210,6 +210,8 @@ will be in effect.
      - Verify the peer's SSL certificate? `More information <http://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html>`_.
    * - **verify_host yes|no**
      - Verify the certificate's name against host? `More information <http://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html>`_.
+   * - **cacert**
+     - Set path to Certificate Authority (CA) bundle `More information <https://curl.se/libcurl/c/CURLOPT_CAINFO.html>`_.
 
 ffmpeg
 ------

--- a/src/input/plugins/CurlInputPlugin.cxx
+++ b/src/input/plugins/CurlInputPlugin.cxx
@@ -148,6 +148,8 @@ static struct curl_slist *http_200_aliases;
 /** HTTP proxy settings */
 static const char *proxy, *proxy_user, *proxy_password;
 static unsigned proxy_port;
+/** CA CERT settings*/
+static const char *cacert;
 
 static bool verify_peer, verify_host;
 
@@ -375,7 +377,7 @@ input_curl_init(EventLoop &event_loop, const ConfigBlock &block)
 #else
 	constexpr bool default_verify = true;
 #endif
-
+	cacert = block.GetBlockValue("cacert");
 	verify_peer = block.GetBlockValue("verify_peer", default_verify);
 	verify_host = block.GetBlockValue("verify_host", default_verify);
 }
@@ -432,6 +434,8 @@ CurlInputStream::InitEasy()
 				   StringFormat<1024>("%s:%s", proxy_user,
 						      proxy_password).c_str());
 
+	if (cacert != nullptr)
+		request->SetOption(CURLOPT_CAINFO, cacert);
 	request->SetVerifyPeer(verify_peer);
 	request->SetVerifyHost(verify_host);
 	request->SetOption(CURLOPT_HTTPHEADER, request_headers.Get());


### PR DESCRIPTION
Add cacert option for curl plugin

    add cacert option for Curl plugin. Allows to set cacert for curl lib
    Added documentation line into doc/plugins.rst with explanation for cacert option