### PR TITLE
decoder/opus: Implement bitrate calculation

### DIFF
--- a/src/decoder/plugins/OpusDecoderPlugin.cxx
+++ b/src/decoder/plugins/OpusDecoderPlugin.cxx
@@ -327,9 +327,15 @@ MPDOpusDecoder::HandleAudio(const ogg_packet &packet)
 			return;
 	}
 
-	// the size of the opus packet in bits / number of samples * samp/sec / 1000
+	/* Formula for calculation of bitrate of the current opus packet:
+	* bits_sent_into_decoder = packet.bytes * 8
+	* bytes_of_audio_decoded = nframes * frame_size
+	* samples_of_audio_decoded_per_channel = bytes_of_audio_decoded / channels / 2
+	* 1/seconds_decoded = opus_sample_rate / samples_of_audio_decoded_per_channel
+	* kbits = bits_sent_into_decoder * 1/seconds_decoded / 1000
+	*/
 	int channels = opus_packet_get_nb_channels((const unsigned char*)packet.packet);
-	uint16_t kbits = (unsigned int)packet.bytes*channels*8 * opus_sample_rate / (nframes * frame_size / 2) / 1000;
+	uint16_t kbits = (unsigned int)packet.bytes*8 * opus_sample_rate / (nframes * frame_size / channels / 2) / 1000;
 
 	/* apply the "skip" value */
 	if (skip >= (unsigned)nframes) {

--- a/src/decoder/plugins/OpusDecoderPlugin.cxx
+++ b/src/decoder/plugins/OpusDecoderPlugin.cxx
@@ -329,13 +329,10 @@ MPDOpusDecoder::HandleAudio(const ogg_packet &packet)
 
 	/* Formula for calculation of bitrate of the current opus packet:
 	* bits_sent_into_decoder = packet.bytes * 8
-	* bytes_of_audio_decoded = nframes * frame_size
-	* samples_of_audio_decoded_per_channel = bytes_of_audio_decoded / channels / 2
-	* 1/seconds_decoded = opus_sample_rate / samples_of_audio_decoded_per_channel
+	* 1/seconds_decoded = opus_sample_rate / nframes
 	* kbits = bits_sent_into_decoder * 1/seconds_decoded / 1000
 	*/
-	int channels = opus_packet_get_nb_channels((const unsigned char*)packet.packet);
-	uint16_t kbits = (unsigned int)packet.bytes*8 * opus_sample_rate / (nframes * frame_size / channels / 2) / 1000;
+	uint16_t kbits = (unsigned int)packet.bytes*8 * opus_sample_rate / nframes / 1000;
 
 	/* apply the "skip" value */
 	if (skip >= (unsigned)nframes) {

--- a/src/decoder/plugins/OpusDecoderPlugin.cxx
+++ b/src/decoder/plugins/OpusDecoderPlugin.cxx
@@ -327,6 +327,10 @@ MPDOpusDecoder::HandleAudio(const ogg_packet &packet)
 			return;
 	}
 
+	// the size of the opus packet in bits / number of samples * samp/sec / 1000
+	int channels = opus_packet_get_nb_channels((const unsigned char*)packet.packet);
+	uint16_t kbits = (unsigned int)packet.bytes*channels*8 * opus_sample_rate / (nframes * frame_size / 2) / 1000;
+
 	/* apply the "skip" value */
 	if (skip >= (unsigned)nframes) {
 		skip -= nframes;
@@ -361,7 +365,7 @@ MPDOpusDecoder::HandleAudio(const ogg_packet &packet)
 	const size_t nbytes = nframes * frame_size;
 	auto cmd = client.SubmitData(input_stream,
 				     data, nbytes,
-				     0);
+				     kbits);
 	if (cmd != DecoderCommand::NONE)
 		throw cmd;
 


### PR DESCRIPTION
This implements obtaining bitrates when playing Ogg/Opus files with the `opus` decoder plugin. The bitrate is calculated per ogg packet by obtaining its size in bits, multiplying by the sample rate, and dividing by the number of samples of audio decoded from said packet. It seems to work fine from my testing and the values returned appear accurate. It should not divide by zero since 0 `nframes` values result in a `return` prior to this line.

For reference, [here](https://github.com/xiph/opusfile/blob/cf218fb54929a1f54e30e2cb208a22d08b08c889/src/opusfile.c#L1814) is how `libopusfile` does it; similar calculations though it seems it might do it over a larger span than just one packet.

This would partially address #428, but I have not yet determined how to do this for the `vorbis` plugin.