### PR TITLE
Android: Detect output change with ACTION_AUDIO_BECOMING_NOISY

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -17,8 +17,6 @@
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-  <uses-permission android:name="android.permission.BLUETOOTH" />
 
   <application android:allowBackup="true"
                android:requestLegacyExternalStorage="true"
@@ -43,7 +41,6 @@
     <receiver android:name=".Receiver">
       <intent-filter>
         <action android:name="android.intent.action.BOOT_COMPLETED" />
-        <action android:name="android.intent.action.HEADSET_PLUG" />
       </intent-filter>
     </receiver>
     <service android:name=".Main" android:process=":main"/>

--- a/android/src/Main.java
+++ b/android/src/Main.java
@@ -24,14 +24,13 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
-import android.bluetooth.BluetoothDevice;
-import android.bluetooth.BluetoothClass;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
+import android.media.AudioManager;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -200,24 +199,14 @@ public class Main extends Service implements Runnable {
 			return;
 
 		IntentFilter filter = new IntentFilter();
-		filter.addAction(Intent.ACTION_HEADSET_PLUG);
-		filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECT_REQUESTED);
-		filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
+		filter.addAction(AudioManager.ACTION_AUDIO_BECOMING_NOISY);
 		registerReceiver(new BroadcastReceiver() {
 			@Override
 			public void onReceive(Context context, Intent intent) {
-				if (!mPauseOnHeadphonesDisconnect) {
+				if (!mPauseOnHeadphonesDisconnect)
 					return;
-				}
-
-				if (intent.getAction().equals(Intent.ACTION_HEADSET_PLUG)) {
-					if (intent.hasExtra("state") && intent.getIntExtra("state", 0) == 0)
-						pause();
-				} else {
-					BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-					if (device.getBluetoothClass().hasService(BluetoothClass.Service.AUDIO))
-						pause();
-				}
+				if (intent.getAction() == AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+					pause();
 			}
 		}, filter);
 


### PR DESCRIPTION
Improves the changes made in 57687779befd796b79b1a569daf9e48eac3aea26 by
using AudioManager.ACTION_AUDIO_BECOMING_NOISY rather than listening for
wired headset unplug events or Bluetooth headset disconnect events. This
method is more flexible, allowing the feature to work on other types of
audio output device, as well as Bluetooth devices that don't set their
device class correctly. This change also has the benefit of being more
responsive, pausing the audio before it is rerouted to the built-in
speaker.

https://developer.android.com/guide/topics/media-apps/volume-and-earphones