### PR TITLE
add constexpr

### DIFF
--- a/src/mixer/plugins/OssMixerPlugin.cxx
+++ b/src/mixer/plugins/OssMixerPlugin.cxx
@@ -175,7 +175,7 @@ OssMixer::SetVolume(unsigned volume)
 		throw MakeErrno("failed to set OSS volume");
 }
 
-const MixerPlugin oss_mixer_plugin = {
+constexpr MixerPlugin oss_mixer_plugin = {
 	oss_mixer_init,
 	true,
 };

--- a/src/mixer/plugins/SndioMixerPlugin.cxx
+++ b/src/mixer/plugins/SndioMixerPlugin.cxx
@@ -53,7 +53,7 @@ sndio_mixer_init([[maybe_unused]] EventLoop &event_loop,
 	return new SndioMixer((SndioOutput &)ao, listener);
 }
 
-const MixerPlugin sndio_mixer_plugin = {
+constexpr MixerPlugin sndio_mixer_plugin = {
 	sndio_mixer_init,
 	false,
 };

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -634,7 +634,7 @@ OssOutput::Play(const void *chunk, size_t size)
 	}
 }
 
-const struct AudioOutputPlugin oss_output_plugin = {
+constexpr struct AudioOutputPlugin oss_output_plugin = {
 	"oss",
 	oss_output_test_default_device,
 	OssOutput::Create,

--- a/src/output/plugins/SndioOutputPlugin.cxx
+++ b/src/output/plugins/SndioOutputPlugin.cxx
@@ -185,7 +185,7 @@ SndioOutput::RegisterMixerListener(Mixer *_mixer, MixerListener *_listener) {
 	listener = _listener;
 }
 
-const struct AudioOutputPlugin sndio_output_plugin = {
+constexpr struct AudioOutputPlugin sndio_output_plugin = {
 	"sndio",
 	sndio_test_default_device,
 	SndioOutput::Create,


### PR DESCRIPTION
Found with cppcoreguidelines-interfaces-global-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>