### PR TITLE
Fix android build error when confronted with package versions ending with '+revision_information'

### DIFF
--- a/python/build/project.py
+++ b/python/build/project.py
@@ -20,7 +20,7 @@ class Project:
             self.base = base
 
         if name is None or version is None:
-            m = re.match(r'^([-\w]+)-(\d[\d.]*[a-z]?[\d.]*)$', self.base)
+            m = re.match(r'^([-\w]+)-(\d[\d.]*[a-z]?[\d.]*(?:-alpha\d+)?)(\+.*)?$', self.base)
             if name is None: name = m.group(1)
             if version is None: version = m.group(2)
 


### PR DESCRIPTION
The script seems to assume package version numbers always end in numeric versions with an optional alpha-suffix. Alas, were it only so simple... Sometimes the package is called fizzbang-1.2.3+release_info in which case the build fails. No more!