### PR TITLE
src/lib/icu: fix iconv() detection when libiconv is installed

### DIFF
--- a/src/lib/icu/meson.build
+++ b/src/lib/icu/meson.build
@@ -12,17 +12,23 @@ if is_windows
   icu_sources += 'Win32.cxx'
 endif
 
+iconv_dep = []
 if icu_dep.found()
   icu_sources += [
     'Util.cxx',
     'Init.cxx',
   ]
 elif not get_option('iconv').disabled()
-  have_iconv = compiler.has_function('iconv', prefix : '#include <iconv.h>')
-  conf.set('HAVE_ICONV', have_iconv)
+  # an installed iconv library will make the builtin iconf() unavailable,
+  # so search for the library first and pass it as (possible) dependency
+  iconv_dep = compiler.find_library('libiconv', required: false)
+  have_iconv = compiler.has_function('iconv', 
+    dependencies: iconv_dep, 
+    prefix : '#include <iconv.h>')
   if not have_iconv and get_option('iconv').enabled()
     error('iconv() not available')
   endif
+  conf.set('HAVE_ICONV', have_iconv)
 endif
 
 icu = static_library(
@@ -31,6 +37,7 @@ icu = static_library(
   include_directories: inc,
   dependencies: [
     icu_dep,
+    iconv_dep,
     fmt_dep,
   ],
 )


### PR DESCRIPTION
iconv() integration may fail when libiconv is installed. In that case, the build may silently disable iconv or fail later during build, because -liconv is not specified. 

Installation of libiconv hides the functionality provided by the C library (it overwrites usr/include/iconv.h and redefines symbols by redefining them, e.g. #define iconv_open libiconv_open)

Meson iconv() detection may accept a libiconf installation, but fails to provide an automatic dependency. The link stage subsequently fails with: 

/nvmedata/autobuild/instance-29/output-1/host/lib/gcc/i686-buildroot-linux-uclibc/9.4.0/../../../../i686-buildroot-linux-uclibc/bin/ld: src/lib/icu/libicu.a.p/Converter.cxx.o: undefined reference to symbol 'libiconv_open'
/nvmedata/autobuild/instance-29/output-1/host/lib/gcc/i686-buildroot-linux-uclibc/9.4.0/../../../../i686-buildroot-linux-uclibc/bin/ld: /nvmedata/autobuild/instance-29/output-1/host/i686-buildroot-linux-uclibc/sysroot/usr/lib32/libiconv.so.2: error adding symbols: DSO missing from command line

This is probably also related to https://github.com/MusicPlayerDaemon/MPD/pull/928

Modify iconv() detection to first check for an installed libiconv and passing it as dependency to compiler.has_function(). The dependency object may be empty, which falls back to the current functionality of only detecting a builtin ficonv(). the libiconv dependency is propagated to the icu library, and thus integrated in the final build. 