### PR TITLE
fix -Wdeprecated warnings with C++20

### DIFF
--- a/src/lib/upnp/ContentDirectoryService.hxx
+++ b/src/lib/upnp/ContentDirectoryService.hxx
@@ -67,8 +67,10 @@ public:
 
 	/** An empty one */
 	ContentDirectoryService() = default;
-
 	~ContentDirectoryService() noexcept;
+
+	ContentDirectoryService(const ContentDirectoryService&) = default;
+	ContentDirectoryService& operator=(const ContentDirectoryService&) = default;
 
 	/** Read a container's children list into dirbuf.
 	 *

--- a/src/pcm/Dop.cxx
+++ b/src/pcm/Dop.cxx
@@ -92,5 +92,5 @@ ConstBuffer<uint32_t>
 DsdToDopConverter::Convert(ConstBuffer<uint8_t> src) noexcept
 {
 	return rest_buffer.Process<uint32_t>(buffer, src, 2 * channels,
-		[=](auto && arg1, auto && arg2, auto && arg3) { return DsdToDop(arg1, arg2, arg3, channels); });
+		[this](auto && arg1, auto && arg2, auto && arg3) { return DsdToDop(arg1, arg2, arg3, channels); });
 }

--- a/src/pcm/Dsd16.cxx
+++ b/src/pcm/Dsd16.cxx
@@ -64,5 +64,5 @@ ConstBuffer<uint16_t>
 Dsd16Converter::Convert(ConstBuffer<uint8_t> src) noexcept
 {
 	return rest_buffer.Process<uint16_t>(buffer, src, channels,
-					     [=](auto && arg1, auto && arg2, auto && arg3) { return Dsd8To16(arg1, arg2, arg3, channels); });
+					     [this](auto && arg1, auto && arg2, auto && arg3) { return Dsd8To16(arg1, arg2, arg3, channels); });
 }

--- a/src/pcm/Dsd32.cxx
+++ b/src/pcm/Dsd32.cxx
@@ -66,5 +66,5 @@ ConstBuffer<uint32_t>
 Dsd32Converter::Convert(ConstBuffer<uint8_t> src) noexcept
 {
 	return rest_buffer.Process<uint32_t>(buffer, src, channels,
-					     [=](auto && arg1, auto && arg2, auto && arg3) { return Dsd8To32(arg1, arg2, arg3, channels); });
+					     [this](auto && arg1, auto && arg2, auto && arg3) { return Dsd8To32(arg1, arg2, arg3, channels); });
 }

--- a/src/song/ISongFilter.hxx
+++ b/src/song/ISongFilter.hxx
@@ -29,7 +29,11 @@ using ISongFilterPtr = std::unique_ptr<ISongFilter>;
 
 class ISongFilter {
 public:
+	ISongFilter() = default;
 	virtual ~ISongFilter() noexcept = default;
+
+	ISongFilter(const ISongFilter&) = default;
+	ISongFilter& operator=(const ISongFilter&) = default;
 
 	virtual ISongFilterPtr Clone() const noexcept = 0;
 


### PR DESCRIPTION
this must be explicit. The rest are C++11 deprecated warnings.

Signed-off-by: Rosen Penev <rosenp@gmail.com>