### PR TITLE
clang-tidy: remove pointless const

### DIFF
--- a/src/playlist/cue/CueParser.cxx
+++ b/src/playlist/cue/CueParser.cxx
@@ -63,7 +63,7 @@ cue_next_token(StringView &src) noexcept
 	return cue_next_word(src);
 }
 
-static const StringView
+static StringView
 cue_next_value(StringView &src) noexcept
 {
 	src.StripLeft();


### PR DESCRIPTION
Found with readability-const-return-type

Signed-off-by: Rosen Penev <rosenp@gmail.com>