### PR TITLE
clang-tidy: replace loop with std::all_of

### DIFF
--- a/src/output/plugins/snapcast/SnapcastOutputPlugin.cxx
+++ b/src/output/plugins/snapcast/SnapcastOutputPlugin.cxx
@@ -367,11 +367,7 @@ SnapcastOutput::IsDrained() const noexcept
 	if (!chunks.empty())
 		return false;
 
-	for (const auto &client : clients)
-		if (!client.IsDrained())
-			return false;
-
-	return true;
+	return std::all_of(clients.begin(), clients.end(), [](auto&& c){ return c.IsDrained(); });
 }
 
 void


### PR DESCRIPTION
Found with readability-use-anyofallof

Signed-off-by: Rosen Penev <rosenp@gmail.com>