### PR TITLE
doc/conf.py: Set sidebar width to 300px to limit wrapping

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -107,6 +107,7 @@ html_theme = 'classic'
 # documentation.
 #
 # html_theme_options = {}
+html_theme_options = {"sidebarwidth": "300px"}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
This enhances readability in sidebar, especially for "User’s Manual" and
"Protocol" pages