### PR TITLE
fix pre-open/enable edge cases PipeWireOutput::SetVolume

### DIFF
--- a/src/output/plugins/PipeWireOutputPlugin.cxx
+++ b/src/output/plugins/PipeWireOutputPlugin.cxx
@@ -311,6 +311,9 @@ PipeWireOutput::PipeWireOutput(const ConfigBlock &block)
 void
 PipeWireOutput::SetVolume(float _volume)
 {
+	if (thread_loop == nullptr)
+		return;
+
 	const PipeWire::ThreadLoopLock lock(thread_loop);
 
 	float newvol = _volume*_volume*_volume;


### PR DESCRIPTION
this patchset prevents a crash due to there being no thread loop yet, as well as (re)storing the volume under more conditions.