### PR TITLE
plugins/FfmpegIO: libavutil/mem.h to work with newest libav

### DIFF
--- a/src/decoder/plugins/FfmpegIo.cxx
+++ b/src/decoder/plugins/FfmpegIo.cxx
@@ -21,6 +21,7 @@
 #define __STDC_CONSTANT_MACROS
 
 #include "FfmpegIo.hxx"
+#include "libavutil/mem.h"
 #include "../DecoderAPI.hxx"
 #include "input/InputStream.hxx"
 


### PR DESCRIPTION
The newest libav has these functions in mem.h. I can successfully build with this include, and cannot otherwise.