### PR TITLE
use cinttypes header

### DIFF
--- a/src/archive/plugins/ZzipArchivePlugin.cxx
+++ b/src/archive/plugins/ZzipArchivePlugin.cxx
@@ -35,7 +35,7 @@
 
 #include <utility>
 
-#include <inttypes.h> /* for PRIoffset (PRIu64) */
+#include <cinttypes> /* for PRIoffset (PRIu64) */
 
 struct ZzipDir {
 	ZZIP_DIR *const dir;


### PR DESCRIPTION
inttypes.h is deprecated.

Signed-off-by: Rosen Penev <rosenp@gmail.com>