### PR TITLE
Fix building under GCC 11

### DIFF
--- a/src/util/RuntimeError.hxx
+++ b/src/util/RuntimeError.hxx
@@ -35,7 +35,7 @@
 
 #include <stdio.h>
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic push
 // TODO: fix this warning properly
 #pragma GCC diagnostic ignored "-Wformat-security"
@@ -59,7 +59,7 @@ FormatInvalidArgument(const char *fmt, Args&&... args) noexcept
 	return std::invalid_argument(buffer);
 }
 
-#ifdef __clang__
+#if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
The build for v022.8 was failing due to -Werror=format-security tripping in GCC 11. This lint was already disabled with Clang, so I just removed the `#ifdef`s.

I don't know in which version GCC enabled this by default, but maybe we should add a check for  `GCC>=version_with_format-security` and `Clang `