### PR TITLE
upnp: use UpnpInit2 always

### DIFF
--- a/src/lib/upnp/Init.cxx
+++ b/src/lib/upnp/Init.cxx
@@ -36,11 +36,7 @@ static void
 DoInit(const char* iface)
 {
 
-#ifdef UPNP_ENABLE_IPV6
 	auto code = UpnpInit2(iface, 0);
-#else
-	auto code = UpnpInit(iface, 0);
-#endif
 	if (code != UPNP_E_SUCCESS)
 		throw FormatRuntimeError("UpnpInit() failed: %s",
 					 UpnpGetErrorMessage(code));


### PR DESCRIPTION
libupnp 1.14 removes the non 2 function. Fixes compilation there.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Fixes: https://github.com/MusicPlayerDaemon/MPD/issues/1499