### PR TITLE
Rough cut for DoP on OSS

### DIFF
--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -48,7 +48,9 @@
 #if defined(__OpenBSD__) || defined(__NetBSD__)
 # include <soundcard.h>
 #else /* !(defined(__OpenBSD__) || defined(__NetBSD__) */
+
 # include <sys/soundcard.h>
+
 #endif /* !(defined(__OpenBSD__) || defined(__NetBSD__) */
 
 /* We got bug reports from FreeBSD users who said that the two 24 bit
@@ -86,7 +88,9 @@ class OssOutput final : AudioOutput {
 #endif
 
 
-    const Domain oss_domain("oss");
+    const Domain oss_domain(
+
+    "oss");
 
     FileDescriptor fd = FileDescriptor::Undefined();
     const char *device;
@@ -114,13 +118,12 @@ public:
 #ifdef ENABLE_DSD
             bool dop,
 #endif
-            const char *_device=nullptr
+            const char *_device = nullptr
     )
-            :AudioOutput(oss_flags),
-             device(_device)
-    {
+            : AudioOutput(oss_flags),
+              device(_device) {
 #ifdef ENABLE_DSD
-        dop_setting = dop;
+          dop_setting = dop;
 #endif
     }
 
@@ -129,21 +132,22 @@ public:
 
 #ifdef AFMT_S24_PACKED
     void Enable() override {
-		pcm_export.Construct();
-	}
+        pcm_export.Construct();
+    }
 
-	void Disable() noexcept override {
-		pcm_export.Destruct();
-	}
+    void Disable() noexcept override {
+        pcm_export.Destruct();
+    }
 #endif
 
     void Open(AudioFormat &audio_format) override;
 
     void Close() noexcept override {
-        DoClose();
+          DoClose();
     }
 
     size_t Play(const void *chunk, size_t size) override;
+
     void Cancel() noexcept override;
 
 private:
@@ -173,47 +177,45 @@ enum oss_stat {
 };
 
 static enum oss_stat
-oss_stat_device(const char *device, int *errno_r) noexcept
-{
-    struct stat st;
+oss_stat_device(const char *device, int *errno_r) noexcept {
+      struct stat st;
 
-    if (0 == stat(device, &st)) {
-        if (!S_ISCHR(st.st_mode)) {
-            return OSS_STAT_NOT_CHAR_DEV;
-        }
-    } else {
-        *errno_r = errno;
+      if (0 == stat(device, &st)) {
+            if (!S_ISCHR(st.st_mode)) {
+                  return OSS_STAT_NOT_CHAR_DEV;
+            }
+      } else {
+            *errno_r = errno;
 
-        switch (errno) {
-            case ENOENT:
-            case ENOTDIR:
-                return OSS_STAT_DOESN_T_EXIST;
-            case EACCES:
-                return OSS_STAT_NO_PERMS;
-            default:
-                return OSS_STAT_OTHER;
-        }
-    }
+            switch (errno) {
+                  case ENOENT:
+                  case ENOTDIR:
+                        return OSS_STAT_DOESN_T_EXIST;
+                  case EACCES:
+                        return OSS_STAT_NO_PERMS;
+                  default:
+                        return OSS_STAT_OTHER;
+            }
+      }
 
-    return OSS_STAT_NO_ERROR;
+      return OSS_STAT_NO_ERROR;
 }
 
-static const char *const default_devices[] = { "/dev/sound/dsp", "/dev/dsp" };
+static const char *const default_devices[] = {"/dev/sound/dsp", "/dev/dsp"};
 
 static bool
-oss_output_test_default_device() noexcept
-{
-    for (int i = std::size(default_devices); --i >= 0; ) {
-        UniqueFileDescriptor fd;
-        if (fd.Open(default_devices[i], O_WRONLY, 0))
-            return true;
+oss_output_test_default_device() noexcept {
+      for (int i = std::size(default_devices); --i >= 0;) {
+            UniqueFileDescriptor fd;
+            if (fd.Open(default_devices[i], O_WRONLY, 0))
+                  return true;
 
-        FormatErrno(oss_output_domain,
-                    "Error opening OSS device \"%s\"",
-                    default_devices[i]);
-    }
+            FormatErrno(oss_output_domain,
+                        "Error opening OSS device \"%s\"",
+                        default_devices[i]);
+      }
 
-    return false;
+      return false;
 }
 
 static OssOutput *
@@ -221,76 +223,73 @@ oss_open_default(
 #ifdef ENABLE_DSD
         bool dop
 #endif
-)
-{
-    int err[std::size(default_devices)];
-    enum oss_stat ret[std::size(default_devices)];
+) {
+      int err[std::size(default_devices)];
+      enum oss_stat ret[std::size(default_devices)];
 
-    for (int i = std::size(default_devices); --i >= 0; ) {
-        ret[i] = oss_stat_device(default_devices[i], &err[i]);
-        if (ret[i] == OSS_STAT_NO_ERROR)
+      for (int i = std::size(default_devices); --i >= 0;) {
+            ret[i] = oss_stat_device(default_devices[i], &err[i]);
+            if (ret[i] == OSS_STAT_NO_ERROR)
+                  return new OssOutput(
+#ifdef ENABLE_DSD
+                          dop,
+#endif
+                          default_devices[i]);
+      }
+
+      for (int i = std::size(default_devices); --i >= 0;) {
+            const char *dev = default_devices[i];
+            switch (ret[i]) {
+                  case OSS_STAT_NO_ERROR:
+                        /* never reached */
+                        break;
+                  case OSS_STAT_DOESN_T_EXIST:
+                        FormatWarning(oss_output_domain,
+                                      "%s not found", dev);
+                        break;
+                  case OSS_STAT_NOT_CHAR_DEV:
+                        FormatWarning(oss_output_domain,
+                                      "%s is not a character device", dev);
+                        break;
+                  case OSS_STAT_NO_PERMS:
+                        FormatWarning(oss_output_domain,
+                                      "%s: permission denied", dev);
+                        break;
+                  case OSS_STAT_OTHER:
+                        FormatErrno(oss_output_domain, err[i],
+                                    "Error accessing %s", dev);
+            }
+      }
+
+      throw std::runtime_error("error trying to open default OSS device");
+}
+
+AudioOutput *
+OssOutput::Create(EventLoop &, const ConfigBlock &block) {
+#ifdef ENABLE_DSD
+      bool dop = block.GetBlockValue("dop", false);
+    if (dop) LogInfo(oss_domain, "experimental oss-dop enabled");
+#endif
+
+      const char *device = block.GetBlockValue("device");
+      if (device != nullptr)
             return new OssOutput(
 #ifdef ENABLE_DSD
                     dop,
 #endif
-                    default_devices[i]);
-    }
+                    device);
 
-    for (int i = std::size(default_devices); --i >= 0; ) {
-        const char *dev = default_devices[i];
-        switch(ret[i]) {
-            case OSS_STAT_NO_ERROR:
-                /* never reached */
-                break;
-            case OSS_STAT_DOESN_T_EXIST:
-                FormatWarning(oss_output_domain,
-                              "%s not found", dev);
-                break;
-            case OSS_STAT_NOT_CHAR_DEV:
-                FormatWarning(oss_output_domain,
-                              "%s is not a character device", dev);
-                break;
-            case OSS_STAT_NO_PERMS:
-                FormatWarning(oss_output_domain,
-                              "%s: permission denied", dev);
-                break;
-            case OSS_STAT_OTHER:
-                FormatErrno(oss_output_domain, err[i],
-                            "Error accessing %s", dev);
-        }
-    }
-
-    throw std::runtime_error("error trying to open default OSS device");
-}
-
-AudioOutput *
-OssOutput::Create(EventLoop &, const ConfigBlock &block)
-{
+      return oss_open_default(
 #ifdef ENABLE_DSD
-    bool dop = block.GetBlockValue("dop", false);
-    if (dop) LogInfo(oss_domain, "experimental oss-dop enabled");
+              dop
 #endif
-
-    const char *device = block.GetBlockValue("device");
-    if (device != nullptr)
-        return new OssOutput(
-#ifdef ENABLE_DSD
-                dop,
-#endif
-                device);
-
-    return oss_open_default(
-#ifdef ENABLE_DSD
-            dop
-#endif
-    );
+      );
 }
 
 void
-OssOutput::DoClose() noexcept
-{
-    if (fd.IsDefined())
-        fd.Close();
+OssOutput::DoClose() noexcept {
+      if (fd.IsDefined())
+            fd.Close();
 }
 
 /**
@@ -302,20 +301,19 @@ OssOutput::DoClose() noexcept
  */
 static bool
 oss_try_ioctl_r(FileDescriptor fd, unsigned long request, int *value_r,
-                const char *msg)
-{
-    assert(fd.IsDefined());
-    assert(value_r != nullptr);
-    assert(msg != nullptr);
+                const char *msg) {
+      assert(fd.IsDefined());
+      assert(value_r != nullptr);
+      assert(msg != nullptr);
 
-    int ret = ioctl(fd.Get(), request, value_r);
-    if (ret >= 0)
-        return true;
+      int ret = ioctl(fd.Get(), request, value_r);
+      if (ret >= 0)
+            return true;
 
-    if (errno == EINVAL)
-        return false;
+      if (errno == EINVAL)
+            return false;
 
-    throw MakeErrno(msg);
+      throw MakeErrno(msg);
 }
 
 /**
@@ -327,9 +325,8 @@ oss_try_ioctl_r(FileDescriptor fd, unsigned long request, int *value_r,
  */
 static bool
 oss_try_ioctl(FileDescriptor fd, unsigned long request, int value,
-              const char *msg)
-{
-    return oss_try_ioctl_r(fd, request, &value, msg);
+              const char *msg) {
+      return oss_try_ioctl_r(fd, request, &value, msg);
 }
 
 /**
@@ -339,31 +336,30 @@ oss_try_ioctl(FileDescriptor fd, unsigned long request, int value,
  * Throws on error.
  */
 static void
-oss_setup_channels(FileDescriptor fd, AudioFormat &audio_format)
-{
-    const char *const msg = "Failed to set channel count";
-    int channels = audio_format.channels;
+oss_setup_channels(FileDescriptor fd, AudioFormat &audio_format) {
+      const char *const msg = "Failed to set channel count";
+      int channels = audio_format.channels;
 
-    if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
-        audio_valid_channel_count(channels)) {
-        audio_format.channels = channels;
-        return;
-    }
-
-    for (unsigned i = 1; i < 2; ++i) {
-        if (i == audio_format.channels)
-            /* don't try that again */
-            continue;
-
-        channels = i;
-        if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
-            audio_valid_channel_count(channels)) {
+      if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
+          audio_valid_channel_count(channels)) {
             audio_format.channels = channels;
             return;
-        }
-    }
+      }
 
-    throw std::runtime_error(msg);
+      for (unsigned i = 1; i < 2; ++i) {
+            if (i == audio_format.channels)
+                  /* don't try that again */
+                  continue;
+
+            channels = i;
+            if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
+                audio_valid_channel_count(channels)) {
+                  audio_format.channels = channels;
+                  return;
+            }
+      }
+
+      throw std::runtime_error(msg);
 }
 
 /**
@@ -377,39 +373,38 @@ oss_setup_sample_rate(FileDescriptor fd, AudioFormat &audio_format
 #ifdef ENABLE_DSD
         , bool dop
 #endif
-)
-{
-    const char *const msg = "Failed to set sample rate";
-    int sample_rate = audio_format.sample_rate;
+) {
+      const char *const msg = "Failed to set sample rate";
+      int sample_rate = audio_format.sample_rate;
 
 #ifdef ENABLE_DSD
-    if (dop) {
+      if (dop) {
         /* DoP packs two 8-bit "samples" in one 24-bit
                "sample" */
         sample_rate /= 2;
     }
 #endif
 
-    if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
-        audio_valid_sample_rate(sample_rate)) {
-        audio_format.sample_rate = sample_rate;
-        return;
-    }
-
-    static constexpr int sample_rates[] = { 48000, 44100, 0 };
-    for (unsigned i = 0; sample_rates[i] != 0; ++i) {
-        sample_rate = sample_rates[i];
-        if (sample_rate == (int)audio_format.sample_rate)
-            continue;
-
-        if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
-            audio_valid_sample_rate(sample_rate)) {
+      if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
+          audio_valid_sample_rate(sample_rate)) {
             audio_format.sample_rate = sample_rate;
             return;
-        }
-    }
+      }
 
-    throw std::runtime_error(msg);
+      static constexpr int sample_rates[] = {48000, 44100, 0};
+      for (unsigned i = 0; sample_rates[i] != 0; ++i) {
+            sample_rate = sample_rates[i];
+            if (sample_rate == (int) audio_format.sample_rate)
+                  continue;
+
+            if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
+                audio_valid_sample_rate(sample_rate)) {
+                  audio_format.sample_rate = sample_rate;
+                  return;
+            }
+      }
+
+      throw std::runtime_error(msg);
 }
 
 /**
@@ -422,46 +417,45 @@ sample_format_to_oss(SampleFormat format
 #ifdef ENABLE_DSD
         , bool dop
 #endif
-) noexcept
-{
-    switch (format) {
-        case SampleFormat::UNDEFINED:
-        case SampleFormat::FLOAT:
-            return AFMT_QUERY;
-        case SampleFormat::DSD:
+) noexcept {
+      switch (format) {
+            case SampleFormat::UNDEFINED:
+            case SampleFormat::FLOAT:
+                  return AFMT_QUERY;
+            case SampleFormat::DSD:
 #ifdef ENABLE_DSD
-#ifdef AFMT_S24_NE
+                  #ifdef AFMT_S24_NE
             if (dop) return AFMT_S24_NE;
 #endif
 #ifdef AFMT_S32_NE
             if (dop) return AFMT_S32_NE;
 #endif
 #endif
-            return AFMT_QUERY;
+                  return AFMT_QUERY;
 
-        case SampleFormat::S8:
-            return AFMT_S8;
+            case SampleFormat::S8:
+                  return AFMT_S8;
 
-        case SampleFormat::S16:
-            return AFMT_S16_NE;
+            case SampleFormat::S16:
+                  return AFMT_S16_NE;
 
-        case SampleFormat::S24_P32:
+            case SampleFormat::S24_P32:
 #ifdef AFMT_S24_NE
-            return AFMT_S24_NE;
+                  return AFMT_S24_NE;
 #else
-            return AFMT_QUERY;
+                  return AFMT_QUERY;
 #endif
 
-        case SampleFormat::S32:
+            case SampleFormat::S32:
 #ifdef AFMT_S32_NE
-            return AFMT_S32_NE;
+                  return AFMT_S32_NE;
 #else
-            return AFMT_QUERY;
+                  return AFMT_QUERY;
 #endif
-    }
+      }
 
-    assert(false);
-    gcc_unreachable();
+      assert(false);
+      gcc_unreachable();
 }
 
 /**
@@ -470,40 +464,40 @@ sample_format_to_oss(SampleFormat format
  */
 gcc_const
 static SampleFormat
+
 sample_format_from_oss(int format
 #ifdef ENABLE_DSD
-, bool dop
+        , bool dop
 #endif
-) noexcept
-{
-    switch (format) {
-        case AFMT_S8:
-            return SampleFormat::S8;
+) noexcept {
+      switch (format) {
+            case AFMT_S8:
+                  return SampleFormat::S8;
 
-        case AFMT_S16_NE:
-            return SampleFormat::S16;
+            case AFMT_S16_NE:
+                  return SampleFormat::S16;
 
 #ifdef AFMT_S24_PACKED
-            case AFMT_S24_PACKED:
-		return SampleFormat::S24_P32;
+                  case AFMT_S24_PACKED:
+        return SampleFormat::S24_P32;
 #endif
 
 #ifdef AFMT_S24_NE
-            case AFMT_S24_NE:
-		return SampleFormat::S24_P32;
+                  case AFMT_S24_NE:
+        return SampleFormat::S24_P32;
 #endif
 
 #ifdef AFMT_S32_NE
-        case AFMT_S32_NE:
+                  case AFMT_S32_NE:
 #ifdef ENABLE_DSD
-        if (dop) return SampleFormat::DSD;
+            if (dop) return SampleFormat::DSD;
 #endif
-            return SampleFormat::S32;
+                return SampleFormat::S32;
 #endif
 
-        default:
-            return SampleFormat::UNDEFINED;
-    }
+            default:
+                  return SampleFormat::UNDEFINED;
+      }
 }
 
 /**
@@ -523,57 +517,56 @@ oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
 #ifdef AFMT_S24_PACKED
         , PcmExport &pcm_export
 #endif
-)
-{
-    int oss_format = sample_format_to_oss(sample_format
+) {
+      int oss_format = sample_format_to_oss(sample_format
 #ifdef ENABLE_DSD
-            , dop
+              , dop
 #endif
-    );
-    if (oss_format == AFMT_QUERY)
-        return false;
+      );
+      if (oss_format == AFMT_QUERY)
+            return false;
 
-    bool success =
-            oss_try_ioctl_r(fd, SNDCTL_DSP_SAMPLESIZE,
-                            &oss_format,
-                            "Failed to set sample format");
+      bool success =
+              oss_try_ioctl_r(fd, SNDCTL_DSP_SAMPLESIZE,
+                              &oss_format,
+                              "Failed to set sample format");
 
 #ifdef AFMT_S24_PACKED
-    if (!success && sample_format == SampleFormat::S24_P32) {
-		/* if the driver doesn't support padded 24 bit, try
-		   packed 24 bit */
-		oss_format = AFMT_S24_PACKED;
-		success = oss_try_ioctl_r(fd, SNDCTL_DSP_SAMPLESIZE,
-					  &oss_format,
-					  "Failed to set sample format");
-	}
+      if (!success && sample_format == SampleFormat::S24_P32) {
+        /* if the driver doesn't support padded 24 bit, try
+           packed 24 bit */
+        oss_format = AFMT_S24_PACKED;
+        success = oss_try_ioctl_r(fd, SNDCTL_DSP_SAMPLESIZE,
+                      &oss_format,
+                      "Failed to set sample format");
+    }
 #endif
 
-    if (!success)
-        return false;
+      if (!success)
+            return false;
 
-    sample_format = sample_format_from_oss(oss_format
+      sample_format = sample_format_from_oss(oss_format
 #ifdef ENABLE_DSD
-            , dop
+              , dop
 #endif
-            );
-    if (sample_format == SampleFormat::UNDEFINED)
-        return false;
+      );
+      if (sample_format == SampleFormat::UNDEFINED)
+            return false;
 
-    *sample_format_r = sample_format;
-    *oss_format_r = oss_format;
+      *sample_format_r = sample_format;
+      *oss_format_r = oss_format;
 
 #ifdef AFMT_S24_PACKED
-    PcmExport::Params params;
-	params.alsa_channel_order = true;
-	params.pack24 = oss_format == AFMT_S24_PACKED;
-	params.reverse_endian = oss_format == AFMT_S24_PACKED &&
-		!IsLittleEndian();
+      PcmExport::Params params;
+    params.alsa_channel_order = true;
+    params.pack24 = oss_format == AFMT_S24_PACKED;
+    params.reverse_endian = oss_format == AFMT_S24_PACKED &&
+        !IsLittleEndian();
 
-	pcm_export.Open(sample_format, 0, params);
+    pcm_export.Open(sample_format, 0, params);
 #endif
 
-    return true;
+      return true;
 }
 
 /**
@@ -589,73 +582,71 @@ oss_setup_sample_format(FileDescriptor fd, AudioFormat &audio_format,
 #ifdef AFMT_S24_PACKED
         , PcmExport &pcm_export
 #endif
-)
-{
-    SampleFormat mpd_format;
-    if (oss_probe_sample_format(fd, audio_format.format,
-                                &mpd_format, oss_format_r
+) {
+      SampleFormat mpd_format;
+      if (oss_probe_sample_format(fd, audio_format.format,
+                                  &mpd_format, oss_format_r
 #ifdef ENABLE_DSD
-            , dop
+              , dop
 #endif
 #ifdef AFMT_S24_PACKED
-            , pcm_export
+              , pcm_export
 #endif
-    )) {
-        audio_format.format = mpd_format;
-        return;
-    }
-
-    /* the requested sample format is not available - probe for
-       other formats supported by MPD */
-
-    static constexpr SampleFormat sample_formats[] = {
-            SampleFormat::S24_P32,
-            SampleFormat::S32,
-            SampleFormat::S16,
-            SampleFormat::S8,
-            SampleFormat::UNDEFINED /* sentinel */
-    };
-
-    for (unsigned i = 0; sample_formats[i] != SampleFormat::UNDEFINED; ++i) {
-        mpd_format = sample_formats[i];
-        if (mpd_format == audio_format.format)
-            /* don't try that again */
-            continue;
-
-        if (oss_probe_sample_format(fd, mpd_format,
-                                    &mpd_format, oss_format_r
-#ifdef ENABLE_DSD
-                , dop
-#endif
-#ifdef AFMT_S24_PACKED
-                , pcm_export
-#endif
-        )) {
+      )) {
             audio_format.format = mpd_format;
             return;
-        }
-    }
+      }
 
-    throw std::runtime_error("Failed to set sample format");
+      /* the requested sample format is not available - probe for
+         other formats supported by MPD */
+
+      static constexpr SampleFormat sample_formats[] = {
+              SampleFormat::S24_P32,
+              SampleFormat::S32,
+              SampleFormat::S16,
+              SampleFormat::S8,
+              SampleFormat::UNDEFINED /* sentinel */
+      };
+
+      for (unsigned i = 0; sample_formats[i] != SampleFormat::UNDEFINED; ++i) {
+            mpd_format = sample_formats[i];
+            if (mpd_format == audio_format.format)
+                  /* don't try that again */
+                  continue;
+
+            if (oss_probe_sample_format(fd, mpd_format,
+                                        &mpd_format, oss_format_r
+#ifdef ENABLE_DSD
+                    , dop
+#endif
+#ifdef AFMT_S24_PACKED
+                    , pcm_export
+#endif
+            )) {
+                  audio_format.format = mpd_format;
+                  return;
+            }
+      }
+
+      throw std::runtime_error("Failed to set sample format");
 }
 
 inline void
-OssOutput::Setup(AudioFormat &_audio_format)
-{
-    oss_setup_channels(fd, _audio_format);
-    oss_setup_sample_rate(fd, _audio_format
+OssOutput::Setup(AudioFormat &_audio_format) {
+      oss_setup_channels(fd, _audio_format);
+      oss_setup_sample_rate(fd, _audio_format
 #ifdef ENABLE_DSD
-            , dop_active
+              , dop_active
 #endif
-    );
-    oss_setup_sample_format(fd, _audio_format, &oss_format
+      );
+      oss_setup_sample_format(fd, _audio_format, &oss_format
 #ifdef ENABLE_DSD
-            , dop_active
+              , dop_active
 #endif
 #ifdef AFMT_S24_PACKED
-            , pcm_export
+              , pcm_export
 #endif
-    );
+      );
 }
 
 /**
@@ -664,62 +655,62 @@ OssOutput::Setup(AudioFormat &_audio_format)
 inline void
 OssOutput::Reopen()
 try {
-    assert(!fd.IsDefined());
+      assert(!fd.IsDefined());
 
-    if (!fd.Open(device, O_WRONLY))
-        throw FormatErrno("Error opening OSS device \"%s\"", device);
+      if (!fd.Open(device, O_WRONLY))
+            throw FormatErrno("Error opening OSS device \"%s\"", device);
 
-    const char *const msg1 = "Failed to set channel count";
-    if (!oss_try_ioctl(fd, SNDCTL_DSP_CHANNELS,
-                       audio_format.channels, msg1))
-        throw std::runtime_error(msg1);
+      const char *const msg1 = "Failed to set channel count";
+      if (!oss_try_ioctl(fd, SNDCTL_DSP_CHANNELS,
+                         audio_format.channels, msg1))
+            throw std::runtime_error(msg1);
 
-    const char *const msg2 = "Failed to set sample rate";
-    auto samplerate = audio_format.sample_rate;
+      const char *const msg2 = "Failed to set sample rate";
+      auto samplerate = audio_format.sample_rate;
 #ifdef ENABLE_DSD
-    if (dop_active) samplerate /= 2;
+      if (dop_active) samplerate /= 2;
 #endif
-    if (!oss_try_ioctl(fd, SNDCTL_DSP_SPEED,
-                       samplerate, msg2))
-        throw std::runtime_error(msg2);
+      if (!oss_try_ioctl(fd, SNDCTL_DSP_SPEED,
+                         samplerate, msg2))
+            throw std::runtime_error(msg2);
 
-    auto samplesize = oss_format;
+      auto samplesize = oss_format;
 #ifdef ENABLE_DSD
-#ifdef AFMT_S24_NE
+      #ifdef AFMT_S24_NE
     if (dop_active) samplesize = AFMT_S24_NE;
 #elif AFMT_S32_NE
     if (dop_active) samplesize = AFMT_S32_NE;
 #endif
 #endif
-    const char *const msg3 = "Failed to set sample format";
-    if (!oss_try_ioctl(fd, SNDCTL_DSP_SAMPLESIZE,
-                       samplesize, msg3))
-        throw std::runtime_error(msg3);
+      const char *const msg3 = "Failed to set sample format";
+      if (!oss_try_ioctl(fd, SNDCTL_DSP_SAMPLESIZE,
+                         samplesize, msg3))
+            throw std::runtime_error(msg3);
 
 } catch (...) {
-    DoClose();
-    throw;
+      DoClose();
+      throw;
 }
 
 void
 OssOutput::Open(AudioFormat &_audio_format)
 try {
-    const auto old_srate = _audio_format.sample_rate;
+      const auto old_srate = _audio_format.sample_rate;
 #ifdef ENABLE_DSD
 
-    if (dop_setting && _audio_format.format == SampleFormat::DSD) {
+      if (dop_setting && _audio_format.format == SampleFormat::DSD) {
         LogInfo(oss_domain, "oss-dop active for current playback");
         dop_active = true;
     }
     if (_audio_format.format != SampleFormat::DSD && dop_active) dop_active = false;
 #endif
 
-    if (!fd.Open(device, O_WRONLY))
-        throw FormatErrno("Error opening OSS device \"%s\"", device);
+      if (!fd.Open(device, O_WRONLY))
+            throw FormatErrno("Error opening OSS device \"%s\"", device);
 
-    Setup(_audio_format);
+      Setup(_audio_format);
 #ifdef ENABLE_DSD
-    if (dop_setting) {
+      if (dop_setting) {
         pcm_export_dop.Construct();
 
         params.alsa_channel_order = true;
@@ -736,45 +727,44 @@ try {
     }
 #endif
 
-    audio_format = _audio_format;
+      audio_format = _audio_format;
 
 } catch (...) {
 #ifdef ENABLE_DSD
-    pcm_export_dop.Destruct();
+      pcm_export_dop.Destruct();
 #endif
-    DoClose();
-    throw;
+      DoClose();
+      throw;
 }
 
 void
-OssOutput::Cancel() noexcept
-{
-    if (fd.IsDefined()) {
-        ioctl(fd.Get(), SNDCTL_DSP_RESET, 0);
-        DoClose();
-    }
+OssOutput::Cancel() noexcept {
+      if (fd.IsDefined()) {
+            ioctl(fd.Get(), SNDCTL_DSP_RESET, 0);
+            DoClose();
+      }
 
 #ifdef ENABLE_DSD
-    pcm_export_dop.Destruct();
+      pcm_export_dop.Destruct();
 #endif
 
 #ifdef AFMT_S24_PACKED
-    pcm_export->Reset();
+      pcm_export->Reset();
 #endif
 }
 
 size_t
 OssOutput::Play(const void *chunk, size_t size) {
-    ssize_t ret;
+      ssize_t ret;
 
-    assert(size > 0);
+      assert(size > 0);
 
-    /* reopen the device since it was closed by dropBufferedAudio */
-    if (!fd.IsDefined())
-        Reopen();
+      /* reopen the device since it was closed by dropBufferedAudio */
+      if (!fd.IsDefined())
+            Reopen();
 
 #ifdef AFMT_S24_PACKED
-    const auto e = pcm_export->Export({chunk, size});
+      const auto e = pcm_export->Export({chunk, size});
     if (e.empty())
         return size;
 
@@ -782,7 +772,7 @@ OssOutput::Play(const void *chunk, size_t size) {
     size = e.size;
 #endif
 #ifdef ENABLE_DSD
-    if (dop_active) {
+      if (dop_active) {
         const auto e = pcm_export_dop->Export({chunk, size});
         if (e.empty())
             return size;
@@ -793,24 +783,24 @@ OssOutput::Play(const void *chunk, size_t size) {
 
 #endif
 
-    while (true) {
-        ret = fd.Write(chunk, size);
+      while (true) {
+            ret = fd.Write(chunk, size);
 
-        if (ret > 0) {
+            if (ret > 0) {
 #ifdef AFMT_S24_PACKED
-            ret = pcm_export->CalcInputSize(ret);
+                  ret = pcm_export->CalcInputSize(ret);
 #endif
 #ifdef ENABLE_DSD
-            if (dop_active) {
+                  if (dop_active) {
                 ret = pcm_export_dop->CalcInputSize(ret);
             }
 #endif
-            return ret;
-        }
+                  return ret;
+            }
 
-        if (ret < 0 && errno != EINTR)
-            throw FormatErrno("Write error on %s", device);
-    }
+            if (ret < 0 && errno != EINTR)
+                  throw FormatErrno("Write error on %s", device);
+      }
 }
 
 constexpr struct AudioOutputPlugin oss_output_plugin = {

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -69,11 +69,11 @@
 
 class OssOutput final : AudioOutput {
 #ifdef AFMT_S24_PACKED
-    Manual<PcmExport> pcm_export;
+	Manual<PcmExport> pcm_export;
 #endif
 
 #ifdef ENABLE_DSD
-    /**
+	/**
      * Enable DSD over PCM according to the DoP standard?
      *
      * @see http://dsd-guide.com/dop-open-standard
@@ -88,50 +88,50 @@ class OssOutput final : AudioOutput {
 #endif
 
 
-    const Domain oss_domain(
+	const Domain oss_domain(
 
-    "oss");
+	"oss");
 
-    FileDescriptor fd = FileDescriptor::Undefined();
-    const char *device;
+	FileDescriptor fd = FileDescriptor::Undefined();
+	const char *device;
 
-    /**
-     * The current input audio format.  This is needed to reopen
-     * the device after cancel().
-     */
-    AudioFormat audio_format;
+	/**
+	 * The current input audio format.  This is needed to reopen
+	 * the device after cancel().
+	 */
+	AudioFormat audio_format;
 
-    /**
-     * The current OSS audio format.  This is needed to reopen the
-     * device after cancel().
-     */
-    int oss_format;
+	/**
+	 * The current OSS audio format.  This is needed to reopen the
+	 * device after cancel().
+	 */
+	int oss_format;
 
 #ifdef AFMT_S24_PACKED
-    static constexpr unsigned oss_flags = FLAG_ENABLE_DISABLE;
+	static constexpr unsigned oss_flags = FLAG_ENABLE_DISABLE;
 #else
-    static constexpr unsigned oss_flags = 0;
+	static constexpr unsigned oss_flags = 0;
 #endif
 
 public:
-    explicit OssOutput(
+	explicit OssOutput(
 #ifdef ENABLE_DSD
-            bool dop,
+			bool dop,
 #endif
-            const char *_device = nullptr
-    )
-            : AudioOutput(oss_flags),
-              device(_device) {
+			const char *_device = nullptr
+	)
+			: AudioOutput(oss_flags),
+			  device(_device) {
 #ifdef ENABLE_DSD
-          dop_setting = dop;
+		dop_setting = dop;
 #endif
-    }
+	}
 
-    static AudioOutput *Create(EventLoop &event_loop,
-                               const ConfigBlock &block);
+	static AudioOutput *Create(EventLoop &event_loop,
+							   const ConfigBlock &block);
 
 #ifdef AFMT_S24_PACKED
-    void Enable() override {
+	void Enable() override {
         pcm_export.Construct();
     }
 
@@ -140,156 +140,156 @@ public:
     }
 #endif
 
-    void Open(AudioFormat &audio_format) override;
+	void Open(AudioFormat &audio_format) override;
 
-    void Close() noexcept override {
-          DoClose();
-    }
+	void Close() noexcept override {
+		DoClose();
+	}
 
-    size_t Play(const void *chunk, size_t size) override;
+	size_t Play(const void *chunk, size_t size) override;
 
-    void Cancel() noexcept override;
+	void Cancel() noexcept override;
 
 private:
-    /**
-     * Sets up the OSS device which was opened before.
-     */
-    void Setup(AudioFormat &audio_format);
+	/**
+	 * Sets up the OSS device which was opened before.
+	 */
+	void Setup(AudioFormat &audio_format);
 
-    /**
-     * Reopen the device with the saved audio_format, without any probing.
-     *
-     * Throws on error.
-     */
-    void Reopen();
+	/**
+	 * Reopen the device with the saved audio_format, without any probing.
+	 *
+	 * Throws on error.
+	 */
+	void Reopen();
 
-    void DoClose() noexcept;
+	void DoClose() noexcept;
 };
 
 static constexpr Domain oss_output_domain("oss_output");
 
 enum oss_stat {
-    OSS_STAT_NO_ERROR = 0,
-    OSS_STAT_NOT_CHAR_DEV = -1,
-    OSS_STAT_NO_PERMS = -2,
-    OSS_STAT_DOESN_T_EXIST = -3,
-    OSS_STAT_OTHER = -4,
+	OSS_STAT_NO_ERROR = 0,
+	OSS_STAT_NOT_CHAR_DEV = -1,
+	OSS_STAT_NO_PERMS = -2,
+	OSS_STAT_DOESN_T_EXIST = -3,
+	OSS_STAT_OTHER = -4,
 };
 
 static enum oss_stat
 oss_stat_device(const char *device, int *errno_r) noexcept {
-      struct stat st;
+	struct stat st;
 
-      if (0 == stat(device, &st)) {
-            if (!S_ISCHR(st.st_mode)) {
-                  return OSS_STAT_NOT_CHAR_DEV;
-            }
-      } else {
-            *errno_r = errno;
+	if (0 == stat(device, &st)) {
+		if (!S_ISCHR(st.st_mode)) {
+			return OSS_STAT_NOT_CHAR_DEV;
+		}
+	} else {
+		*errno_r = errno;
 
-            switch (errno) {
-                  case ENOENT:
-                  case ENOTDIR:
-                        return OSS_STAT_DOESN_T_EXIST;
-                  case EACCES:
-                        return OSS_STAT_NO_PERMS;
-                  default:
-                        return OSS_STAT_OTHER;
-            }
-      }
+		switch (errno) {
+			case ENOENT:
+			case ENOTDIR:
+				return OSS_STAT_DOESN_T_EXIST;
+			case EACCES:
+				return OSS_STAT_NO_PERMS;
+			default:
+				return OSS_STAT_OTHER;
+		}
+	}
 
-      return OSS_STAT_NO_ERROR;
+	return OSS_STAT_NO_ERROR;
 }
 
 static const char *const default_devices[] = {"/dev/sound/dsp", "/dev/dsp"};
 
 static bool
 oss_output_test_default_device() noexcept {
-      for (int i = std::size(default_devices); --i >= 0;) {
-            UniqueFileDescriptor fd;
-            if (fd.Open(default_devices[i], O_WRONLY, 0))
-                  return true;
+	for (int i = std::size(default_devices); --i >= 0;) {
+		UniqueFileDescriptor fd;
+		if (fd.Open(default_devices[i], O_WRONLY, 0))
+			return true;
 
-            FormatErrno(oss_output_domain,
-                        "Error opening OSS device \"%s\"",
-                        default_devices[i]);
-      }
+		FormatErrno(oss_output_domain,
+					"Error opening OSS device \"%s\"",
+					default_devices[i]);
+	}
 
-      return false;
+	return false;
 }
 
 static OssOutput *
 oss_open_default(
 #ifdef ENABLE_DSD
-        bool dop
+		bool dop
 #endif
 ) {
-      int err[std::size(default_devices)];
-      enum oss_stat ret[std::size(default_devices)];
+	int err[std::size(default_devices)];
+	enum oss_stat ret[std::size(default_devices)];
 
-      for (int i = std::size(default_devices); --i >= 0;) {
-            ret[i] = oss_stat_device(default_devices[i], &err[i]);
-            if (ret[i] == OSS_STAT_NO_ERROR)
-                  return new OssOutput(
+	for (int i = std::size(default_devices); --i >= 0;) {
+		ret[i] = oss_stat_device(default_devices[i], &err[i]);
+		if (ret[i] == OSS_STAT_NO_ERROR)
+			return new OssOutput(
 #ifdef ENABLE_DSD
-                          dop,
+					dop,
 #endif
-                          default_devices[i]);
-      }
+					default_devices[i]);
+	}
 
-      for (int i = std::size(default_devices); --i >= 0;) {
-            const char *dev = default_devices[i];
-            switch (ret[i]) {
-                  case OSS_STAT_NO_ERROR:
-                        /* never reached */
-                        break;
-                  case OSS_STAT_DOESN_T_EXIST:
-                        FormatWarning(oss_output_domain,
-                                      "%s not found", dev);
-                        break;
-                  case OSS_STAT_NOT_CHAR_DEV:
-                        FormatWarning(oss_output_domain,
-                                      "%s is not a character device", dev);
-                        break;
-                  case OSS_STAT_NO_PERMS:
-                        FormatWarning(oss_output_domain,
-                                      "%s: permission denied", dev);
-                        break;
-                  case OSS_STAT_OTHER:
-                        FormatErrno(oss_output_domain, err[i],
-                                    "Error accessing %s", dev);
-            }
-      }
+	for (int i = std::size(default_devices); --i >= 0;) {
+		const char *dev = default_devices[i];
+		switch (ret[i]) {
+			case OSS_STAT_NO_ERROR:
+				/* never reached */
+				break;
+			case OSS_STAT_DOESN_T_EXIST:
+				FormatWarning(oss_output_domain,
+							  "%s not found", dev);
+				break;
+			case OSS_STAT_NOT_CHAR_DEV:
+				FormatWarning(oss_output_domain,
+							  "%s is not a character device", dev);
+				break;
+			case OSS_STAT_NO_PERMS:
+				FormatWarning(oss_output_domain,
+							  "%s: permission denied", dev);
+				break;
+			case OSS_STAT_OTHER:
+				FormatErrno(oss_output_domain, err[i],
+							"Error accessing %s", dev);
+		}
+	}
 
-      throw std::runtime_error("error trying to open default OSS device");
+	throw std::runtime_error("error trying to open default OSS device");
 }
 
 AudioOutput *
 OssOutput::Create(EventLoop &, const ConfigBlock &block) {
 #ifdef ENABLE_DSD
-      bool dop = block.GetBlockValue("dop", false);
+	bool dop = block.GetBlockValue("dop", false);
     if (dop) LogInfo(oss_domain, "experimental oss-dop enabled");
 #endif
 
-      const char *device = block.GetBlockValue("device");
-      if (device != nullptr)
-            return new OssOutput(
+	const char *device = block.GetBlockValue("device");
+	if (device != nullptr)
+		return new OssOutput(
 #ifdef ENABLE_DSD
-                    dop,
+				dop,
 #endif
-                    device);
+				device);
 
-      return oss_open_default(
+	return oss_open_default(
 #ifdef ENABLE_DSD
-              dop
+			dop
 #endif
-      );
+	);
 }
 
 void
 OssOutput::DoClose() noexcept {
-      if (fd.IsDefined())
-            fd.Close();
+	if (fd.IsDefined())
+		fd.Close();
 }
 
 /**
@@ -301,19 +301,19 @@ OssOutput::DoClose() noexcept {
  */
 static bool
 oss_try_ioctl_r(FileDescriptor fd, unsigned long request, int *value_r,
-                const char *msg) {
-      assert(fd.IsDefined());
-      assert(value_r != nullptr);
-      assert(msg != nullptr);
+				const char *msg) {
+	assert(fd.IsDefined());
+	assert(value_r != nullptr);
+	assert(msg != nullptr);
 
-      int ret = ioctl(fd.Get(), request, value_r);
-      if (ret >= 0)
-            return true;
+	int ret = ioctl(fd.Get(), request, value_r);
+	if (ret >= 0)
+		return true;
 
-      if (errno == EINVAL)
-            return false;
+	if (errno == EINVAL)
+		return false;
 
-      throw MakeErrno(msg);
+	throw MakeErrno(msg);
 }
 
 /**
@@ -325,8 +325,8 @@ oss_try_ioctl_r(FileDescriptor fd, unsigned long request, int *value_r,
  */
 static bool
 oss_try_ioctl(FileDescriptor fd, unsigned long request, int value,
-              const char *msg) {
-      return oss_try_ioctl_r(fd, request, &value, msg);
+			  const char *msg) {
+	return oss_try_ioctl_r(fd, request, &value, msg);
 }
 
 /**
@@ -337,29 +337,29 @@ oss_try_ioctl(FileDescriptor fd, unsigned long request, int value,
  */
 static void
 oss_setup_channels(FileDescriptor fd, AudioFormat &audio_format) {
-      const char *const msg = "Failed to set channel count";
-      int channels = audio_format.channels;
+	const char *const msg = "Failed to set channel count";
+	int channels = audio_format.channels;
 
-      if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
-          audio_valid_channel_count(channels)) {
-            audio_format.channels = channels;
-            return;
-      }
+	if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
+		audio_valid_channel_count(channels)) {
+		audio_format.channels = channels;
+		return;
+	}
 
-      for (unsigned i = 1; i < 2; ++i) {
-            if (i == audio_format.channels)
-                  /* don't try that again */
-                  continue;
+	for (unsigned i = 1; i < 2; ++i) {
+		if (i == audio_format.channels)
+			/* don't try that again */
+			continue;
 
-            channels = i;
-            if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
-                audio_valid_channel_count(channels)) {
-                  audio_format.channels = channels;
-                  return;
-            }
-      }
+		channels = i;
+		if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
+			audio_valid_channel_count(channels)) {
+			audio_format.channels = channels;
+			return;
+		}
+	}
 
-      throw std::runtime_error(msg);
+	throw std::runtime_error(msg);
 }
 
 /**
@@ -371,40 +371,40 @@ oss_setup_channels(FileDescriptor fd, AudioFormat &audio_format) {
 static void
 oss_setup_sample_rate(FileDescriptor fd, AudioFormat &audio_format
 #ifdef ENABLE_DSD
-        , bool dop
+		, bool dop
 #endif
 ) {
-      const char *const msg = "Failed to set sample rate";
-      int sample_rate = audio_format.sample_rate;
+	const char *const msg = "Failed to set sample rate";
+	int sample_rate = audio_format.sample_rate;
 
 #ifdef ENABLE_DSD
-      if (dop) {
+	if (dop) {
         /* DoP packs two 8-bit "samples" in one 24-bit
                "sample" */
         sample_rate /= 2;
     }
 #endif
 
-      if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
-          audio_valid_sample_rate(sample_rate)) {
-            audio_format.sample_rate = sample_rate;
-            return;
-      }
+	if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
+		audio_valid_sample_rate(sample_rate)) {
+		audio_format.sample_rate = sample_rate;
+		return;
+	}
 
-      static constexpr int sample_rates[] = {48000, 44100, 0};
-      for (unsigned i = 0; sample_rates[i] != 0; ++i) {
-            sample_rate = sample_rates[i];
-            if (sample_rate == (int) audio_format.sample_rate)
-                  continue;
+	static constexpr int sample_rates[] = {48000, 44100, 0};
+	for (unsigned i = 0; sample_rates[i] != 0; ++i) {
+		sample_rate = sample_rates[i];
+		if (sample_rate == (int) audio_format.sample_rate)
+			continue;
 
-            if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
-                audio_valid_sample_rate(sample_rate)) {
-                  audio_format.sample_rate = sample_rate;
-                  return;
-            }
-      }
+		if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
+			audio_valid_sample_rate(sample_rate)) {
+			audio_format.sample_rate = sample_rate;
+			return;
+		}
+	}
 
-      throw std::runtime_error(msg);
+	throw std::runtime_error(msg);
 }
 
 /**
@@ -415,47 +415,47 @@ gcc_const
 static int
 sample_format_to_oss(SampleFormat format
 #ifdef ENABLE_DSD
-        , bool dop
+		, bool dop
 #endif
 ) noexcept {
-      switch (format) {
-            case SampleFormat::UNDEFINED:
-            case SampleFormat::FLOAT:
-                  return AFMT_QUERY;
-            case SampleFormat::DSD:
+	switch (format) {
+		case SampleFormat::UNDEFINED:
+		case SampleFormat::FLOAT:
+			return AFMT_QUERY;
+		case SampleFormat::DSD:
 #ifdef ENABLE_DSD
-                  #ifdef AFMT_S24_NE
+			#ifdef AFMT_S24_NE
             if (dop) return AFMT_S24_NE;
 #endif
 #ifdef AFMT_S32_NE
             if (dop) return AFMT_S32_NE;
 #endif
 #endif
-                  return AFMT_QUERY;
+			return AFMT_QUERY;
 
-            case SampleFormat::S8:
-                  return AFMT_S8;
+		case SampleFormat::S8:
+			return AFMT_S8;
 
-            case SampleFormat::S16:
-                  return AFMT_S16_NE;
+		case SampleFormat::S16:
+			return AFMT_S16_NE;
 
-            case SampleFormat::S24_P32:
+		case SampleFormat::S24_P32:
 #ifdef AFMT_S24_NE
-                  return AFMT_S24_NE;
+			return AFMT_S24_NE;
 #else
-                  return AFMT_QUERY;
+			return AFMT_QUERY;
 #endif
 
-            case SampleFormat::S32:
+		case SampleFormat::S32:
 #ifdef AFMT_S32_NE
-                  return AFMT_S32_NE;
+			return AFMT_S32_NE;
 #else
-                  return AFMT_QUERY;
+			return AFMT_QUERY;
 #endif
-      }
+	}
 
-      assert(false);
-      gcc_unreachable();
+	assert(false);
+	gcc_unreachable();
 }
 
 /**
@@ -467,37 +467,37 @@ static SampleFormat
 
 sample_format_from_oss(int format
 #ifdef ENABLE_DSD
-        , bool dop
+		, bool dop
 #endif
 ) noexcept {
-      switch (format) {
-            case AFMT_S8:
-                  return SampleFormat::S8;
+	switch (format) {
+		case AFMT_S8:
+			return SampleFormat::S8;
 
-            case AFMT_S16_NE:
-                  return SampleFormat::S16;
+		case AFMT_S16_NE:
+			return SampleFormat::S16;
 
 #ifdef AFMT_S24_PACKED
-                  case AFMT_S24_PACKED:
+			case AFMT_S24_PACKED:
         return SampleFormat::S24_P32;
 #endif
 
 #ifdef AFMT_S24_NE
-                  case AFMT_S24_NE:
+			case AFMT_S24_NE:
         return SampleFormat::S24_P32;
 #endif
 
 #ifdef AFMT_S32_NE
-                  case AFMT_S32_NE:
+			case AFMT_S32_NE:
 #ifdef ENABLE_DSD
             if (dop) return SampleFormat::DSD;
 #endif
                 return SampleFormat::S32;
 #endif
 
-            default:
-                  return SampleFormat::UNDEFINED;
-      }
+		default:
+			return SampleFormat::UNDEFINED;
+	}
 }
 
 /**
@@ -509,30 +509,30 @@ sample_format_from_oss(int format
  */
 static bool
 oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
-                        SampleFormat *sample_format_r,
-                        int *oss_format_r
+						SampleFormat *sample_format_r,
+						int *oss_format_r
 #ifdef ENABLE_DSD
-        , bool dop
+		, bool dop
 #endif
 #ifdef AFMT_S24_PACKED
-        , PcmExport &pcm_export
+		, PcmExport &pcm_export
 #endif
 ) {
-      int oss_format = sample_format_to_oss(sample_format
+	int oss_format = sample_format_to_oss(sample_format
 #ifdef ENABLE_DSD
-              , dop
+			, dop
 #endif
-      );
-      if (oss_format == AFMT_QUERY)
-            return false;
+	);
+	if (oss_format == AFMT_QUERY)
+		return false;
 
-      bool success =
-              oss_try_ioctl_r(fd, SNDCTL_DSP_SAMPLESIZE,
-                              &oss_format,
-                              "Failed to set sample format");
+	bool success =
+			oss_try_ioctl_r(fd, SNDCTL_DSP_SAMPLESIZE,
+							&oss_format,
+							"Failed to set sample format");
 
 #ifdef AFMT_S24_PACKED
-      if (!success && sample_format == SampleFormat::S24_P32) {
+	if (!success && sample_format == SampleFormat::S24_P32) {
         /* if the driver doesn't support padded 24 bit, try
            packed 24 bit */
         oss_format = AFMT_S24_PACKED;
@@ -542,22 +542,22 @@ oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
     }
 #endif
 
-      if (!success)
-            return false;
+	if (!success)
+		return false;
 
-      sample_format = sample_format_from_oss(oss_format
+	sample_format = sample_format_from_oss(oss_format
 #ifdef ENABLE_DSD
-              , dop
+			, dop
 #endif
-      );
-      if (sample_format == SampleFormat::UNDEFINED)
-            return false;
+	);
+	if (sample_format == SampleFormat::UNDEFINED)
+		return false;
 
-      *sample_format_r = sample_format;
-      *oss_format_r = oss_format;
+	*sample_format_r = sample_format;
+	*oss_format_r = oss_format;
 
 #ifdef AFMT_S24_PACKED
-      PcmExport::Params params;
+	PcmExport::Params params;
     params.alsa_channel_order = true;
     params.pack24 = oss_format == AFMT_S24_PACKED;
     params.reverse_endian = oss_format == AFMT_S24_PACKED &&
@@ -566,7 +566,7 @@ oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
     pcm_export.Open(sample_format, 0, params);
 #endif
 
-      return true;
+	return true;
 }
 
 /**
@@ -575,78 +575,78 @@ oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
  */
 static void
 oss_setup_sample_format(FileDescriptor fd, AudioFormat &audio_format,
-                        int *oss_format_r
+						int *oss_format_r
 #ifdef ENABLE_DSD
-        , bool dop
+		, bool dop
 #endif
 #ifdef AFMT_S24_PACKED
-        , PcmExport &pcm_export
+		, PcmExport &pcm_export
 #endif
 ) {
-      SampleFormat mpd_format;
-      if (oss_probe_sample_format(fd, audio_format.format,
-                                  &mpd_format, oss_format_r
+	SampleFormat mpd_format;
+	if (oss_probe_sample_format(fd, audio_format.format,
+								&mpd_format, oss_format_r
 #ifdef ENABLE_DSD
-              , dop
+			, dop
 #endif
 #ifdef AFMT_S24_PACKED
-              , pcm_export
+			, pcm_export
 #endif
-      )) {
-            audio_format.format = mpd_format;
-            return;
-      }
+	)) {
+		audio_format.format = mpd_format;
+		return;
+	}
 
-      /* the requested sample format is not available - probe for
-         other formats supported by MPD */
+	/* the requested sample format is not available - probe for
+	   other formats supported by MPD */
 
-      static constexpr SampleFormat sample_formats[] = {
-              SampleFormat::S24_P32,
-              SampleFormat::S32,
-              SampleFormat::S16,
-              SampleFormat::S8,
-              SampleFormat::UNDEFINED /* sentinel */
-      };
+	static constexpr SampleFormat sample_formats[] = {
+			SampleFormat::S24_P32,
+			SampleFormat::S32,
+			SampleFormat::S16,
+			SampleFormat::S8,
+			SampleFormat::UNDEFINED /* sentinel */
+	};
 
-      for (unsigned i = 0; sample_formats[i] != SampleFormat::UNDEFINED; ++i) {
-            mpd_format = sample_formats[i];
-            if (mpd_format == audio_format.format)
-                  /* don't try that again */
-                  continue;
+	for (unsigned i = 0; sample_formats[i] != SampleFormat::UNDEFINED; ++i) {
+		mpd_format = sample_formats[i];
+		if (mpd_format == audio_format.format)
+			/* don't try that again */
+			continue;
 
-            if (oss_probe_sample_format(fd, mpd_format,
-                                        &mpd_format, oss_format_r
+		if (oss_probe_sample_format(fd, mpd_format,
+									&mpd_format, oss_format_r
 #ifdef ENABLE_DSD
-                    , dop
+				, dop
 #endif
 #ifdef AFMT_S24_PACKED
-                    , pcm_export
+				, pcm_export
 #endif
-            )) {
-                  audio_format.format = mpd_format;
-                  return;
-            }
-      }
+		)) {
+			audio_format.format = mpd_format;
+			return;
+		}
+	}
 
-      throw std::runtime_error("Failed to set sample format");
+	throw std::runtime_error("Failed to set sample format");
 }
 
 inline void
 OssOutput::Setup(AudioFormat &_audio_format) {
-      oss_setup_channels(fd, _audio_format);
-      oss_setup_sample_rate(fd, _audio_format
+	oss_setup_channels(fd, _audio_format);
+	oss_setup_sample_rate(fd, _audio_format
 #ifdef ENABLE_DSD
-              , dop_active
+			, dop_active
 #endif
-      );
-      oss_setup_sample_format(fd, _audio_format, &oss_format
+	);
+	oss_setup_sample_format(fd, _audio_format, &oss_format
 #ifdef ENABLE_DSD
-              , dop_active
+			, dop_active
 #endif
 #ifdef AFMT_S24_PACKED
-              , pcm_export
+			, pcm_export
 #endif
-      );
+	);
 }
 
 /**
@@ -655,62 +655,62 @@ OssOutput::Setup(AudioFormat &_audio_format) {
 inline void
 OssOutput::Reopen()
 try {
-      assert(!fd.IsDefined());
+	assert(!fd.IsDefined());
 
-      if (!fd.Open(device, O_WRONLY))
-            throw FormatErrno("Error opening OSS device \"%s\"", device);
+	if (!fd.Open(device, O_WRONLY))
+		throw FormatErrno("Error opening OSS device \"%s\"", device);
 
-      const char *const msg1 = "Failed to set channel count";
-      if (!oss_try_ioctl(fd, SNDCTL_DSP_CHANNELS,
-                         audio_format.channels, msg1))
-            throw std::runtime_error(msg1);
+	const char *const msg1 = "Failed to set channel count";
+	if (!oss_try_ioctl(fd, SNDCTL_DSP_CHANNELS,
+					   audio_format.channels, msg1))
+		throw std::runtime_error(msg1);
 
-      const char *const msg2 = "Failed to set sample rate";
-      auto samplerate = audio_format.sample_rate;
+	const char *const msg2 = "Failed to set sample rate";
+	auto samplerate = audio_format.sample_rate;
 #ifdef ENABLE_DSD
-      if (dop_active) samplerate /= 2;
+	if (dop_active) samplerate /= 2;
 #endif
-      if (!oss_try_ioctl(fd, SNDCTL_DSP_SPEED,
-                         samplerate, msg2))
-            throw std::runtime_error(msg2);
+	if (!oss_try_ioctl(fd, SNDCTL_DSP_SPEED,
+					   samplerate, msg2))
+		throw std::runtime_error(msg2);
 
-      auto samplesize = oss_format;
+	auto samplesize = oss_format;
 #ifdef ENABLE_DSD
-      #ifdef AFMT_S24_NE
+	#ifdef AFMT_S24_NE
     if (dop_active) samplesize = AFMT_S24_NE;
 #elif AFMT_S32_NE
     if (dop_active) samplesize = AFMT_S32_NE;
 #endif
 #endif
-      const char *const msg3 = "Failed to set sample format";
-      if (!oss_try_ioctl(fd, SNDCTL_DSP_SAMPLESIZE,
-                         samplesize, msg3))
-            throw std::runtime_error(msg3);
+	const char *const msg3 = "Failed to set sample format";
+	if (!oss_try_ioctl(fd, SNDCTL_DSP_SAMPLESIZE,
+					   samplesize, msg3))
+		throw std::runtime_error(msg3);
 
 } catch (...) {
-      DoClose();
-      throw;
+	DoClose();
+	throw;
 }
 
 void
 OssOutput::Open(AudioFormat &_audio_format)
 try {
-      const auto old_srate = _audio_format.sample_rate;
+	const auto old_srate = _audio_format.sample_rate;
 #ifdef ENABLE_DSD
 
-      if (dop_setting && _audio_format.format == SampleFormat::DSD) {
+	if (dop_setting && _audio_format.format == SampleFormat::DSD) {
         LogInfo(oss_domain, "oss-dop active for current playback");
         dop_active = true;
     }
     if (_audio_format.format != SampleFormat::DSD && dop_active) dop_active = false;
 #endif
 
-      if (!fd.Open(device, O_WRONLY))
-            throw FormatErrno("Error opening OSS device \"%s\"", device);
+	if (!fd.Open(device, O_WRONLY))
+		throw FormatErrno("Error opening OSS device \"%s\"", device);
 
-      Setup(_audio_format);
+	Setup(_audio_format);
 #ifdef ENABLE_DSD
-      if (dop_setting) {
+	if (dop_setting) {
         pcm_export_dop.Construct();
 
         params.alsa_channel_order = true;
@@ -727,44 +727,44 @@ try {
     }
 #endif
 
-      audio_format = _audio_format;
+	audio_format = _audio_format;
 
 } catch (...) {
 #ifdef ENABLE_DSD
-      pcm_export_dop.Destruct();
+	pcm_export_dop.Destruct();
 #endif
-      DoClose();
-      throw;
+	DoClose();
+	throw;
 }
 
 void
 OssOutput::Cancel() noexcept {
-      if (fd.IsDefined()) {
-            ioctl(fd.Get(), SNDCTL_DSP_RESET, 0);
-            DoClose();
-      }
+	if (fd.IsDefined()) {
+		ioctl(fd.Get(), SNDCTL_DSP_RESET, 0);
+		DoClose();
+	}
 
 #ifdef ENABLE_DSD
-      pcm_export_dop.Destruct();
+	pcm_export_dop.Destruct();
 #endif
 
 #ifdef AFMT_S24_PACKED
-      pcm_export->Reset();
+	pcm_export->Reset();
 #endif
 }
 
 size_t
 OssOutput::Play(const void *chunk, size_t size) {
-      ssize_t ret;
+	ssize_t ret;
 
-      assert(size > 0);
+	assert(size > 0);
 
-      /* reopen the device since it was closed by dropBufferedAudio */
-      if (!fd.IsDefined())
-            Reopen();
+	/* reopen the device since it was closed by dropBufferedAudio */
+	if (!fd.IsDefined())
+		Reopen();
 
 #ifdef AFMT_S24_PACKED
-      const auto e = pcm_export->Export({chunk, size});
+	const auto e = pcm_export->Export({chunk, size});
     if (e.empty())
         return size;
 
@@ -772,7 +772,7 @@ OssOutput::Play(const void *chunk, size_t size) {
     size = e.size;
 #endif
 #ifdef ENABLE_DSD
-      if (dop_active) {
+	if (dop_active) {
         const auto e = pcm_export_dop->Export({chunk, size});
         if (e.empty())
             return size;
@@ -783,29 +783,29 @@ OssOutput::Play(const void *chunk, size_t size) {
 
 #endif
 
-      while (true) {
-            ret = fd.Write(chunk, size);
+	while (true) {
+		ret = fd.Write(chunk, size);
 
-            if (ret > 0) {
+		if (ret > 0) {
 #ifdef AFMT_S24_PACKED
-                  ret = pcm_export->CalcInputSize(ret);
+			ret = pcm_export->CalcInputSize(ret);
 #endif
 #ifdef ENABLE_DSD
-                  if (dop_active) {
+			if (dop_active) {
                 ret = pcm_export_dop->CalcInputSize(ret);
             }
 #endif
-                  return ret;
-            }
+			return ret;
+		}
 
-            if (ret < 0 && errno != EINTR)
-                  throw FormatErrno("Write error on %s", device);
-      }
+		if (ret < 0 && errno != EINTR)
+			throw FormatErrno("Write error on %s", device);
+	}
 }
 
 constexpr struct AudioOutputPlugin oss_output_plugin = {
-        "oss",
-        oss_output_test_default_device,
-        OssOutput::Create,
-        &oss_mixer_plugin,
+		"oss",
+		oss_output_test_default_device,
+		OssOutput::Create,
+		&oss_mixer_plugin,
 };

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -17,6 +17,18 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "config.h"
+
+#include "util/RuntimeError.hxx"
+#include "util/StringBuffer.hxx"
+#include "pcm/AudioFormat.hxx"
+
+#ifdef ENABLE_DSD
+#include "src/pcm/Dop.hxx"
+#include "pcm/Export.hxx"
+#include "util/Manual.hxx"
+#endif
+
 #include "OssOutputPlugin.hxx"
 #include "../OutputAPI.hxx"
 #include "mixer/MixerList.hxx"
@@ -37,6 +49,8 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+const Domain oss_domain("oss");
 
 #if defined(__OpenBSD__) || defined(__NetBSD__)
 # include <soundcard.h>
@@ -60,40 +74,65 @@
 
 class OssOutput final : AudioOutput {
 #ifdef AFMT_S24_PACKED
-	Manual<PcmExport> pcm_export;
+    Manual<PcmExport> pcm_export;
 #endif
 
-	FileDescriptor fd = FileDescriptor::Undefined();
-	const char *device;
+#ifdef ENABLE_DSD
+    /**
+     * Enable DSD over PCM according to the DoP standard?
+     *
+     * @see http://dsd-guide.com/dop-open-standard
+     *
+     * this is default in oss as no other dsd-method is known to man
+     */
+    bool dop_setting = false;
+    bool dop_active = false;
 
-	/**
-	 * The current input audio format.  This is needed to reopen
-	 * the device after cancel().
-	 */
-	AudioFormat audio_format;
+    PcmExport::Params params;
+    Manual<PcmExport> pcm_export;
+#endif
 
-	/**
-	 * The current OSS audio format.  This is needed to reopen the
-	 * device after cancel().
-	 */
-	int oss_format;
+    FileDescriptor fd = FileDescriptor::Undefined();
+    const char *device;
+
+    /**
+     * The current input audio format.  This is needed to reopen
+     * the device after cancel().
+     */
+    AudioFormat audio_format;
+
+    /**
+     * The current OSS audio format.  This is needed to reopen the
+     * device after cancel().
+     */
+    int oss_format;
 
 #ifdef AFMT_S24_PACKED
-	static constexpr unsigned oss_flags = FLAG_ENABLE_DISABLE;
+    static constexpr unsigned oss_flags = FLAG_ENABLE_DISABLE;
 #else
-	static constexpr unsigned oss_flags = 0;
+    static constexpr unsigned oss_flags = 0;
 #endif
 
 public:
-	explicit OssOutput(const char *_device=nullptr)
-		:AudioOutput(oss_flags),
-		 device(_device) {}
+    explicit OssOutput(
+#ifdef ENABLE_DSD
+            bool dop,
+#endif
+            const char *_device=nullptr
+    )
+            :AudioOutput(oss_flags),
+             device(_device)
+    {
+#ifdef ENABLE_DSD
+        dop_setting = dop;
+#endif
+    }
 
-	static AudioOutput *Create(EventLoop &event_loop,
-				   const ConfigBlock &block);
+    static AudioOutput *Create(EventLoop &event_loop,
+                               const ConfigBlock &block);
 
 #ifdef AFMT_S24_PACKED
-	void Enable() override {
+    void Enable() override {
 		pcm_export.Construct();
 	}
 
@@ -102,65 +141,65 @@ public:
 	}
 #endif
 
-	void Open(AudioFormat &audio_format) override;
+    void Open(AudioFormat &audio_format) override;
 
-	void Close() noexcept override {
-		DoClose();
-	}
+    void Close() noexcept override {
+        DoClose();
+    }
 
-	size_t Play(const void *chunk, size_t size) override;
-	void Cancel() noexcept override;
+    size_t Play(const void *chunk, size_t size) override;
+    void Cancel() noexcept override;
 
 private:
-	/**
-	 * Sets up the OSS device which was opened before.
-	 */
-	void Setup(AudioFormat &audio_format);
+    /**
+     * Sets up the OSS device which was opened before.
+     */
+    void Setup(AudioFormat &audio_format);
 
-	/**
-	 * Reopen the device with the saved audio_format, without any probing.
-	 *
-	 * Throws on error.
-	 */
-	void Reopen();
+    /**
+     * Reopen the device with the saved audio_format, without any probing.
+     *
+     * Throws on error.
+     */
+    void Reopen();
 
-	void DoClose() noexcept;
+    void DoClose() noexcept;
 };
 
 static constexpr Domain oss_output_domain("oss_output");
 
 enum oss_stat {
-	OSS_STAT_NO_ERROR = 0,
-	OSS_STAT_NOT_CHAR_DEV = -1,
-	OSS_STAT_NO_PERMS = -2,
-	OSS_STAT_DOESN_T_EXIST = -3,
-	OSS_STAT_OTHER = -4,
+    OSS_STAT_NO_ERROR = 0,
+    OSS_STAT_NOT_CHAR_DEV = -1,
+    OSS_STAT_NO_PERMS = -2,
+    OSS_STAT_DOESN_T_EXIST = -3,
+    OSS_STAT_OTHER = -4,
 };
 
 static enum oss_stat
 oss_stat_device(const char *device, int *errno_r) noexcept
 {
-	struct stat st;
+    struct stat st;
 
-	if (0 == stat(device, &st)) {
-		if (!S_ISCHR(st.st_mode)) {
-			return OSS_STAT_NOT_CHAR_DEV;
-		}
-	} else {
-		*errno_r = errno;
+    if (0 == stat(device, &st)) {
+        if (!S_ISCHR(st.st_mode)) {
+            return OSS_STAT_NOT_CHAR_DEV;
+        }
+    } else {
+        *errno_r = errno;
 
-		switch (errno) {
-		case ENOENT:
-		case ENOTDIR:
-			return OSS_STAT_DOESN_T_EXIST;
-		case EACCES:
-			return OSS_STAT_NO_PERMS;
-		default:
-			return OSS_STAT_OTHER;
-		}
-	}
+        switch (errno) {
+            case ENOENT:
+            case ENOTDIR:
+                return OSS_STAT_DOESN_T_EXIST;
+            case EACCES:
+                return OSS_STAT_NO_PERMS;
+            default:
+                return OSS_STAT_OTHER;
+        }
+    }
 
-	return OSS_STAT_NO_ERROR;
+    return OSS_STAT_NO_ERROR;
 }
 
 static const char *const default_devices[] = { "/dev/sound/dsp", "/dev/dsp" };
@@ -168,73 +207,94 @@ static const char *const default_devices[] = { "/dev/sound/dsp", "/dev/dsp" };
 static bool
 oss_output_test_default_device() noexcept
 {
-	for (int i = std::size(default_devices); --i >= 0; ) {
-		UniqueFileDescriptor fd;
-		if (fd.Open(default_devices[i], O_WRONLY, 0))
-			return true;
+    for (int i = std::size(default_devices); --i >= 0; ) {
+        UniqueFileDescriptor fd;
+        if (fd.Open(default_devices[i], O_WRONLY, 0))
+            return true;
 
-		FormatErrno(oss_output_domain,
-			    "Error opening OSS device \"%s\"",
-			    default_devices[i]);
-	}
+        FormatErrno(oss_output_domain,
+                    "Error opening OSS device \"%s\"",
+                    default_devices[i]);
+    }
 
-	return false;
+    return false;
 }
 
 static OssOutput *
-oss_open_default()
+oss_open_default(
+#ifdef ENABLE_DSD
+        bool dop
+#endif
+)
 {
-	int err[std::size(default_devices)];
-	enum oss_stat ret[std::size(default_devices)];
+    int err[std::size(default_devices)];
+    enum oss_stat ret[std::size(default_devices)];
 
-	for (int i = std::size(default_devices); --i >= 0; ) {
-		ret[i] = oss_stat_device(default_devices[i], &err[i]);
-		if (ret[i] == OSS_STAT_NO_ERROR)
-			return new OssOutput(default_devices[i]);
-	}
+    for (int i = std::size(default_devices); --i >= 0; ) {
+        ret[i] = oss_stat_device(default_devices[i], &err[i]);
+        if (ret[i] == OSS_STAT_NO_ERROR)
+            return new OssOutput(
+#ifdef ENABLE_DSD
+                    dop,
+#endif
+                    default_devices[i]);
+    }
 
-	for (int i = std::size(default_devices); --i >= 0; ) {
-		const char *dev = default_devices[i];
-		switch(ret[i]) {
-		case OSS_STAT_NO_ERROR:
-			/* never reached */
-			break;
-		case OSS_STAT_DOESN_T_EXIST:
-			FormatWarning(oss_output_domain,
-				      "%s not found", dev);
-			break;
-		case OSS_STAT_NOT_CHAR_DEV:
-			FormatWarning(oss_output_domain,
-				      "%s is not a character device", dev);
-			break;
-		case OSS_STAT_NO_PERMS:
-			FormatWarning(oss_output_domain,
-				      "%s: permission denied", dev);
-			break;
-		case OSS_STAT_OTHER:
-			FormatErrno(oss_output_domain, err[i],
-				    "Error accessing %s", dev);
-		}
-	}
+    for (int i = std::size(default_devices); --i >= 0; ) {
+        const char *dev = default_devices[i];
+        switch(ret[i]) {
+            case OSS_STAT_NO_ERROR:
+                /* never reached */
+                break;
+            case OSS_STAT_DOESN_T_EXIST:
+                FormatWarning(oss_output_domain,
+                              "%s not found", dev);
+                break;
+            case OSS_STAT_NOT_CHAR_DEV:
+                FormatWarning(oss_output_domain,
+                              "%s is not a character device", dev);
+                break;
+            case OSS_STAT_NO_PERMS:
+                FormatWarning(oss_output_domain,
+                              "%s: permission denied", dev);
+                break;
+            case OSS_STAT_OTHER:
+                FormatErrno(oss_output_domain, err[i],
+                            "Error accessing %s", dev);
+        }
+    }
 
-	throw std::runtime_error("error trying to open default OSS device");
+    throw std::runtime_error("error trying to open default OSS device");
 }
 
 AudioOutput *
 OssOutput::Create(EventLoop &, const ConfigBlock &block)
 {
-	const char *device = block.GetBlockValue("device");
-	if (device != nullptr)
-		return new OssOutput(device);
+#ifdef ENABLE_DSD
+    bool dop = block.GetBlockValue("dop", false);
+    if (dop) LogInfo(oss_domain, "experimental oss-dop enabled");
+#endif
 
-	return oss_open_default();
+    const char *device = block.GetBlockValue("device");
+    if (device != nullptr)
+        return new OssOutput(
+#ifdef ENABLE_DSD
+                dop,
+#endif
+                device);
+
+    return oss_open_default(
+#ifdef ENABLE_DSD
+            dop
+#endif
+    );
 }
 
 void
 OssOutput::DoClose() noexcept
 {
-	if (fd.IsDefined())
-		fd.Close();
+    if (fd.IsDefined())
+        fd.Close();
 }
 
 /**
@@ -246,20 +306,20 @@ OssOutput::DoClose() noexcept
  */
 static bool
 oss_try_ioctl_r(FileDescriptor fd, unsigned long request, int *value_r,
-		const char *msg)
+                const char *msg)
 {
-	assert(fd.IsDefined());
-	assert(value_r != nullptr);
-	assert(msg != nullptr);
+    assert(fd.IsDefined());
+    assert(value_r != nullptr);
+    assert(msg != nullptr);
 
-	int ret = ioctl(fd.Get(), request, value_r);
-	if (ret >= 0)
-		return true;
+    int ret = ioctl(fd.Get(), request, value_r);
+    if (ret >= 0)
+        return true;
 
-	if (errno == EINVAL)
-		return false;
+    if (errno == EINVAL)
+        return false;
 
-	throw MakeErrno(msg);
+    throw MakeErrno(msg);
 }
 
 /**
@@ -271,9 +331,9 @@ oss_try_ioctl_r(FileDescriptor fd, unsigned long request, int *value_r,
  */
 static bool
 oss_try_ioctl(FileDescriptor fd, unsigned long request, int value,
-	      const char *msg)
+              const char *msg)
 {
-	return oss_try_ioctl_r(fd, request, &value, msg);
+    return oss_try_ioctl_r(fd, request, &value, msg);
 }
 
 /**
@@ -285,29 +345,29 @@ oss_try_ioctl(FileDescriptor fd, unsigned long request, int value,
 static void
 oss_setup_channels(FileDescriptor fd, AudioFormat &audio_format)
 {
-	const char *const msg = "Failed to set channel count";
-	int channels = audio_format.channels;
+    const char *const msg = "Failed to set channel count";
+    int channels = audio_format.channels;
 
-	if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
-	    audio_valid_channel_count(channels)) {
-		audio_format.channels = channels;
-		return;
-	}
+    if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
+        audio_valid_channel_count(channels)) {
+        audio_format.channels = channels;
+        return;
+    }
 
-	for (unsigned i = 1; i < 2; ++i) {
-		if (i == audio_format.channels)
-			/* don't try that again */
-			continue;
+    for (unsigned i = 1; i < 2; ++i) {
+        if (i == audio_format.channels)
+            /* don't try that again */
+            continue;
 
-		channels = i;
-		if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
-		    audio_valid_channel_count(channels)) {
-			audio_format.channels = channels;
-			return;
-		}
-	}
+        channels = i;
+        if (oss_try_ioctl_r(fd, SNDCTL_DSP_CHANNELS, &channels, msg) &&
+            audio_valid_channel_count(channels)) {
+            audio_format.channels = channels;
+            return;
+        }
+    }
 
-	throw std::runtime_error(msg);
+    throw std::runtime_error(msg);
 }
 
 /**
@@ -317,31 +377,43 @@ oss_setup_channels(FileDescriptor fd, AudioFormat &audio_format)
  * Throws on error.
  */
 static void
-oss_setup_sample_rate(FileDescriptor fd, AudioFormat &audio_format)
+oss_setup_sample_rate(FileDescriptor fd, AudioFormat &audio_format
+#ifdef ENABLE_DSD
+        , bool dop
+#endif
+)
 {
-	const char *const msg = "Failed to set sample rate";
-	int sample_rate = audio_format.sample_rate;
+    const char *const msg = "Failed to set sample rate";
+    int sample_rate = audio_format.sample_rate;
 
-	if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
-	    audio_valid_sample_rate(sample_rate)) {
-		audio_format.sample_rate = sample_rate;
-		return;
-	}
+#ifdef ENABLE_DSD
+    if (dop) {
+        /* DoP packs two 8-bit "samples" in one 24-bit
+               "sample" */
+        sample_rate /= 2;
+    }
+#endif
 
-	static constexpr int sample_rates[] = { 48000, 44100, 0 };
-	for (unsigned i = 0; sample_rates[i] != 0; ++i) {
-		sample_rate = sample_rates[i];
-		if (sample_rate == (int)audio_format.sample_rate)
-			continue;
+    if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
+        audio_valid_sample_rate(sample_rate)) {
+        audio_format.sample_rate = sample_rate;
+        return;
+    }
 
-		if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
-		    audio_valid_sample_rate(sample_rate)) {
-			audio_format.sample_rate = sample_rate;
-			return;
-		}
-	}
+    static constexpr int sample_rates[] = { 48000, 44100, 0 };
+    for (unsigned i = 0; sample_rates[i] != 0; ++i) {
+        sample_rate = sample_rates[i];
+        if (sample_rate == (int)audio_format.sample_rate)
+            continue;
 
-	throw std::runtime_error(msg);
+        if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
+            audio_valid_sample_rate(sample_rate)) {
+            audio_format.sample_rate = sample_rate;
+            return;
+        }
+    }
+
+    throw std::runtime_error(msg);
 }
 
 /**
@@ -350,37 +422,50 @@ oss_setup_sample_rate(FileDescriptor fd, AudioFormat &audio_format)
  */
 gcc_const
 static int
-sample_format_to_oss(SampleFormat format) noexcept
+sample_format_to_oss(SampleFormat format
+#ifdef ENABLE_DSD
+        , bool dop
+#endif
+) noexcept
 {
-	switch (format) {
-	case SampleFormat::UNDEFINED:
-	case SampleFormat::FLOAT:
-	case SampleFormat::DSD:
-		return AFMT_QUERY;
-
-	case SampleFormat::S8:
-		return AFMT_S8;
-
-	case SampleFormat::S16:
-		return AFMT_S16_NE;
-
-	case SampleFormat::S24_P32:
+    switch (format) {
+        case SampleFormat::UNDEFINED:
+        case SampleFormat::FLOAT:
+            return AFMT_QUERY;
+        case SampleFormat::DSD:
+#ifdef ENABLE_DSD
 #ifdef AFMT_S24_NE
-		return AFMT_S24_NE;
-#else
-		return AFMT_QUERY;
+            if (dop) return AFMT_S24_NE;
 #endif
-
-	case SampleFormat::S32:
 #ifdef AFMT_S32_NE
-		return AFMT_S32_NE;
-#else
-		return AFMT_QUERY;
+            if (dop) return AFMT_S32_NE;
 #endif
-	}
+#endif
+            return AFMT_QUERY;
 
-	assert(false);
-	gcc_unreachable();
+        case SampleFormat::S8:
+            return AFMT_S8;
+
+        case SampleFormat::S16:
+            return AFMT_S16_NE;
+
+        case SampleFormat::S24_P32:
+#ifdef AFMT_S24_NE
+            return AFMT_S24_NE;
+#else
+            return AFMT_QUERY;
+#endif
+
+        case SampleFormat::S32:
+#ifdef AFMT_S32_NE
+            return AFMT_S32_NE;
+#else
+            return AFMT_QUERY;
+#endif
+    }
+
+    assert(false);
+    gcc_unreachable();
 }
 
 /**
@@ -389,33 +474,40 @@ sample_format_to_oss(SampleFormat format) noexcept
  */
 gcc_const
 static SampleFormat
-sample_format_from_oss(int format) noexcept
+sample_format_from_oss(int format
+#ifdef ENABLE_DSD
+, bool dop
+#endif
+) noexcept
 {
-	switch (format) {
-	case AFMT_S8:
-		return SampleFormat::S8;
+    switch (format) {
+        case AFMT_S8:
+            return SampleFormat::S8;
 
-	case AFMT_S16_NE:
-		return SampleFormat::S16;
+        case AFMT_S16_NE:
+            return SampleFormat::S16;
 
 #ifdef AFMT_S24_PACKED
-	case AFMT_S24_PACKED:
+            case AFMT_S24_PACKED:
 		return SampleFormat::S24_P32;
 #endif
 
 #ifdef AFMT_S24_NE
-	case AFMT_S24_NE:
+            case AFMT_S24_NE:
 		return SampleFormat::S24_P32;
 #endif
 
 #ifdef AFMT_S32_NE
-	case AFMT_S32_NE:
-		return SampleFormat::S32;
+        case AFMT_S32_NE:
+#ifdef ENABLE_DSD
+        if (dop) return SampleFormat::DSD;
+#endif
+            return SampleFormat::S32;
 #endif
 
-	default:
-		return SampleFormat::UNDEFINED;
-	}
+        default:
+            return SampleFormat::UNDEFINED;
+    }
 }
 
 /**
@@ -427,24 +519,31 @@ sample_format_from_oss(int format) noexcept
  */
 static bool
 oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
-			SampleFormat *sample_format_r,
-			int *oss_format_r
-#ifdef AFMT_S24_PACKED
-			, PcmExport &pcm_export
+                        SampleFormat *sample_format_r,
+                        int *oss_format_r
+#ifdef ENABLE_DSD
+        , bool dop
 #endif
-			)
+#ifdef AFMT_S24_PACKED
+        , PcmExport &pcm_export
+#endif
+)
 {
-	int oss_format = sample_format_to_oss(sample_format);
-	if (oss_format == AFMT_QUERY)
-		return false;
+    int oss_format = sample_format_to_oss(sample_format
+#ifdef ENABLE_DSD
+            , dop
+#endif
+    );
+    if (oss_format == AFMT_QUERY)
+        return false;
 
-	bool success =
-		oss_try_ioctl_r(fd, SNDCTL_DSP_SAMPLESIZE,
-				&oss_format,
-				"Failed to set sample format");
+    bool success =
+            oss_try_ioctl_r(fd, SNDCTL_DSP_SAMPLESIZE,
+                            &oss_format,
+                            "Failed to set sample format");
 
 #ifdef AFMT_S24_PACKED
-	if (!success && sample_format == SampleFormat::S24_P32) {
+    if (!success && sample_format == SampleFormat::S24_P32) {
 		/* if the driver doesn't support padded 24 bit, try
 		   packed 24 bit */
 		oss_format = AFMT_S24_PACKED;
@@ -454,18 +553,22 @@ oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
 	}
 #endif
 
-	if (!success)
-		return false;
+    if (!success)
+        return false;
 
-	sample_format = sample_format_from_oss(oss_format);
-	if (sample_format == SampleFormat::UNDEFINED)
-		return false;
+    sample_format = sample_format_from_oss(oss_format
+#ifdef ENABLE_DSD
+            , dop
+#endif
+            );
+    if (sample_format == SampleFormat::UNDEFINED)
+        return false;
 
-	*sample_format_r = sample_format;
-	*oss_format_r = oss_format;
+    *sample_format_r = sample_format;
+    *oss_format_r = oss_format;
 
 #ifdef AFMT_S24_PACKED
-	PcmExport::Params params;
+    PcmExport::Params params;
 	params.alsa_channel_order = true;
 	params.pack24 = oss_format == AFMT_S24_PACKED;
 	params.reverse_endian = oss_format == AFMT_S24_PACKED &&
@@ -474,7 +577,7 @@ oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
 	pcm_export.Open(sample_format, 0, params);
 #endif
 
-	return true;
+    return true;
 }
 
 /**
@@ -483,64 +586,80 @@ oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
  */
 static void
 oss_setup_sample_format(FileDescriptor fd, AudioFormat &audio_format,
-			int *oss_format_r
-#ifdef AFMT_S24_PACKED
-			, PcmExport &pcm_export
+                        int *oss_format_r
+#ifdef ENABLE_DSD
+        , bool dop
 #endif
-			)
+#ifdef AFMT_S24_PACKED
+        , PcmExport &pcm_export
+#endif
+)
 {
-	SampleFormat mpd_format;
-	if (oss_probe_sample_format(fd, audio_format.format,
-				    &mpd_format, oss_format_r
-#ifdef AFMT_S24_PACKED
-				    , pcm_export
+    SampleFormat mpd_format;
+    if (oss_probe_sample_format(fd, audio_format.format,
+                                &mpd_format, oss_format_r
+#ifdef ENABLE_DSD
+            , dop
 #endif
-				    )) {
-		audio_format.format = mpd_format;
-		return;
-	}
-
-	/* the requested sample format is not available - probe for
-	   other formats supported by MPD */
-
-	static constexpr SampleFormat sample_formats[] = {
-		SampleFormat::S24_P32,
-		SampleFormat::S32,
-		SampleFormat::S16,
-		SampleFormat::S8,
-		SampleFormat::UNDEFINED /* sentinel */
-	};
-
-	for (unsigned i = 0; sample_formats[i] != SampleFormat::UNDEFINED; ++i) {
-		mpd_format = sample_formats[i];
-		if (mpd_format == audio_format.format)
-			/* don't try that again */
-			continue;
-
-		if (oss_probe_sample_format(fd, mpd_format,
-					    &mpd_format, oss_format_r
 #ifdef AFMT_S24_PACKED
-					    , pcm_export
+            , pcm_export
 #endif
-					    )) {
-			audio_format.format = mpd_format;
-			return;
-		}
-	}
+    )) {
+        audio_format.format = mpd_format;
+        return;
+    }
 
-	throw std::runtime_error("Failed to set sample format");
+    /* the requested sample format is not available - probe for
+       other formats supported by MPD */
+
+    static constexpr SampleFormat sample_formats[] = {
+            SampleFormat::S24_P32,
+            SampleFormat::S32,
+            SampleFormat::S16,
+            SampleFormat::S8,
+            SampleFormat::UNDEFINED /* sentinel */
+    };
+
+    for (unsigned i = 0; sample_formats[i] != SampleFormat::UNDEFINED; ++i) {
+        mpd_format = sample_formats[i];
+        if (mpd_format == audio_format.format)
+            /* don't try that again */
+            continue;
+
+        if (oss_probe_sample_format(fd, mpd_format,
+                                    &mpd_format, oss_format_r
+#ifdef ENABLE_DSD
+                , dop
+#endif
+#ifdef AFMT_S24_PACKED
+                , pcm_export
+#endif
+        )) {
+            audio_format.format = mpd_format;
+            return;
+        }
+    }
+
+    throw std::runtime_error("Failed to set sample format");
 }
 
 inline void
 OssOutput::Setup(AudioFormat &_audio_format)
 {
-	oss_setup_channels(fd, _audio_format);
-	oss_setup_sample_rate(fd, _audio_format);
-	oss_setup_sample_format(fd, _audio_format, &oss_format
-#ifdef AFMT_S24_PACKED
-				, pcm_export
+    oss_setup_channels(fd, _audio_format);
+    oss_setup_sample_rate(fd, _audio_format
+#ifdef ENABLE_DSD
+            , dop_active
 #endif
-				);
+    );
+    oss_setup_sample_format(fd, _audio_format, &oss_format
+#ifdef ENABLE_DSD
+            , dop_active
+#endif
+#ifdef AFMT_S24_PACKED
+            , pcm_export
+#endif
+    );
 }
 
 /**
@@ -549,94 +668,156 @@ OssOutput::Setup(AudioFormat &_audio_format)
 inline void
 OssOutput::Reopen()
 try {
-	assert(!fd.IsDefined());
+    assert(!fd.IsDefined());
 
-	if (!fd.Open(device, O_WRONLY))
-		throw FormatErrno("Error opening OSS device \"%s\"", device);
+    if (!fd.Open(device, O_WRONLY))
+        throw FormatErrno("Error opening OSS device \"%s\"", device);
 
-	const char *const msg1 = "Failed to set channel count";
-	if (!oss_try_ioctl(fd, SNDCTL_DSP_CHANNELS,
-			   audio_format.channels, msg1))
-		throw std::runtime_error(msg1);
+    const char *const msg1 = "Failed to set channel count";
+    if (!oss_try_ioctl(fd, SNDCTL_DSP_CHANNELS,
+                       audio_format.channels, msg1))
+        throw std::runtime_error(msg1);
 
-	const char *const msg2 = "Failed to set sample rate";
-	if (!oss_try_ioctl(fd, SNDCTL_DSP_SPEED,
-			   audio_format.sample_rate, msg2))
-		throw std::runtime_error(msg2);
+    const char *const msg2 = "Failed to set sample rate";
+    auto samplerate = audio_format.sample_rate;
+#ifdef ENABLE_DSD
+    if (dop_active) samplerate /= 2;
+#endif
+    if (!oss_try_ioctl(fd, SNDCTL_DSP_SPEED,
+                       samplerate, msg2))
+        throw std::runtime_error(msg2);
 
-	const char *const msg3 = "Failed to set sample format";
-	if (!oss_try_ioctl(fd, SNDCTL_DSP_SAMPLESIZE,
-			   oss_format, msg3))
-		throw std::runtime_error(msg3);
+    auto samplesize = oss_format;
+#ifdef ENABLE_DSD
+#ifdef AFMT_S24_NE
+    if (dop_active) samplesize = AFMT_S24_NE;
+#elif AFMT_S32_NE
+    if (dop_active) samplesize = AFMT_S32_NE;
+#endif
+#endif
+    const char *const msg3 = "Failed to set sample format";
+    if (!oss_try_ioctl(fd, SNDCTL_DSP_SAMPLESIZE,
+                       samplesize, msg3))
+        throw std::runtime_error(msg3);
+
 } catch (...) {
-	DoClose();
-	throw;
+    DoClose();
+    throw;
 }
 
 void
 OssOutput::Open(AudioFormat &_audio_format)
 try {
-	if (!fd.Open(device, O_WRONLY))
-		throw FormatErrno("Error opening OSS device \"%s\"", device);
+    const auto old_srate = _audio_format.sample_rate;
+#ifdef ENABLE_DSD
 
-	Setup(_audio_format);
+    if (dop_setting && _audio_format.format == SampleFormat::DSD) {
+        LogInfo(oss_domain, "oss-dop active for current playback");
+        dop_active = true;
+    }
+    if (_audio_format.format != SampleFormat::DSD && dop_active) dop_active = false;
+#endif
 
-	audio_format = _audio_format;
+    if (!fd.Open(device, O_WRONLY))
+        throw FormatErrno("Error opening OSS device \"%s\"", device);
+
+    Setup(_audio_format);
+#ifdef ENABLE_DSD
+    if (dop_setting) {
+        pcm_export.Construct();
+
+        params.alsa_channel_order = true;
+        params.dsd_mode = PcmExport::DsdMode::DOP;
+        params.pack24 = false;
+        params.shift8 = true;
+        params.reverse_endian = !IsLittleEndian();
+
+        pcm_export->Open(SampleFormat::DSD, _audio_format.channels, params);
+
+    }
+    if (dop_active) {
+        _audio_format.sample_rate = old_srate;
+    }
+#endif
+
+    audio_format = _audio_format;
+
 } catch (...) {
-	DoClose();
-	throw;
+#ifdef ENABLE_DSD
+    pcm_export.Destruct();
+#endif
+    DoClose();
+    throw;
 }
 
 void
 OssOutput::Cancel() noexcept
 {
-	if (fd.IsDefined()) {
-		ioctl(fd.Get(), SNDCTL_DSP_RESET, 0);
-		DoClose();
-	}
+    if (fd.IsDefined()) {
+        ioctl(fd.Get(), SNDCTL_DSP_RESET, 0);
+        DoClose();
+    }
+
+#ifdef ENABLE_DSD
+    pcm_export.Destruct();
+#endif
 
 #ifdef AFMT_S24_PACKED
-	pcm_export->Reset();
+    pcm_export->Reset();
 #endif
 }
 
 size_t
-OssOutput::Play(const void *chunk, size_t size)
-{
-	ssize_t ret;
+OssOutput::Play(const void *chunk, size_t size) {
+    ssize_t ret;
 
-	assert(size > 0);
+    assert(size > 0);
 
-	/* reopen the device since it was closed by dropBufferedAudio */
-	if (!fd.IsDefined())
-		Reopen();
+    /* reopen the device since it was closed by dropBufferedAudio */
+    if (!fd.IsDefined())
+        Reopen();
 
 #ifdef AFMT_S24_PACKED
-	const auto e = pcm_export->Export({chunk, size});
-	if (e.empty())
-		return size;
+    const auto e = pcm_export->Export({chunk, size});
+    if (e.empty())
+        return size;
 
-	chunk = e.data;
-	size = e.size;
+    chunk = e.data;
+    size = e.size;
+#endif
+#ifdef ENABLE_DSD
+    const auto e = pcm_export->Export({chunk, size});
+    if (e.empty())
+        return size;
+
+    chunk = e.data;
+    size = e.size;
+
 #endif
 
-	while (true) {
-		ret = fd.Write(chunk, size);
-		if (ret > 0) {
+    while (true) {
+        ret = fd.Write(chunk, size);
+
+        if (ret > 0) {
 #ifdef AFMT_S24_PACKED
-			ret = pcm_export->CalcInputSize(ret);
+            ret = pcm_export->CalcInputSize(ret);
 #endif
-			return ret;
-		}
+#ifdef ENABLE_DSD
+            if (dop_active) {
+                ret = pcm_export->CalcInputSize(ret);
+            }
+#endif
+            return ret;
+        }
 
-		if (ret < 0 && errno != EINTR)
-			throw FormatErrno("Write error on %s", device);
-	}
+        if (ret < 0 && errno != EINTR)
+            throw FormatErrno("Write error on %s", device);
+    }
 }
 
 constexpr struct AudioOutputPlugin oss_output_plugin = {
-	"oss",
-	oss_output_test_default_device,
-	OssOutput::Create,
-	&oss_mixer_plugin,
+        "oss",
+        oss_output_test_default_device,
+        OssOutput::Create,
+        &oss_mixer_plugin,
 };

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -786,12 +786,14 @@ OssOutput::Play(const void *chunk, size_t size) {
     size = e.size;
 #endif
 #ifdef ENABLE_DSD
-    const auto e = pcm_export->Export({chunk, size});
-    if (e.empty())
-        return size;
+    if (dop_active) {
+        const auto e = pcm_export->Export({chunk, size});
+        if (e.empty())
+            return size;
 
-    chunk = e.data;
-    size = e.size;
+        chunk = e.data;
+        size = e.size;
+    }
 
 #endif
 

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -19,12 +19,8 @@
 
 #include "config.h"
 
-#include "util/RuntimeError.hxx"
-#include "util/StringBuffer.hxx"
-#include "pcm/AudioFormat.hxx"
-
 #ifdef ENABLE_DSD
-#include "src/pcm/Dop.hxx"
+#undef AFMT_S24_PACKED
 #include "pcm/Export.hxx"
 #include "util/Manual.hxx"
 #endif
@@ -49,8 +45,6 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
-
-const Domain oss_domain("oss");
 
 #if defined(__OpenBSD__) || defined(__NetBSD__)
 # include <soundcard.h>
@@ -91,6 +85,9 @@ class OssOutput final : AudioOutput {
     PcmExport::Params params;
     Manual<PcmExport> pcm_export;
 #endif
+
+
+    const Domain oss_domain("oss");
 
     FileDescriptor fd = FileDescriptor::Undefined();
     const char *device;


### PR DESCRIPTION
## Overview
What: DSD over PCM for the OSS output plugin.
Why: When using non-linux *NIX ALSA will not be available and therefore DSD gets resampled which is undesirable if DAC supports it via DoP.
## Introduction
This is a very rough cut for enabling dop under oss. I have little experience with this project and the code may contain some leftovers from experimentation. Please also excuse it being one huge commit. I changed some things locally to make the default branch of mpd compile under FreeBSD which I did not want to include here.
I am very much open to discussion and comments, please rip the code apart :^)
## Testing
This has been tested with a Sabaj Da2 under FreeBSD. Input files were of many formats: wavpack-dsd64, dsf-dsd64, dsf-dsd128, dsf-dsd256 (noisy). Up to and including DSD128 work flawless, DSD playback is taking place according to the DACs status LED. CPU usage is at 0%.
## Notes
The code written is quite hacky. This is the first "proof of work" implementation, any improvements or so can still take place. As I said, rip it apart.