### PR TITLE
output/plugins: fix build error with clang and -stdlib=libc++

### DIFF
--- a/src/output/plugins/PipeWireOutputPlugin.cxx
+++ b/src/output/plugins/PipeWireOutputPlugin.cxx
@@ -55,6 +55,7 @@
 #include <boost/lockfree/spsc_queue.hpp>
 
 #include <algorithm>
+#include <array>
 #include <stdexcept>
 #include <string>
 


### PR DESCRIPTION
This fixes this build error observed with clang and `-stdlib=libc++`:

```
../mpd-0.23.3/src/output/plugins/PipeWireOutputPlugin.cxx:661:55: error: implicit instantiation of undefined template 'std::array<std::byte, 64>'
        std::array<std::byte, MAX_CHANNELS * MAX_INTERLEAVE> buffer;
                                                             ^
/usr/include/c++/v1/__tuple:219:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
```