### PR TITLE
replace several emplace_back with push_back

### DIFF
--- a/src/PlaylistFile.cxx
+++ b/src/PlaylistFile.cxx
@@ -239,7 +239,7 @@ try {
 				continue;
 		}
 
-		contents.emplace_back(std::move(uri_utf8));
+		contents.push_back(std::move(uri_utf8));
 		if (contents.size() >= playlist_max_length)
 			break;
 	}

--- a/src/command/DatabaseCommands.cxx
+++ b/src/command/DatabaseCommands.cxx
@@ -295,13 +295,13 @@ handle_list(Client &client, Request args, Response &r)
 			return CommandResult::ERROR;
 		}
 
-		tag_types.emplace_back(group);
+		tag_types.push_back(group);
 
 		args.pop_back();
 		args.pop_back();
 	}
 
-	tag_types.emplace_back(tagType);
+	tag_types.push_back(tagType);
 
 	if (!args.empty()) {
 		filter = std::make_unique<SongFilter>();

--- a/src/db/plugins/upnp/Directory.cxx
+++ b/src/db/plugins/upnp/Directory.cxx
@@ -200,7 +200,7 @@ protected:
 		if ((!strcmp(name, "container") || !strcmp(name, "item")) &&
 		    object.Check()) {
 			tag.Commit(object.tag);
-			directory.objects.emplace_back(std::move(object));
+			directory.objects.push_back(std::move(object));
 		}
 
 		state = NONE;

--- a/src/lib/upnp/Device.cxx
+++ b/src/lib/upnp/Device.cxx
@@ -83,7 +83,7 @@ protected:
 			trimstring(*value);
 			value = nullptr;
 		} else if (!strcmp(name, "service")) {
-			m_device.services.emplace_back(std::move(m_tservice));
+			m_device.services.push_back(std::move(m_tservice));
 			m_tservice = {};
 		}
 	}

--- a/src/lib/upnp/Discovery.cxx
+++ b/src/lib/upnp/Discovery.cxx
@@ -148,7 +148,7 @@ UPnPDeviceDirectory::LockAdd(ContentDirectoryDescriptor &&d)
 		}
 	}
 
-	directories.emplace_back(std::move(d));
+	directories.push_back(std::move(d));
 
 	if (listener != nullptr)
 		AnnounceFoundUPnP(*listener, directories.back().device);

--- a/src/output/MultipleOutputs.cxx
+++ b/src/output/MultipleOutputs.cxx
@@ -104,18 +104,18 @@ MultipleOutputs::Configure(EventLoop &event_loop, EventLoop &rt_event_loop,
 			throw FormatRuntimeError("output devices with identical "
 						 "names: %s", output->GetName());
 
-		outputs.emplace_back(std::move(output));
+		outputs.push_back(std::move(output));
 	}
 
 	if (outputs.empty()) {
 		/* auto-detect device */
 		const ConfigBlock empty;
-		outputs.emplace_back(LoadOutputControl(event_loop,
-						       rt_event_loop,
-						       replay_gain_config,
-						       mixer_listener,
-						       client, empty, defaults,
-						       nullptr));
+		outputs.push_back(LoadOutputControl(event_loop,
+						    rt_event_loop,
+						    replay_gain_config,
+						    mixer_listener,
+						    client, empty, defaults,
+						    nullptr));
 	}
 }
 


### PR DESCRIPTION
The former is pointless when the types match and when there is no need
to call the constructor.

Verified with clang-tidy's modernize-use-emplace.

Signed-off-by: Rosen Penev <rosenp@gmail.com>