### PR TITLE
include <utility> for std::forward

### DIFF
--- a/src/Log.hxx
+++ b/src/Log.hxx
@@ -30,6 +30,7 @@
 
 #include <exception>
 #include <string_view>
+#include <utility>
 
 class Domain;
 

--- a/src/lib/expat/ExpatParser.hxx
+++ b/src/lib/expat/ExpatParser.hxx
@@ -25,6 +25,7 @@
 #include <expat.h>
 
 #include <stdexcept>
+#include <utility>
 
 class InputStream;
 


### PR DESCRIPTION
Fixes
../git/src/Log.hxx:121:42: error: no member named 'forward' in namespace 'std'
        LogFormat(LogLevel::ERROR, e, fmt, std::forward<Args>(args)...);

Signed-off-by: Khem Raj <raj.khem@gmail.com>