### PR TITLE
MPD_TIMEOUT is in seconds

### DIFF
--- a/doc/client.rst
+++ b/doc/client.rst
@@ -60,6 +60,5 @@ The following environment variables should be obeyed by all clients
   socket.
 - :envvar:`MPD_PORT`: the port number; defaults to 6600.
 - :envvar:`MPD_TIMEOUT`: timeout for connecting to MPD and for waiting
-  for MPD's response in milliseconds.  A good default is 30 seconds
-  (i.e. 30.000 ms).
+  for MPD's response in seconds.  A good default is 30 seconds.
 


### PR DESCRIPTION
At least I believe libmpdclient is reading env. var. as second:
https://github.com/MusicPlayerDaemon/libmpdclient/blob/master/src/settings.c#L142

ncmpc manual also mentions `MPD_TIMEOUT` being is second.