### PR TITLE
Enable DOP on OSS

### DIFF
--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -463,7 +463,11 @@ sample_format_to_oss(SampleFormat format
  */
 gcc_const
 static SampleFormat
-sample_format_from_oss(int format) noexcept
+sample_format_from_oss(int format
+#ifdef ENABLE_DSD
+        , bool dop
+#endif
+) noexcept
 {
 	switch (format) {
 	case AFMT_S8:
@@ -484,6 +488,9 @@ sample_format_from_oss(int format) noexcept
 
 #ifdef AFMT_S32_NE
 	case AFMT_S32_NE:
+#ifdef ENABLE_DSD
+        if (dop) return SampleFormat::DSD;
+#endif
 		return SampleFormat::S32;
 #endif
 

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -510,12 +510,19 @@ static bool
 oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
 			SampleFormat *sample_format_r,
 			int *oss_format_r
+#ifdef ENABLE_DSD
+        , bool dop
+#endif
 #ifdef AFMT_S24_PACKED
 			, PcmExport &pcm_export
 #endif
 			)
 {
-	int oss_format = sample_format_to_oss(sample_format);
+	int oss_format = sample_format_to_oss(sample_format
+#ifdef ENABLE_DSD
+    , dop
+#endif
+    );
 	if (oss_format == AFMT_QUERY)
 		return false;
 
@@ -538,7 +545,12 @@ oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
 	if (!success)
 		return false;
 
-	sample_format = sample_format_from_oss(oss_format);
+	sample_format = sample_format_from_oss(oss_format
+#ifdef ENABLE_DSD
+            , dop
+#endif
+	);
+
 	if (sample_format == SampleFormat::UNDEFINED)
 		return false;
 
@@ -565,6 +577,9 @@ oss_probe_sample_format(FileDescriptor fd, SampleFormat sample_format,
 static void
 oss_setup_sample_format(FileDescriptor fd, AudioFormat &audio_format,
 			int *oss_format_r
+#ifdef ENABLE_DSD
+        , bool dop
+#endif
 #ifdef AFMT_S24_PACKED
 			, PcmExport &pcm_export
 #endif
@@ -573,6 +588,9 @@ oss_setup_sample_format(FileDescriptor fd, AudioFormat &audio_format,
 	SampleFormat mpd_format;
 	if (oss_probe_sample_format(fd, audio_format.format,
 				    &mpd_format, oss_format_r
+#ifdef ENABLE_DSD
+            , dop
+#endif
 #ifdef AFMT_S24_PACKED
 				    , pcm_export
 #endif
@@ -600,6 +618,9 @@ oss_setup_sample_format(FileDescriptor fd, AudioFormat &audio_format,
 
 		if (oss_probe_sample_format(fd, mpd_format,
 					    &mpd_format, oss_format_r
+#ifdef ENABLE_DSD
+                , dop
+#endif
 #ifdef AFMT_S24_PACKED
 					    , pcm_export
 #endif

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -259,11 +259,24 @@ oss_open_default(
 AudioOutput *
 OssOutput::Create(EventLoop &, const ConfigBlock &block)
 {
+#ifdef ENABLE_DSD
+    bool dop = block.GetBlockValue("dop", false);
+    if (dop) LogInfo(oss_domain, "experimental oss-dop enabled");
+#endif
+
 	const char *device = block.GetBlockValue("device");
 	if (device != nullptr)
-		return new OssOutput(device);
+		return new OssOutput(device
+#ifdef ENABLE_DSD
+                dop,
+#endif
+		);
 
-	return oss_open_default();
+	return oss_open_default(
+#ifdef ENABLE_DSD
+    dop
+#endif
+    );
 }
 
 void

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -86,6 +86,8 @@ class OssOutput final : AudioOutput {
     Manual<PcmExport> dop_export;
 #endif
 
+    const Domain oss_domain("oss");
+
 	FileDescriptor fd = FileDescriptor::Undefined();
 	const char *device;
 

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -211,15 +211,22 @@ oss_output_test_default_device() noexcept
 }
 
 static OssOutput *
-oss_open_default()
-{
+oss_open_default(
+#ifdef ENABLE_DSD
+        bool dop
+#endif
+) {
 	int err[std::size(default_devices)];
 	enum oss_stat ret[std::size(default_devices)];
 
 	for (int i = std::size(default_devices); --i >= 0; ) {
 		ret[i] = oss_stat_device(default_devices[i], &err[i]);
 		if (ret[i] == OSS_STAT_NO_ERROR)
-			return new OssOutput(default_devices[i]);
+			return new OssOutput(default_devices[i]
+#ifdef ENABLE_DSD
+                    dop,
+#endif
+			);
 	}
 
 	for (int i = std::size(default_devices); --i >= 0; ) {

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -68,6 +68,21 @@ class OssOutput final : AudioOutput {
 	Manual<PcmExport> pcm_export;
 #endif
 
+#ifdef ENABLE_DSD
+    /**
+     * Enable DSD over PCM according to the DoP standard?
+     *
+     * @see http://dsd-guide.com/dop-open-standard
+     *
+     * this is default in oss as no other dsd-method is known to man
+     */
+    bool dop_setting = false;
+    bool dop_active = false;
+
+    PcmExport::Params dop_params;
+    Manual<PcmExport> dop_export;
+#endif
+
 	FileDescriptor fd = FileDescriptor::Undefined();
 	const char *device;
 

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -17,6 +17,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#ifdef ENABLE_DSD
+#include "pcm/Export.hxx"
+#include "util/Manual.hxx"
+#endif
+
 #include "OssOutputPlugin.hxx"
 #include "../OutputAPI.hxx"
 #include "mixer/MixerList.hxx"

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -637,8 +637,15 @@ inline void
 OssOutput::Setup(AudioFormat &_audio_format)
 {
 	oss_setup_channels(fd, _audio_format);
-	oss_setup_sample_rate(fd, _audio_format);
+	oss_setup_sample_rate(fd, _audio_format
+#ifdef ENABLE_DSD
+            , dop_active
+#endif
+	);
 	oss_setup_sample_format(fd, _audio_format, &oss_format
+#ifdef ENABLE_DSD
+            , dop_active
+#endif
 #ifdef AFMT_S24_PACKED
 				, pcm_export
 #endif

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -773,12 +773,27 @@ OssOutput::Play(const void *chunk, size_t size)
 	chunk = e.data;
 	size = e.size;
 #endif
+#ifdef ENABLE_DSD
+    if (dop_active) {
+    const auto e = dop_export->Export({chunk, size});
+    if (e.empty())
+        return size;
+
+    chunk = e.data;
+    size = e.size;
+    }
+#endif
 
 	while (true) {
 		ret = fd.Write(chunk, size);
 		if (ret > 0) {
 #ifdef AFMT_S24_PACKED
 			ret = pcm_export->CalcInputSize(ret);
+#endif
+#ifdef ENABLE_DSD
+            if (dop_active) {
+                ret = dop_export->CalcInputSize(ret);
+            }
 #endif
 			return ret;
 		}

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -366,10 +366,22 @@ oss_setup_channels(FileDescriptor fd, AudioFormat &audio_format)
  * Throws on error.
  */
 static void
-oss_setup_sample_rate(FileDescriptor fd, AudioFormat &audio_format)
+oss_setup_sample_rate(FileDescriptor fd, AudioFormat &audio_format
+#ifdef ENABLE_DSD
+        , bool dop
+#endif
+)
 {
 	const char *const msg = "Failed to set sample rate";
 	int sample_rate = audio_format.sample_rate;
+
+#ifdef ENABLE_DSD
+    if (dop) {
+        /* DoP packs two 8-bit "samples" in one 24-bit
+               "sample" */
+        sample_rate /= 2;
+    }
+#endif
 
 	if (oss_try_ioctl_r(fd, SNDCTL_DSP_SPEED, &sample_rate, msg) &&
 	    audio_valid_sample_rate(sample_rate)) {

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -697,10 +697,10 @@ void
 OssOutput::Open(AudioFormat &_audio_format)
 try {
 #ifdef ENABLE_DSD
-
     if (dop_setting && _audio_format.format == SampleFormat::DSD) {
-        // TODO: use channels, samplerate and highest available samplerate to determine if dop is insufficient to play the requested file
-        if (_audio_format.sample_rate > 705600) {
+        const uint32_t required_samplerate = (_audio_format.sample_rate / 2) * _audio_format.channels;
+        // TODO: determine max-samplerate and dont use the highest possible
+        if (required_samplerate > 768000) {
             LogInfo(oss_domain, "Tried playing DSD256 or higher through DoP which does not work, falling back to conversion");
             _audio_format.format = SampleFormat::S32;
         }
@@ -727,7 +727,6 @@ try {
         dop_params.reverse_endian = !IsLittleEndian();
 
         dop_export->Open(SampleFormat::DSD, _audio_format.channels, dop_params);
-
     }
     if (dop_active) {
         _audio_format.sample_rate = old_srate;

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -749,6 +749,9 @@ OssOutput::Cancel() noexcept
 #ifdef AFMT_S24_PACKED
 	pcm_export->Reset();
 #endif
+#ifdef ENABLE_DSD
+    dop_export->Reset();
+#endif
 }
 
 size_t

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -67,6 +67,8 @@
 #include "util/Manual.hxx"
 #endif
 
+const Domain oss_domain("oss");
+
 class OssOutput final : AudioOutput {
 #ifdef AFMT_S24_PACKED
 	Manual<PcmExport> pcm_export;
@@ -86,8 +88,6 @@ class OssOutput final : AudioOutput {
     PcmExport::Params dop_params;
     Manual<PcmExport> dop_export;
 #endif
-
-    const Domain oss_domain("oss");
 
 	FileDescriptor fd = FileDescriptor::Undefined();
 	const char *device;

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -17,7 +17,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#define ENABLE_DSD
 #define AFMT_S32_NE
 
 #include "OssOutputPlugin.hxx"

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -411,13 +411,26 @@ oss_setup_sample_rate(FileDescriptor fd, AudioFormat &audio_format
  */
 gcc_const
 static int
-sample_format_to_oss(SampleFormat format) noexcept
+sample_format_to_oss(SampleFormat format
+#ifdef ENABLE_DSD
+        , bool dop
+#endif
+) noexcept
 {
 	switch (format) {
 	case SampleFormat::UNDEFINED:
 	case SampleFormat::FLOAT:
 	case SampleFormat::DSD:
+#ifdef ENABLE_DSD
+#ifdef AFMT_S32_NE
+        if (dop) return AFMT_S32_NE;
+        else return AFMT_QUERRY;
+#else
 		return AFMT_QUERY;
+#endif
+#else
+        return AFMT_QUERY;
+#endif
 
 	case SampleFormat::S8:
 		return AFMT_S8;

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -106,8 +106,17 @@ class OssOutput final : AudioOutput {
 
 public:
 	explicit OssOutput(const char *_device=nullptr)
+#ifdef ENABLE_DSD
+    bool dop,
+#endif
 		:AudioOutput(oss_flags),
-		 device(_device) {}
+		 device(_device)
+	{
+#ifdef ENABLE_DSD
+        dop_setting = dop;
+        dop_export.Construct();
+#endif
+	}
 
 	static AudioOutput *Create(EventLoop &event_loop,
 				   const ConfigBlock &block);

--- a/src/output/plugins/OssOutputPlugin.cxx
+++ b/src/output/plugins/OssOutputPlugin.cxx
@@ -24,6 +24,7 @@
 #include "pcm/Export.hxx"
 #include "util/Manual.hxx"
 #endif
+#endif
 
 #include "OssOutputPlugin.hxx"
 #include "../OutputAPI.hxx"


### PR DESCRIPTION
### Explanation
This adds support for DOP using the PcmExport function if the macro ENABLE_DSD is defined. If enabled within the config-file using "dop", the boolean dop_setting will be true. If DSD input is encountered and the setting is on, it is checked whether the oss-device supports the required samplerate. If that is the case, dop_active is set to true and conversion of the input is prevented. If the sample rate is not supported, conversion to S32 is requested. When playing back, the PcmExport is used to pack the incoming stream into PCM.
### Reasoning
This is required for OSs without the required driver support for native DSD playback that also have no ALSA. Mainly *BSD users are the target audience for this functionality, as ALSA here is only a proxy without full functionality.
### Requirements
- DAC that supports the DOP standard
- Building with OSS, DSD and S32-Format
### Supported Formats / Required PCM Formats
DSF, DFF and WavPack-DSD will work.

DSD64,  1 Channel -> S24:176.4kHz (untested, lack of time / missing samples)
DSD64,  2 Channel -> S24:352.8kHz
DSD64,  4 Channel -> S24:705.6kHz (untested, lmissing equipment)
DSD128, 1 Channel -> S24:352.8kHz (untested, lack of time / missing samples)
DSD128, 2 Channel -> S24:705.6kHz
DSD256, 1 Channel -> S24:705.6kHz (untested, lack of time / missing samples)
### Changes
- inclusion of required files
- adding new domain for logging
- adding dop_satisfied private function
- adding required member variables for storing dop state and for dop-packing
- adding dop boolean parameter to many functions that are required to act a little differently when dop is active
### Testing
This has been tested to work with a Sabaj Da2 on FreeBSD, where the red status indicator LED clearly shows that DSD playback is taking place, instead of purple for "hi-res" which is seen when converting.
### Issues
I have not tested this with S24 and right now AFMT_S32_NE is required. If not defined, ENABLE_DSD will be undef'ed. This will be addressed in a bit, however no DAC which supports DOP but not 32Bit is known to me. Also, AFMT_S32_NE is not defined when building on FreeBSD which is why this is just blatantly defined in the file at the moment.
Additionally, the new dop-option is not added into any documentation whatsoever.