### PR TITLE
unique_ptr/new to make_unique

### DIFF
--- a/src/filter/plugins/ConvertFilterPlugin.cxx
+++ b/src/filter/plugins/ConvertFilterPlugin.cxx
@@ -121,7 +121,7 @@ std::unique_ptr<Filter>
 convert_filter_new(const AudioFormat in_audio_format,
 		   const AudioFormat out_audio_format)
 {
-	std::unique_ptr<ConvertFilter> filter(new ConvertFilter(in_audio_format));
+	auto filter = std::make_unique<ConvertFilter>(in_audio_format);
 	filter->Set(out_audio_format);
 	return filter;
 }

--- a/src/tag/Builder.cxx
+++ b/src/tag/Builder.cxx
@@ -158,7 +158,7 @@ TagBuilder::Commit() noexcept
 std::unique_ptr<Tag>
 TagBuilder::CommitNew() noexcept
 {
-	std::unique_ptr<Tag> tag(new Tag());
+	auto tag = std::make_unique<Tag>();
 	Commit(*tag);
 	return tag;
 }


### PR DESCRIPTION
The latter is easier to read and is the "correct" thing to do.

Signed-off-by: Rosen Penev <rosenp@gmail.com>