### PR TITLE
time/ISO8601: don't use glibc extension in strptime.

### DIFF
--- a/src/time/ISO8601.cxx
+++ b/src/time/ISO8601.cxx
@@ -202,7 +202,7 @@ ParseISO8601(const char *s)
 	}
 
 	/* parse the date */
-	const char *end = strptime(s, "%F", &tm);
+	const char *end = strptime(s, "%Y-%m-%d", &tm);
 	if (end == nullptr) {
 		/* try without field separators */
 		end = strptime(s, "%Y%m%d", &tm);


### PR DESCRIPTION
Per the manual for strptime, %F is equivalent %Y-%m-%d, so use that
directly.