### PR TITLE
storage/plugins/CurlStorage: don't use glibc extension in

### DIFF
--- a/src/storage/plugins/CurlStorage.cxx
+++ b/src/storage/plugins/CurlStorage.cxx
@@ -193,7 +193,7 @@ ParseTimeStamp(const char *s)
 {
 	try {
 		// TODO: make this more robust
-		return ParseTimePoint(s, "%a, %d %b %Y %T %Z");
+		return ParseTimePoint(s, "%a, %d %b %Y %T");
 	} catch (...) {
 		return std::chrono::system_clock::time_point::min();
 	}


### PR DESCRIPTION
ParseTimePoint.

%Z is a glibc extension to strptime, and is a no-op there, due to the
mapping between timezone names and their definition (especially when the
name comes from a different machine) being ambiguous / impossible.  Time
in HTTP headers is guaranteed to be UTC.

Passing an unknown format to strptime() implementations that don't
support it will generally cause them to return NULL, which will lead to
ParseTimePoint throwing an exception and ParseTimeStamp using an
unnecessary fallback.

Since the timezone name goes at the end of the string, we don't need to
use %Z to skip it (could be an issue in a different time stamp format),
so simply removing %Z works best.