### PR TITLE
Remove bmp, tiff and add webp for coverimage filenames

### DIFF
--- a/src/command/FileCommands.cxx
+++ b/src/command/FileCommands.cxx
@@ -160,8 +160,7 @@ find_stream_art(std::string_view directory, Mutex &mutex)
 	static constexpr auto art_names = std::array {
 		"cover.png",
 		"cover.jpg",
-		"cover.tiff",
-		"cover.bmp",
+		"cover.webp",
 	};
 
 	for(const auto name : art_names) {


### PR DESCRIPTION
- supporting bmp and tiff seems outdated
- webp is more widely used for coverimages