### PR TITLE
queue/PlayListState: Setting consume or single to "oneshot" causes exception on server restart

### DIFF
--- a/src/queue/PlaylistState.cxx
+++ b/src/queue/PlaylistState.cxx
@@ -92,9 +92,9 @@ playlist_state_save(BufferedOutputStream &os, const struct playlist &playlist,
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_REPEAT "{}\n"),
 	       (unsigned)playlist.queue.repeat);
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_SINGLE "{}\n"),
-		   (unsigned)playlist.queue.single);
+		   SingleToString(playlist.queue.single));
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_CONSUME "{}\n"),
-	       (unsigned)playlist.queue.consume);
+	       ConsumeToString(playlist.queue.consume));
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_CROSSFADE "{}\n"),
 	       pc.GetCrossFade().count());
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_MIXRAMPDB "{}\n"),


### PR DESCRIPTION
e.g
server_socket: bind to '0.0.0.0:6601' failed (continuing anyway, because binding to '[::]:6601' succeeded): Failed to bind socket: Address already in use
output: No 'audio_output' defined in config file
output: Successfully detected a osx audio device
exception: Unrecognized single mode, expected 0, 1, or oneshot

It seems the the state restore code is not using the SingleToString and ConsumeToString functions.