### PR TITLE
Added cross-origin header to http headers of the http output.

### DIFF
--- a/src/output/plugins/httpd/HttpdClient.cxx
+++ b/src/output/plugins/httpd/HttpdClient.cxx
@@ -162,6 +162,7 @@ HttpdClient::SendResponse() noexcept
 			 "Connection: close\r\n"
 			 "Pragma: no-cache\r\n"
 			 "Cache-Control: no-cache, no-store\r\n"
+			 "Access-Control-Allow-Origin: *\r\n"
 			 "\r\n",
 			 httpd.content_type);
 		response = buffer;

--- a/src/output/plugins/httpd/IcyMetaDataServer.cxx
+++ b/src/output/plugins/httpd/IcyMetaDataServer.cxx
@@ -45,6 +45,7 @@ icy_server_metadata_header(const char *name,
 			    "Connection: close\r\n"
 			    "Pragma: no-cache\r\n"
 			    "Cache-Control: no-cache, no-store\r\n"
+				"Access-Control-Allow-Origin: *\r\n"
 			    "\r\n",
 			    name,
 			    genre,


### PR DESCRIPTION
The current http output doesn't provide a header for cross-origin support. This prevents to use the mpd http stream directly from an other webapplication due the origin from the webpage differs from then the audio stream.

The fix is to add the following header to the http response:
Access-Control-Allow-Origin: *

Related to #1119.