### PR TITLE
Make volume changes to apply to disabled software mixers.

### DIFF
--- a/src/mixer/MixerAll.cxx
+++ b/src/mixer/MixerAll.cxx
@@ -34,11 +34,11 @@ gcc_pure
 static int
 output_mixer_get_volume(const AudioOutputControl &ao) noexcept
 {
-	if (!ao.IsEnabled())
-		return -1;
-
 	auto *mixer = ao.GetMixer();
 	if (mixer == nullptr)
+		return -1;
+
+	if (!ao.IsEnabled() && !mixer->IsPlugin(software_mixer_plugin))
 		return -1;
 
 	try {
@@ -76,11 +76,11 @@ output_mixer_set_volume(AudioOutputControl &ao, unsigned volume) noexcept
 {
 	assert(volume <= 100);
 
-	if (!ao.IsEnabled())
-		return false;
-
 	auto *mixer = ao.GetMixer();
 	if (mixer == nullptr)
+		return false;
+
+	if (!ao.IsEnabled() && !mixer->IsPlugin(software_mixer_plugin))
 		return false;
 
 	try {


### PR DESCRIPTION
This resolves #1423.

Move audio output state check ahead of mixer check and force volume
applying even for disabled software mixed outputs.

This fixes incorrect software mixer volume that used to occur when volume was changed while output being disabled.

This is easily reproduced with following sequence of commands on multi-output software mixed MPD setup.

mpc volume 38; mpc disable 3; mpc volume 88; mpc enable 3

On current MPD, following commands would result in output 3 playing at volume 38, while all other enabled outputs would play at volume 88. Moreover, global volume would display average of outputs real volumes. In my case, it's 75.

After applying this patch, following commands would produce expected behavior. All outputs play at expected (88) volume. And volume is correctly displayed as 88.

Signed-off-by: Vitaly Ostrosablin <tmp6154@yandex.ru>