### PR TITLE
Fix DSCP LE value

### DIFF
--- a/src/net/DscpParser.cxx
+++ b/src/net/DscpParser.cxx
@@ -69,7 +69,7 @@
 #endif
 
 #ifndef IPTOS_DSCP_LE
-#define IPTOS_DSCP_LE 0x01
+#define IPTOS_DSCP_LE 0x04
 #endif
 
 static constexpr struct {


### PR DESCRIPTION
Correct value is 0x04 since the lower 2 ECN bits need to be accounted for.