### PR TITLE
upnp: add option to configure interface for db plugin

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -61,6 +61,15 @@ upnp
 
 Provides access to UPnP media servers.
 
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Setting
+     - Description
+   * - **interface**
+     - Interface used to discover media servers. Decided by upnp if left unconfigured.
+
 Storage plugins
 ===============
 

--- a/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
+++ b/src/db/plugins/upnp/UpnpDatabasePlugin.cxx
@@ -155,7 +155,7 @@ UpnpDatabase::Create(EventLoop &, EventLoop &io_event_loop,
 void
 UpnpDatabase::Open()
 {
-	handle = UpnpClientGlobalInit();
+	handle = UpnpClientGlobalInit(nullptr);
 
 	discovery = new UPnPDeviceDirectory(event_loop, handle);
 	try {

--- a/src/lib/upnp/ClientInit.cxx
+++ b/src/lib/upnp/ClientInit.cxx
@@ -57,9 +57,9 @@ DoInit()
 }
 
 UpnpClient_Handle
-UpnpClientGlobalInit()
+UpnpClientGlobalInit(const char* iface)
 {
-	UpnpGlobalInit();
+	UpnpGlobalInit(iface);
 
 	try {
 		const std::lock_guard<Mutex> protect(upnp_client_init_mutex);

--- a/src/lib/upnp/ClientInit.hxx
+++ b/src/lib/upnp/ClientInit.hxx
@@ -23,7 +23,7 @@
 #include "Compat.hxx"
 
 UpnpClient_Handle
-UpnpClientGlobalInit();
+UpnpClientGlobalInit(const char* iface);
 
 void
 UpnpClientGlobalFinish() noexcept;

--- a/src/lib/upnp/Init.cxx
+++ b/src/lib/upnp/Init.cxx
@@ -33,12 +33,13 @@ static Mutex upnp_init_mutex;
 static unsigned upnp_ref;
 
 static void
-DoInit()
+DoInit(const char* iface)
 {
+
 #ifdef UPNP_ENABLE_IPV6
-	auto code = UpnpInit2(nullptr, 0);
+	auto code = UpnpInit2(iface, 0);
 #else
-	auto code = UpnpInit(nullptr, 0);
+	auto code = UpnpInit(iface, 0);
 #endif
 	if (code != UPNP_E_SUCCESS)
 		throw FormatRuntimeError("UpnpInit() failed: %s",
@@ -53,12 +54,12 @@ DoInit()
 }
 
 void
-UpnpGlobalInit()
+UpnpGlobalInit(const char* iface)
 {
 	const std::lock_guard<Mutex> protect(upnp_init_mutex);
 
 	if (upnp_ref == 0)
-		DoInit();
+		DoInit(iface);
 
 	++upnp_ref;
 }

--- a/src/lib/upnp/Init.hxx
+++ b/src/lib/upnp/Init.hxx
@@ -21,7 +21,7 @@
 #define MPD_UPNP_INIT_HXX
 
 void
-UpnpGlobalInit();
+UpnpGlobalInit(const char* iface);
 
 void
 UpnpGlobalFinish() noexcept;

--- a/src/neighbor/plugins/UpnpNeighborPlugin.cxx
+++ b/src/neighbor/plugins/UpnpNeighborPlugin.cxx
@@ -74,7 +74,7 @@ private:
 void
 UpnpNeighborExplorer::Open()
 {
-	auto handle = UpnpClientGlobalInit();
+	auto handle = UpnpClientGlobalInit(nullptr);
 
 	discovery = new UPnPDeviceDirectory(event_loop, handle, this);
 


### PR DESCRIPTION
Add an option to the UPnP database plugin to configure which interface
is used by upnp to discover servers.

upnp by default selects the first interface that is not loopback, which
in some cases might not be the desired interface. For example if wanting
to access a DLNA server over a VPN connection.

The "interface" option can now be set to the name of the desired
interface to achieve this.

The default behaviour remains unchanged.