### PR TITLE
Implement volume updates for pipewire output

### DIFF
--- a/src/mixer/plugins/PipeWireMixerPlugin.cxx
+++ b/src/mixer/plugins/PipeWireMixerPlugin.cxx
@@ -37,6 +37,8 @@ public:
 	{
 	}
 
+	~PipeWireMixer() override;
+
 	PipeWireMixer(const PipeWireMixer &) = delete;
 	PipeWireMixer &operator=(const PipeWireMixer &) = delete;
 
@@ -82,7 +84,14 @@ pipewire_mixer_init([[maybe_unused]] EventLoop &event_loop, AudioOutput &ao,
 		    const ConfigBlock &)
 {
 	auto &po = (PipeWireOutput &)ao;
-	return new PipeWireMixer(po, listener);
+	auto *pm = new PipeWireMixer(po, listener);
+	pipewire_output_set_mixer(po, *pm);
+	return pm;
+}
+
+PipeWireMixer::~PipeWireMixer()
+{
+	pipewire_output_clear_mixer(output, *this);
 }
 
 const MixerPlugin pipewire_mixer_plugin = {

--- a/src/output/plugins/PipeWireOutputPlugin.hxx
+++ b/src/output/plugins/PipeWireOutputPlugin.hxx
@@ -21,8 +21,15 @@
 #define MPD_PIPEWIRE_OUTPUT_PLUGIN_HXX
 
 class PipeWireOutput;
+class PipeWireMixer;
 
 extern const struct AudioOutputPlugin pipewire_output_plugin;
+
+void
+pipewire_output_set_mixer(PipeWireOutput &po, PipeWireMixer &pm);
+
+void
+pipewire_output_clear_mixer(PipeWireOutput &po, PipeWireMixer &pm);
 
 void
 pipewire_output_set_volume(PipeWireOutput &output, float volume);


### PR DESCRIPTION
Some notes:
SPA_PROP_volume isn't really used and isn't compatible with PulseAudio which Pipewire also has to support. I have switched to using SPA_PROP_channelVolumes instead.
Moved volume restore logic to the ParamUpdate handler. This is called once when stream starts and is what pipewire-pulse does.
