### PR TITLE
remove std::move

### DIFF
--- a/src/client/Response.cxx
+++ b/src/client/Response.cxx
@@ -80,7 +80,7 @@ Response::VFmtError(enum ack code,
 	Fmt(FMT_STRING("ACK [{}@{}] {{{}}} "),
 	    (int)code, list_index, command);
 
-	VFmt(format_str, std::move(args));
+	VFmt(format_str, args);
 
 	Write("\n");
 }


### PR DESCRIPTION
clang-tidy reports this is trivially copyable and thus std::move has no
effect.

Signed-off-by: Rosen Penev <rosenp@gmail.com>