### PR TITLE
Sets the curl proxy ssl verify options to the values of the host configuration options

### DIFF
--- a/src/input/plugins/CurlInputPlugin.cxx
+++ b/src/input/plugins/CurlInputPlugin.cxx
@@ -437,6 +437,8 @@ CurlInputStream::InitEasy()
 	request->SetVerifyPeer(verify_peer);
 	request->SetVerifyHost(verify_host);
 	request->SetOption(CURLOPT_HTTPHEADER, request_headers.Get());
+	request->SetProxyVerifyPeer(verify_peer);
+	request->SetProxyVerifyHost(verify_host);
 }
 
 void

--- a/src/lib/curl/Request.hxx
+++ b/src/lib/curl/Request.hxx
@@ -122,6 +122,14 @@ public:
 		easy.SetVerifyPeer(value);
 	}
 
+	void SetProxyVerifyHost(bool value) {
+		easy.SetOption(CURLOPT_PROXY_SSL_VERIFYHOST, value == true ? 2L : 0L);
+	}
+
+	void SetProxyVerifyPeer(bool value) {
+		easy.SetOption(CURLOPT_PROXY_SSL_VERIFYPEER, value);
+	}
+
 	void SetNoBody(bool value=true) {
 		easy.SetNoBody(value);
 	}


### PR DESCRIPTION
This fixes #1616

Or do you want two new configuration options for the curl plugin?