### PR TITLE
clang-tidy: make deleted members public

### DIFF
--- a/src/output/plugins/AoOutputPlugin.cxx
+++ b/src/output/plugins/AoOutputPlugin.cxx
@@ -57,11 +57,10 @@ class AoOutput final : AudioOutput, SafeSingleton<AoInit> {
 
 	explicit AoOutput(const ConfigBlock &block);
 	~AoOutput() override;
-
+public:
 	AoOutput(const AoOutput &) = delete;
 	AoOutput &operator=(const AoOutput &) = delete;
 
-public:
 	static AudioOutput *Create(EventLoop &, const ConfigBlock &block) {
 		return new AoOutput(block);
 	}


### PR DESCRIPTION
Found with modernize-use-equals-delete

Signed-off-by: Rosen Penev <rosenp@gmail.com>