### PR TITLE
src/lib/upnp: introduce Upnp namespace to fix link error with libnpupnp

### DIFF
--- a/src/lib/upnp/Device.cxx
+++ b/src/lib/upnp/Device.cxx
@@ -23,6 +23,8 @@
 
 #include <string.h>
 
+using namespace Upnp;
+
 /* this destructor exists here just so it won't get inlined */
 UPnPDevice::~UPnPDevice() noexcept = default;
 

--- a/src/lib/upnp/Util.cxx
+++ b/src/lib/upnp/Util.cxx
@@ -19,6 +19,8 @@
 
 #include "Util.hxx"
 
+namespace Upnp {
+
 /** Get rid of white space at both ends */
 void
 trimstring(std::string &s, const char *ws) noexcept
@@ -66,3 +68,5 @@ path_getfather(const std::string &s) noexcept
 	path_catslash(father);
 	return father;
 }
+
+} // namespace Upnp

--- a/src/lib/upnp/Util.hxx
+++ b/src/lib/upnp/Util.hxx
@@ -22,10 +22,14 @@
 
 #include <string>
 
+namespace Upnp {
+
 void
 trimstring(std::string &s, const char *ws = " \t\n") noexcept;
 
 std::string
 path_getfather(const std::string &s) noexcept;
+
+} // namespace Upnp
 
 #endif /* _UPNPP_H_X_INCLUDED_ */


### PR DESCRIPTION
libnpupnp declares a function trimstring() with scope external, which results in a link error due to multiple definitions of the same symbol. 

  [libnpupnp-4-2-1::src/inc/smallut.h::157]
  extern void trimstring(std::string& s, const char *ws = " \t");

  [mpd-0.23.6::src/lib/upnp/Utils.hpp::27]
  void
  trimstring(std::string &s, const char *ws) noexcept

Introduce a namespace for the mpd implementation of trimstring() to fix the following build error:

mips-buildroot-linux-musl/bin/ld: mips-buildroot-linux-musl/sysroot/usr/lib/libnpupnp.a(libnpupnp_la-smallut.o): in function `trimstring(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, char const*)':
smallut.cpp:(.text+0x114c): multiple definition of `trimstring(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, char const*)'; src/lib/upnp/libupnp.a.p/Util.cxx.o:Util.cxx:(.text._Z10trimstringRNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPKc+0x0): first defined here
