### PR TITLE
Merge tags instead of replacing when dynamically updating song tags from remote stream

### DIFF
--- a/src/player/Thread.cxx
+++ b/src/player/Thread.cxx
@@ -920,7 +920,7 @@ PlayerControl::LockUpdateSongTag(DetachedSong &song,
 		   streams may change tags dynamically */
 		return;
 
-	song.SetTag(new_tag);
+	song.MergeTag(new_tag);
 
 	LockSetTaggedSong(song);
 

--- a/src/song/DetachedSong.hxx
+++ b/src/song/DetachedSong.hxx
@@ -212,6 +212,10 @@ public:
 		tag = std::move(other.tag);
 	}
 
+	void MergeTag(const Tag &_tag) noexcept {
+		tag = Tag::Merge(tag, _tag);
+	}
+
 	/**
 	 * Similar to the MoveTagFrom(), but move only the #TagItem
 	 * array.


### PR DESCRIPTION
issue MusicPlayerDaemon/MPD#1400

Tested with this playlist for remote stream with tags:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<playlist version="1" xmlns="http://xspf.org/ns/0/">
  <trackList>
    <track>
        <location>http://live02.rfi.fr/rfimonde-64.mp3</location>
        <title>RFI Monde</title>
        <album>French international radio</album>
        <creator>French Radio</creator>
        <annotation>French listening</annotation>
        <trackNum>1</trackNum>
    </track>
  </trackList>
</playlist>
```

Before change local tags are gone when playback starts:
<pre>
OK MPD 0.24.0
playlistinfo 0:1
file: http://live02.rfi.fr/rfimonde-64.mp3
Title: RFI Monde
Album: French international radio
Artist: French Radio
Comment: French listening
Track: 1
Pos: 0
Id: 2
OK
play
OK
playlistinfo 0:1
file: http://live02.rfi.fr/rfimonde-64.mp3
Name: RFI monde 64
Pos: 0
Id: 2
OK
</pre>

After change local tags are preserved when playback starts:
<pre>
OK MPD 0.24.0
playlistinfo 0:1
file: http://live02.rfi.fr/rfimonde-64.mp3
Title: RFI Monde
Album: French international radio
Artist: French Radio
Comment: French listening
Track: 1
Pos: 0
Id: 2
OK
play
OK
playlistinfo 0:1
file: http://live02.rfi.fr/rfimonde-64.mp3
Name: RFI monde 64
Title: RFI Monde
Album: French international radio
Artist: French Radio
Comment: French listening
Track: 1
Pos: 0
Id: 2
OK
</pre>