### PR TITLE
Fix seeking HLS on-demand streaming not working

### DIFF
--- a/src/decoder/plugins/FfmpegDecoderPlugin.cxx
+++ b/src/decoder/plugins/FfmpegDecoderPlugin.cxx
@@ -471,7 +471,7 @@ static bool
 IsSeekable(const AVFormatContext &format_context) noexcept
 {
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(58, 6, 100)
-	return (format_context.ctx_flags & AVFMTCTX_UNSEEKABLE) != 0;
+	return (format_context.ctx_flags & AVFMTCTX_UNSEEKABLE) == 0;
 #else
 	(void)format_context;
 	return false;

--- a/src/decoder/plugins/FfmpegDecoderPlugin.cxx
+++ b/src/decoder/plugins/FfmpegDecoderPlugin.cxx
@@ -533,9 +533,8 @@ FfmpegDecode(DecoderClient &client, InputStream *input,
 		: FromFfmpegTimeChecked(format_context.duration, AV_TIME_BASE_Q);
 
 	client.Ready(audio_format,
-		     input
-		     ? input->IsSeekable()
-		     : IsSeekable(format_context),
+		     (input ? input->IsSeekable() : false)
+		     || IsSeekable(format_context),
 		     total_time);
 
 	FfmpegParseMetaData(client, format_context, audio_stream);


### PR DESCRIPTION
Seeking HLS on-demand streaming not work if the content is served by a server which doesn't support partial requests from the client for file downloads.
I believe the pertial request support is not really needed because content is split into short length chunk files in HLS streaming.

This situation can be reproduced by following procedure (I'm using x86 PC running Ubuntu 20.04).

Prepare HLS example content as follows:
```
$ mkdir test
$ ffmpeg -i example.flac -vn -c:a aac -b:a 128000 -f hls -hls_list_size 0 test/output.m3u8
```
Prepare NGINX web server using the official Docker image.
```
$ docker run --name tmp-nginx-container -d nginx
$ docker cp tmp-nginx-container:/etc/nginx/conf.d/default.conf .
$ docker rm -f tmp-nginx-container
```
Edit default.conf and add "max_ranges 0;" to "location / {...}" like following:
```
    location / {
        root   /usr/share/nginx/html;
        index  index.html index.htm;
        max_ranges 0;
    }
```
This disables partial requests support and removes 'Accept-Ranges: bytes' header from the server response.
Then, run the server:
```
$ docker run --name test-nginx -v $PWD/test:/usr/share/nginx/html:ro -v $PWD/default.conf:/etc/nginx/conf.d/default.conf -d -p 8080:80 nginx
```
Setup MPD to play the next URL.
`http://address-of-the-server:8080/output.m3u8`
Seeking this stream results in "exception: Not seekable".  

I've patched src/decoder/plugins/FfmpegDecoderPlugin.cxx to solve the issue as follows:

1. Fixed logical condition of if statement in IsSeekable()
   I beleive the original condition is wrong.
2. Modified second argument of the client.Ready in FfmpegDecode().

I am not sure how the 2. affects other situations than playing HLS streaming.
So, if this is not preferable, please ignore my PR.
