### PR TITLE
apple/Throw: add missing <cstring> header

### DIFF
--- a/src/apple/Throw.cxx
+++ b/src/apple/Throw.cxx
@@ -31,6 +31,7 @@
 #include "ErrorRef.hxx"
 #include "StringRef.hxx"
 
+#include <cstring>
 #include <stdexcept>
 
 namespace Apple {
@@ -57,8 +58,8 @@ ThrowOSStatus(OSStatus status, const char *_msg)
 	const Apple::StringRef cfstr(cferr.CopyDescription());
 
 	char msg[1024];
-	strcpy(msg, _msg);
-	size_t length = strlen(msg);
+	std::strcpy(msg, _msg);
+	size_t length = std::strlen(msg);
 
 	cfstr.GetCString(msg + length, sizeof(msg) - length);
 	throw std::runtime_error(msg);


### PR DESCRIPTION
`strlen()` and `strcpy()` are provided by the `<string.h>` and `<cstring>` headers (as functions in global and `std` namespaces, respectively).

Compilers MAY provide an implementation for either of the functions without including the extra header but the existence of a declaration without the header is not assured.

Fixes #1530.