### PR TITLE
protocol/ArgParser.cxx: Add missing #include <stdio.h>

### DIFF
--- a/src/protocol/ArgParser.cxx
+++ b/src/protocol/ArgParser.cxx
@@ -23,6 +23,7 @@
 #include "Chrono.hxx"
 #include "util/NumberParser.hxx"
 
+#include <stdio.h>
 #include <stdlib.h>
 
 static inline ProtocolError


### PR DESCRIPTION
Fixes a build problem on platforms where stdio.h is not included
transitively. snprintf() is defined in stdio.h.