### PR TITLE
curl input plugin - added config options: verbose, low_speed_limit, low_speed_time, tcp_keepalive, tcp_keepidle, tcp_keepintvl

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -244,10 +244,36 @@ will be in effect.
    * - **cacert**
      - Set path to Certificate Authority (CA) bundle `More information <https://curl.se/libcurl/c/CURLOPT_CAINFO.html>`_.
      -
-   * - **connect_timeout**
+   * - **connect_timeout** [#since_0_24]_
      - Set the the connect phase timeout in seconds. "0" is `libcurl`'s default built-in connection timeout - 300 seconds.
        `More information <https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html>`_.
      - 10
+   * - **verbose yes|no** [#since_0_24]_
+     - Set the onoff parameter to 1 to make the library display a lot of verbose information.
+       `More information <https://curl.se/libcurl/c/CURLOPT_VERBOSE.html>`_.
+     - no
+   * - **low_speed_limit** [#since_0_24]_
+     - The average transfer speed in bytes per second that the transfer should be below during **low_speed_time** seconds for libcurl to consider it to be too slow and abort.
+       `More information <https://curl.se/libcurl/c/CURLOPT_LOW_SPEED_LIMIT.html>`_.
+     - 0 (disabled)
+   * - **low_speed_time** [#since_0_24]_
+     - The time in number seconds that the transfer speed should be below the **low_speed_limit** for the libcurl to consider it too slow and abort.
+       `More information <https://curl.se/libcurl/c/CURLOPT_LOW_SPEED_TIME.html>`_.
+     - 0 (disabled)
+   * - **tcp_keepalive yes|no** [#since_0_24]_
+     - If set to yes, TCP keepalive probes will be sent. The delay and frequency of these probes can be controlled by the **tcp_keepidle** and **tcp_keepintvl** options, provided the operating system supports them.
+       `More information <https://curl.se/libcurl/c/CURLOPT_TCP_KEEPALIVE.html>`_.
+     - no (disabled)
+   * - **tcp_keepidle** [#since_0_24]_
+     - Sets the delay, in seconds, that the operating system will wait while the connection is idle before sending keepalive probes. Not all operating systems support this option.
+       `More information <https://curl.se/libcurl/c/CURLOPT_TCP_KEEPIDLE.html>`_.
+     - 60
+   * - **tcp_keepintvl** [#since_0_24]_
+     - Sets the interval, in seconds, that the operating system will wait between sending keepalive probes. Not all operating systems support this option.
+       `More information <https://curl.se/libcurl/c/CURLOPT_TCP_KEEPINTVL.html>`_.
+     - 60
+
+Note: the ``low_speed`` and ``tcp_keep`` options may help solve network interruptions and connections dropped by server. Please refer to this curl issue for discussion: https://github.com/curl/curl/issues/8345
 
 ffmpeg
 ------
@@ -1405,3 +1431,7 @@ Allows to load music files from ZIP archives using `zziplib <http://zziplib.sour
 iso
 ---
 Allows to load music files from ISO 9660 images using `libcdio <https://www.gnu.org/software/libcdio/>`_.
+
+.. rubric:: Footnotes
+
+.. [#since_0_24] Since :program:`MPD` 0.24

--- a/src/input/plugins/CurlInputPlugin.cxx
+++ b/src/input/plugins/CurlInputPlugin.cxx
@@ -154,6 +154,48 @@ static bool verify_peer, verify_host;
 /** Connection settings */
 static long connect_timeout;
 
+/**
+ * CURLOPT_VERBOSE - verbose mode
+ * DEFAULT 0, meaning disabled.
+ */
+static bool verbose = false;
+
+/**
+ * CURLOPT_LOW_SPEED_LIMIT - low speed limit in bytes per second
+ * DEFAULT 0, disabled
+ */
+static const unsigned default_low_speed_limit = 0;
+static long low_speed_limit = default_low_speed_limit;
+
+/**
+ * CURLOPT_LOW_SPEED_TIME - low speed limit time period in seconds
+ * DEFAULT 0, disabled
+ */
+static const unsigned default_low_speed_time = 0;
+static long low_speed_time = default_low_speed_time;
+
+/**
+ * CURLOPT_TCP_KEEPALIVE - TCP keep-alive probing
+ * DEFAULT false, disabled
+ */
+static const bool default_tcp_keepalive = false;
+static bool tcp_keepalive = default_tcp_keepalive;
+
+/**
+ * CURLOPT_TCP_KEEPIDLE - TCP keep-alive idle time wait in seconds
+ * DEFAULT 60 seconds
+ */
+static const unsigned default_tcp_keepidle = 60;
+static long tcp_keepidle = default_tcp_keepidle;
+
+/**
+ * CURLOPT_TCP_KEEPINTVL - TCP keep-alive interval in seconds
+ * DEFAULT 60 seconds
+ */
+static const unsigned default_tcp_keepintvl = 60;
+static long tcp_keepintvl = default_tcp_keepintvl;
+
+
 static CurlInit *curl_init;
 
 static constexpr Domain curl_domain("curl");
@@ -382,6 +424,18 @@ input_curl_init(EventLoop &event_loop, const ConfigBlock &block)
 	unsigned timeout = block.GetBlockValue("connect_timeout",
 					       default_connection_timeout);
 	connect_timeout = static_cast<long>(timeout);
+
+	verbose = block.GetBlockValue("verbose",verbose);
+
+	low_speed_limit = block.GetBlockValue("low_speed_limit", default_low_speed_limit);
+
+	low_speed_time = block.GetBlockValue("low_speed_time", default_low_speed_time);
+
+	tcp_keepalive = block.GetBlockValue("tcp_keepalive",default_tcp_keepalive);
+
+	tcp_keepidle  = block.GetBlockValue("tcp_keepidle",default_tcp_keepidle);
+
+	tcp_keepintvl = block.GetBlockValue("tcp_keepintvl",default_tcp_keepintvl);
 }
 
 static void
@@ -448,6 +502,15 @@ CurlInputStream::InitEasy()
 	request->SetProxyVerifyPeer(verify_peer);
 	request->SetProxyVerifyHost(verify_host);
 	request->SetConnectTimeout(connect_timeout);
+
+	request->SetOption(CURLOPT_VERBOSE, verbose ? 1 : 0);
+
+	request->SetOption(CURLOPT_LOW_SPEED_LIMIT, low_speed_limit);
+	request->SetOption(CURLOPT_LOW_SPEED_TIME, low_speed_time);
+
+	request->SetOption(CURLOPT_TCP_KEEPALIVE, tcp_keepalive ? 1 : 0);
+	request->SetOption(CURLOPT_TCP_KEEPIDLE, tcp_keepidle);
+	request->SetOption(CURLOPT_TCP_KEEPINTVL, tcp_keepintvl);
 }
 
 void


### PR DESCRIPTION
Use of these options can help diagnose network streaming issues or work around network interruptions and server dropped connections.