### PR TITLE
use data() instead of &[0]

### DIFF
--- a/src/playlist/cue/CueParser.cxx
+++ b/src/playlist/cue/CueParser.cxx
@@ -43,7 +43,7 @@ cue_next_word(std::string_view &src) noexcept
 static std::string_view
 cue_next_quoted(std::string_view &src) noexcept
 {
-	assert(src.data()[-1] == '"');
+	assert(src[-1] == '"');
 
 	auto end = src.find('"');
 	if (end == src.npos)

--- a/src/playlist/plugins/EmbeddedCuePlaylistPlugin.cxx
+++ b/src/playlist/plugins/EmbeddedCuePlaylistPlugin.cxx
@@ -106,7 +106,7 @@ embcue_playlist_open_uri(const char *uri,
 
 	playlist->cuesheet = std::move(extract_cuesheet.cuesheet);
 
-	playlist->next = &playlist->cuesheet[0];
+	playlist->next = playlist->cuesheet.data();
 	playlist->parser = std::make_unique<CueParser>();
 
 	return playlist;


### PR DESCRIPTION
No need for C pointer manipulation.

Removed data() for string_view as [] can be used without.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

That assert looks like it should be

```
assert(src.back() == '"');
```

Unless I understand the code wrong.