### PR TITLE
archive/meson.build: add missing libfmt dependency

### DIFF
--- a/src/archive/meson.build
+++ b/src/archive/meson.build
@@ -25,6 +25,9 @@ archive_glue = static_library(
   'ArchivePlugin.cxx',
   '../input/plugins/ArchiveInputPlugin.cxx',
   include_directories: inc,
+  dependencies: [
+    log_dep,
+  ],
 )
 
 archive_glue_dep = declare_dependency(


### PR DESCRIPTION
I couldn't compile a recent master (57687779b) on macOS with MacPorts. Adding this Meson depency solved the problem.