### PR TITLE
.github: Add reminder to include backtrace in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,3 +24,4 @@ about: Create a bug report
 
 ## Log
 <!-- Paste relevant portions of the log file here (--verbose) -->
+<!-- If MPD has crashed, include a backtrace (see https://mpd.readthedocs.io/en/stable/user.html#mpd-crashes) -->


### PR DESCRIPTION
I saw #1560 and felt that the need for the inclusion of a backtrace could be expressed directly in the issue template, which is the first document that new bug reporters will see.