### PR TITLE
meson: use dependency('iconv')

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'mpd',
   ['c', 'cpp'],
   version: '0.24',
-  meson_version: '>= 0.56.0',
+  meson_version: '>= 0.60.0',
   default_options: [
     'c_std=c11',
     'build.c_std=c11',

--- a/src/lib/icu/meson.build
+++ b/src/lib/icu/meson.build
@@ -19,16 +19,8 @@ if icu_dep.found()
     'Init.cxx',
   ]
 elif not get_option('iconv').disabled()
-  # an installed iconv library will make the builtin iconv() unavailable,
-  # so search for the library first and pass it as (possible) dependency
-  iconv_dep = compiler.find_library('libiconv', required: false)
-  have_iconv = compiler.has_function('iconv', 
-    dependencies: iconv_dep, 
-    prefix : '#include <iconv.h>')
-  if not have_iconv and get_option('iconv').enabled()
-    error('iconv() not available')
-  endif
-  conf.set('HAVE_ICONV', have_iconv)
+  iconv_dep = dependency('iconv')
+  conf.set('HAVE_ICONV', iconv_dep.found())
 endif
 
 icu = static_library(


### PR DESCRIPTION
Properly deals with iconv, unlike the current solution. have_iconv fails
when libiconv CFLAGS are passed to the compiler. Tested under OpenWrt
with its CONFIG_BUILD_NLS, which adds libiconv include flags.

Requires meson version to be increased to 0.60.

Signed-off-by: Rosen Penev <rosenp@gmail.com>