### PR TITLE
tag/Builder: don't ignore the result of tag_pool_dup_item

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ ver 0.23 (not yet released)
   - snapcast: new plugin
 * tags
   - new tags "ComposerSort", "Ensemble", "Movement", "MovementNumber", and "Location"
+  - fix crash caused by bug in TagBuilder and a few potential reference leaks
 * new build-time dependency: libfmt
 
 ver 0.22.9 (2021/06/23)

--- a/src/tag/Builder.cxx
+++ b/src/tag/Builder.cxx
@@ -63,12 +63,13 @@ TagBuilder::operator=(const TagBuilder &other) noexcept
 	/* copy all attributes */
 	duration = other.duration;
 	has_playlist = other.has_playlist;
-	items = other.items;
 
-	/* increment the tag pool refcounters */
+	RemoveAll();
+	items.reserve(other.items.size());
+
 	const std::lock_guard<Mutex> protect(tag_pool_lock);
 	for (auto i : items)
-		tag_pool_dup_item(i);
+		items.push_back(tag_pool_dup_item(i));
 
 	return *this;
 }
@@ -78,6 +79,8 @@ TagBuilder::operator=(TagBuilder &&other) noexcept
 {
 	duration = other.duration;
 	has_playlist = other.has_playlist;
+
+	RemoveAll();
 	items = std::move(other.items);
 
 	return *this;
@@ -92,7 +95,7 @@ TagBuilder::operator=(Tag &&other) noexcept
 	/* move all TagItem pointers from the Tag object; we don't
 	   need to contact the tag pool, because all we do is move
 	   references */
-	items.clear();
+	RemoveAll();
 	items.reserve(other.num_items);
 	std::copy_n(other.items, other.num_items, std::back_inserter(items));
 

--- a/src/tag/Pool.hxx
+++ b/src/tag/Pool.hxx
@@ -28,9 +28,11 @@ extern Mutex tag_pool_lock;
 struct TagItem;
 struct StringView;
 
+[[nodiscard]]
 TagItem *
 tag_pool_get_item(TagType type, StringView value) noexcept;
 
+[[nodiscard]]
 TagItem *
 tag_pool_dup_item(TagItem *item) noexcept;
 


### PR DESCRIPTION
Also, use RemoveAll() instead of directly clearing TagBuilder::items in most cases, as its elements represent references that must be released.

I added `[[nodiscard]]` to tag_pool_get_item and tag_pool_dup_item to try and prevent future misuse of these functions.

Closes #1023

---

TagBuilder assumes that tag_pool_dup_item can be used to safely increment the refcount of each TagItem:
https://github.com/MusicPlayerDaemon/MPD/blob/0e0f46a1e0a7662db0b497b636f87e4402ade099/src/tag/Builder.cxx#L68-L71

But tag_pool_dup_item may return a freshly allocated item if the reference counter is maxed out:
https://github.com/MusicPlayerDaemon/MPD/blob/0e0f46a1e0a7662db0b497b636f87e4402ade099/src/tag/Pool.cxx#L137-L145

This not only leaks the new TagItem, but fails to increment the original TagItem's reference count, causing a [heap-use-after-free](https://github.com/MusicPlayerDaemon/MPD/issues/1023#issuecomment-867060432) later on as the reference count will hit zero before all of the references have been released.

This can be proven to happen in practice by adding an assertion to the original loop:
```cpp
for (auto i : items) {
    const auto new_item = tag_pool_dup_item(i);
    /* assert that we incremented the refcount */
    assert(new_item == i);
}
```

This assertion fails if I simply rescan my music library with `mpc rescan`:
```
mpd: ../src/tag/Builder.cxx:73: TagBuilder& TagBuilder::operator=(const TagBuilder&): Assertion `new_item == i' failed.

Thread 4 "update" received signal SIGABRT, Aborted.
[Switching to Thread 0x7fffddc39640 (LWP 660666)]
0x00007ffff2669d22 in raise () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff2669d22 in raise () at /usr/lib/libc.so.6
#1  0x00007ffff2653862 in abort () at /usr/lib/libc.so.6
#2  0x00007ffff2653747 in _nl_load_domain.cold () at /usr/lib/libc.so.6
#3  0x00007ffff2662616 in  () at /usr/lib/libc.so.6
#4  0x0000555555851e50 in TagBuilder::operator=(TagBuilder const&) (this=this@entry=0x62100006a148, other=...) at ../src/tag/Builder.cxx:73
#5  0x000055555593a448 in CueParser::Feed(StringView) (this=this@entry=0x62100006a120, src=...) at ../src/playlist/cue/CueParser.cxx:253
#6  0x000055555592b973 in CuePlaylist::NextSong() (this=0x621000069100) at ../src/playlist/plugins/CuePlaylistPlugin.cxx:54
#7  0x0000555555954284 in UpdateWalk::UpdatePlaylistFile(Directory&, std::basic_string_view<char, std::char_traits<char> >, StorageFileInfo const&, PlaylistPlugin const&) (this=<optimized out>, parent=<optimized out>, name=<optimized out>, info=<optimized out>, plugin=<optimized out>) at ../src/db/update/Playlist.cxx:67
#8  0x000055555595580c in UpdateWalk::UpdatePlaylistFile(Directory&, std::basic_string_view<char, std::char_traits<char> >, char const*, StorageFileInfo const&) (this=this@entry=0x60b00001eff0, directory=..., name=<optimized out>, suffix=suffix@entry=0x603000249117 "cue", info=...) at ../src/db/update/Playlist.cxx:99
#9  0x000055555594e5ed in UpdateWalk::UpdateRegularFile(Directory&, char const*, StorageFileInfo const&) (info=..., name=0x603000249100 "Rush - Moving Pictures.cue", directory=..., this=0x60b00001eff0) at ../src/db/update/Walk.cxx:198
#10 UpdateWalk::UpdateDirectoryChild(Directory&, ExcludeList const&, char const*, StorageFileInfo const&) (this=<optimized out>, directory=<optimized out>, exclude_list=<optimized out>, name=0x603000249100 "Rush - Moving Pictures.cue", info=...) at ../src/db/update/Walk.cxx:209
#11 0x000055555594c529 in UpdateWalk::UpdateDirectory(Directory&, ExcludeList const&, StorageFileInfo const&) (this=<optimized out>, directory=<optimized out>, exclude_list=<optimized out>, info=<optimized out>) at ../src/db/update/Walk.cxx:386
#12 0x000055555594e48d in UpdateWalk::UpdateDirectoryChild(Directory&, ExcludeList const&, char const*, StorageFileInfo const&) (this=<optimized out>, directory=<optimized out>, exclude_list=<optimized out>, name=<optimized out>, info=...) at ../src/db/update/Walk.cxx:223
#13 0x000055555594c529 in UpdateWalk::UpdateDirectory(Directory&, ExcludeList const&, StorageFileInfo const&) (this=<optimized out>, directory=<optimized out>, exclude_list=<optimized out>, info=<optimized out>) at ../src/db/update/Walk.cxx:386
#14 0x000055555594e48d in UpdateWalk::UpdateDirectoryChild(Directory&, ExcludeList const&, char const*, StorageFileInfo const&) (this=<optimized out>, directory=<optimized out>, exclude_list=<optimized out>, name=<optimized out>, info=...) at ../src/db/update/Walk.cxx:223
#15 0x000055555594c529 in UpdateWalk::UpdateDirectory(Directory&, ExcludeList const&, StorageFileInfo const&) (this=<optimized out>, directory=<optimized out>, exclude_list=<optimized out>, info=<optimized out>) at ../src/db/update/Walk.cxx:386
#16 0x000055555594e48d in UpdateWalk::UpdateDirectoryChild(Directory&, ExcludeList const&, char const*, StorageFileInfo const&) (this=<optimized out>, directory=<optimized out>, exclude_list=<optimized out>, name=<optimized out>, info=...) at ../src/db/update/Walk.cxx:223
#17 0x000055555594c529 in UpdateWalk::UpdateDirectory(Directory&, ExcludeList const&, StorageFileInfo const&) (this=<optimized out>, directory=<optimized out>, exclude_list=<optimized out>, info=<optimized out>) at ../src/db/update/Walk.cxx:386
#18 0x0000555555950bdb in UpdateWalk::Walk(Directory&, char const*, bool) (this=<optimized out>, root=<optimized out>, path=<optimized out>, discard=<optimized out>) at ../src/db/update/Walk.cxx:530
#19 0x00005555559407d3 in UpdateService::Task() (this=0x611000008ec0) at ../src/db/plugins/simple/SimpleDatabasePlugin.hxx:85
#20 BindMethodDetail::BindMethodWrapperGenerator2<UpdateService, true, void (UpdateService::*)() noexcept, &UpdateService::Task, void>::Invoke(void*) (_instance=0x611000008ec0) at ../src/util/BindMethod.hxx:189
#21 0x00005555557746dc in BoundMethod<void () noexcept>::operator()() const (this=0x611000008f10) at ../src/util/BindMethod.hxx:91
#22 Thread::Run() (this=0x611000008f10) at ../src/thread/Thread.cxx:63
#23 Thread::ThreadProc(void*) (ctx=0x611000008f10) at ../src/thread/Thread.cxx:92
#24 0x00007ffff2802259 in start_thread () at /usr/lib/libpthread.so.0
#25 0x00007ffff272b5e3 in clone () at /usr/lib/libc.so.6
```