### PR TITLE
Fix non-x86 Android build error: needs_exe_wrapper

### DIFF
--- a/python/build/meson.py
+++ b/python/build/meson.py
@@ -53,19 +53,21 @@ pkgconfig = '{toolchain.pkg_config}'
         f.write(f"""
 [properties]
 root = '{toolchain.install_prefix}'
-
-[built-in options]
-c_args = {repr((toolchain.cppflags + ' ' + toolchain.cflags).split())}
-c_link_args = {repr(toolchain.ldflags.split() + toolchain.libs.split())}
-
-cpp_args = {repr((toolchain.cppflags + ' ' + toolchain.cxxflags).split())}
-cpp_link_args = {repr(toolchain.ldflags.split() + toolchain.libs.split())}
 """)
 
         if 'android' in toolchain.arch:
             f.write("""
 # Keep Meson from executing Android-x86 test binariees
 needs_exe_wrapper = true
+""")
+
+        f.write(f"""
+[built-in options]
+c_args = {repr((toolchain.cppflags + ' ' + toolchain.cflags).split())}
+c_link_args = {repr(toolchain.ldflags.split() + toolchain.libs.split())}
+
+cpp_args = {repr((toolchain.cppflags + ' ' + toolchain.cxxflags).split())}
+cpp_link_args = {repr(toolchain.ldflags.split() + toolchain.libs.split())}
 """)
 
         f.write(f"""


### PR DESCRIPTION
Fixes build error when compiling for arm64 Android:
```
lib/src/libmpdclient-2.19/meson.build:1:0: ERROR: Unknown options: "needs_exe_wrapper"
```