### PR TITLE
doc/plugins.rst: fix PipeWire link

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -1100,7 +1100,7 @@ The pipe plugin starts a program and writes raw PCM data into its standard input
 pipewire
 --------
 
-Connect to a `PipeWire <https://pipewire.org/>``_ server.  Requires
+Connect to a `PipeWire <https://pipewire.org/>`_ server.  Requires
 ``libpipewire``.
 
 .. list-table::


### PR DESCRIPTION
Currently, it issues a warning when documentation is built:
```
WARNING: Unknown target name: "pipewire <https://pipewire.org/>`".
```
and the link is not rendered in the HTML output.