### PR TITLE
Add (resurrect?) doxygen support

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -37,9 +37,9 @@ if get_option('manpages')
   )
 endif
 
-doxygen = find_program('doxygen', required: false)
-if get_option('doxygen') and doxygen.found()
+if get_option('doxygen')
 
+  doxygen = find_program('doxygen', required: true)
   conf_data = configuration_data()
   conf_data.set('VERSION', meson.project_version())
   conf_data.set('abs_top_srcdir', meson.source_root())

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -36,3 +36,22 @@ if get_option('manpages')
     install_dir: [join_paths(get_option('mandir'), 'man1'), join_paths(get_option('mandir'), 'man5')],
   )
 endif
+
+doxygen = find_program('doxygen', required: false)
+if get_option('doxygen') and doxygen.found()
+
+  conf_data = configuration_data()
+  conf_data.set('VERSION', meson.project_version())
+  conf_data.set('abs_top_srcdir', meson.source_root())
+  doxyfile = configure_file(
+    input: 'doxygen.conf.in',
+    output: 'Doxyfile',
+    configuration: conf_data
+  )
+  
+  custom_target('Doxygen',
+    command: [doxygen, doxyfile],
+    output: ['api'],
+    build_by_default: true
+  )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 option('documentation', type: 'feature', description: 'Build documentation')
 option('html_manual', type: 'boolean', value: true, description: 'Build the HTML manual')
 option('manpages', type: 'boolean', value: true, description: 'Build manual pages')
+option('doxygen', type: 'boolean', value: false, description: 'Build doxygen source documentation')
 
 option('syslog', type: 'feature', description: 'syslog support')
 option('inotify', type: 'boolean', value: true, description: 'inotify support (for automatic database update)')


### PR DESCRIPTION
Added a `doxygen` option to the `doc` build. It makes use of the already-present but unused file `doxygen.conf.in`. The option is set to false by default.