### PR TITLE
yajl/YajlResponseParser: add getJson()

### DIFF
--- a/src/command/FileCommands.cxx
+++ b/src/command/FileCommands.cxx
@@ -158,6 +158,7 @@ static InputStreamPtr
 find_stream_art(std::string_view directory, Mutex &mutex)
 {
 	static constexpr auto art_names = std::array {
+		"folder.jpg",
 		"cover.png",
 		"cover.jpg",
 		"cover.webp",

--- a/src/lib/yajl/Handle.hxx
+++ b/src/lib/yajl/Handle.hxx
@@ -33,6 +33,7 @@
 #include <yajl/yajl_parse.h>
 
 #include <utility>
+#include <string>
 
 namespace Yajl {
 
@@ -41,6 +42,7 @@ namespace Yajl {
  */
 class Handle {
 	yajl_handle handle = nullptr;
+	std::string json;
 
 public:
 	Handle() = default;
@@ -62,8 +64,11 @@ public:
 		std::swap(handle, src.handle);
 		return *this;
 	}
+	
+	std::string getJson() {return json;}
 
 	void Parse(const unsigned char *jsonText, size_t jsonTextLength) {
+		json=std::string(reinterpret_cast<const char*>(jsonText));
 		HandleStatus(yajl_parse(handle, jsonText, jsonTextLength));
 	}
 

--- a/src/lib/yajl/ResponseParser.hxx
+++ b/src/lib/yajl/ResponseParser.hxx
@@ -44,6 +44,7 @@ public:
 	YajlResponseParser(Args... args) noexcept
 		:handle(std::forward<Args>(args)...) {}
 
+	std::string getJson() {return handle.getJson();}
 	/* virtual methods fro CurlResponseParser */
 	void OnData(ConstBuffer<void> data) final;
 	void OnEnd() override;


### PR DESCRIPTION
added the filename folder.jpg to the list.

yajl/YajlResponseParser: now hold the jsonText, so clients can log if it's needed.