### PR TITLE
Stickers on some tag types and playlists

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1385,6 +1385,41 @@ Objects which may have stickers are addressed by their object
 type ("song" for song objects) and their URI (the path within
 the database for songs).
 
+.. note:: Since :program:`MPD` 0.24 stickers can also be attached to playlists,
+  some tag types, and :ref:`filter expressions <filter_syntax>`.
+  The following tag types are alloed: Title, Album, Artist, AlbumArtist, Genre,
+  Composer, Performer, Conductor, Work, Ensable, Location, and Label.
+
+.. list-table:: Sticker addressing
+   :widths: 10 45 45
+   :header-rows: 2
+
+   * - Type
+     - URI
+     - URI
+
+   * -
+     - get, set, delete, list, find
+     - find only
+
+   * - "song"
+     - File path within the database
+     - Directory path within the database to find a sticker on
+       all songs under this path recursively
+
+   * - "playlist"
+     - The playlist name of a stored playlist
+     - An empty string to find a sticker in all playlists
+
+   * - Tag type e.g. "Album"
+     - The tag value
+     - An empty string to find a sticker in all instances of the tag type
+
+   * - "filter"
+     - A :ref:`filter expression <filter_syntax>`.
+
+     - An empty string to find a sticker in all instances of the filter
+
 .. _command_sticker_get:
 
 :command:`sticker get {TYPE} {URI} {NAME}`
@@ -1424,6 +1459,43 @@ the database for songs).
 
     Other supported operators are:
     "``<``", "``>``"
+
+Examples:
+
+   .. code-block::
+
+     sitcker set song "path/to/song_1.mp3" "name_1" "value_1"
+     OK
+     sitcker set song "path/to/song_2.mp3" "name_1" "value_2"
+     OK
+     sticker get song "path/to/song_1.mp3" "name_1"
+     sticker: name_1=value_1
+     OK
+     sitcker find song "path" "name_1"
+     file: path/to/song_1.mp3
+     sticker: name_1=value_1
+     file: path/to/song_2.mp3
+     sticker: name_1=value_2
+     OK
+
+   .. code-block::
+
+    sticker set Album "Greatest Hits" "name_1" "value_1"
+    OK
+    sticker find Album "" name_1
+    Album: Greatest Hits
+    sticker: name_1=value_1
+    OK
+    stciker set filter "((album == 'Greatest Hits') AND (artist == 'Vera Lynn'))" name_1 value_1
+    OK
+    stciker set filter "((album == 'Greatest Hits') AND (artist == 'Johnny Chester'))" name_1 value_1
+    OK
+    sticker find filter "" name_1
+    filter: ((album == 'Greatest Hits') AND (artist == 'Johnny Chester'))
+    sticker: name_1=value_1
+    filter: ((album == 'Greatest Hits') AND (artist == 'Vera Lynn'))
+    sticker: name_1=value_1
+    OK
 
 Connection settings
 ===================

--- a/meson.build
+++ b/meson.build
@@ -462,6 +462,9 @@ if sqlite_dep.found()
     'src/sticker/Database.cxx',
     'src/sticker/Print.cxx',
     'src/sticker/SongSticker.cxx',
+    'src/sticker/TagSticker.cxx',
+    'src/sticker/AllowedTags.c',
+    'src/sticker/StickerCleanupService.cxx',
   ]
 endif
 

--- a/src/Instance.hxx
+++ b/src/Instance.hxx
@@ -41,6 +41,7 @@ class NeighborGlue;
 #ifdef ENABLE_DATABASE
 #include "db/DatabaseListener.hxx"
 #include "db/Ptr.hxx"
+
 class Storage;
 class UpdateService;
 #ifdef ENABLE_INOTIFY
@@ -56,6 +57,7 @@ struct Partition;
 class StateFile;
 class RemoteTagCache;
 class StickerDatabase;
+class StickerCleanupService;
 class InputCacheManager;
 
 /**
@@ -141,6 +143,8 @@ struct Instance final
 
 #ifdef ENABLE_SQLITE
 	std::unique_ptr<StickerDatabase> sticker_database;
+
+	std::unique_ptr<StickerCleanupService> sticker_cleanup;
 #endif
 
 	Instance();
@@ -203,6 +207,8 @@ struct Instance final
 	bool HasStickerDatabase() const noexcept {
 		return sticker_database != nullptr;
 	}
+
+	void OnSickerCleanupDone(StickerCleanupService *service, bool changed) noexcept;
 #endif
 
 	void BeginShutdownUpdate() noexcept;
@@ -216,6 +222,8 @@ struct Instance final
 #endif
 
 	void FlushCaches() noexcept;
+
+	void OnPlaylistDeleted(const char *name) const noexcept;
 
 private:
 #ifdef ENABLE_DATABASE

--- a/src/command/PlaylistCommands.cxx
+++ b/src/command/PlaylistCommands.cxx
@@ -171,6 +171,9 @@ handle_rm([[maybe_unused]] Client &client, Request args, [[maybe_unused]] Respon
 	const char *const name = args.front();
 
 	spl_delete(name);
+
+	client.GetInstance().OnPlaylistDeleted(name);
+
 	return CommandResult::OK;
 }
 

--- a/src/command/StickerCommands.cxx
+++ b/src/command/StickerCommands.cxx
@@ -22,7 +22,10 @@
 #include "SongPrint.hxx"
 #include "db/Interface.hxx"
 #include "sticker/Sticker.hxx"
+#include "sticker/TagSticker.hxx"
+#include "sticker/Database.hxx"
 #include "sticker/SongSticker.hxx"
+#include "sticker/AllowedTags.h"
 #include "sticker/Print.hxx"
 #include "client/Client.hxx"
 #include "client/Response.hxx"
@@ -30,133 +33,284 @@
 #include "Instance.hxx"
 #include "util/StringAPI.hxx"
 #include "util/ScopeExit.hxx"
+#include "tag/ParseName.hxx"
+#include "sticker/TagSticker.hxx"
+#include "song/LightSong.hxx"
+#include "PlaylistFile.hxx"
+#include "db/PlaylistInfo.hxx"
+#include "db/PlaylistVector.hxx"
+#include "db/DatabaseLock.hxx"
+#include "song/Filter.hxx"
 
 namespace {
-struct sticker_song_find_data {
-	Response &r;
-	const char *name;
-};
-} // namespace
 
-static void
-sticker_song_find_print_cb(const LightSong &song, const char *value,
-			   void *user_data)
-{
-	auto *data =
-		(struct sticker_song_find_data *)user_data;
+class DomainHandler {
+public:
+	virtual ~DomainHandler() = default;
 
-	song_print_uri(data->r, song);
-	sticker_print_value(data->r, data->name, value);
-}
-
-static CommandResult
-handle_sticker_song(Response &r, Partition &partition,
-		    StickerDatabase &sticker_database,
-		    Request args)
-{
-	const Database &db = partition.GetDatabaseOrThrow();
-
-	const char *const cmd = args.front();
-
-	/* get song song_id key */
-	if (args.size() == 4 && StringIsEqual(cmd, "get")) {
-		const LightSong *song = db.GetSong(args[2]);
-		assert(song != nullptr);
-		AtScopeExit(&db, song) { db.ReturnSong(song); };
-
-		const auto value = sticker_song_get_value(sticker_database,
-							  *song, args[3]);
+	virtual CommandResult Get(const char *uri, const char *name) {
+		const auto value = sticker_database.LoadValue(sticker_type,
+							      ValidateUri(uri).c_str(),
+							      name);
 		if (value.empty()) {
-			r.Error(ACK_ERROR_NO_EXIST, "no such sticker");
+			response.FmtError(ACK_ERROR_NO_EXIST, "no such sticker: \"{}\"", name);
 			return CommandResult::ERROR;
 		}
 
-		sticker_print_value(r, args[3], value.c_str());
+		sticker_print_value(response, name, value.c_str());
 
 		return CommandResult::OK;
-	/* list song song_id */
-	} else if (args.size() == 3 && StringIsEqual(cmd, "list")) {
-		const LightSong *song = db.GetSong(args[2]);
-		assert(song != nullptr);
-		AtScopeExit(&db, song) { db.ReturnSong(song); };
+	}
 
-		const auto sticker = sticker_song_get(sticker_database, *song);
-		sticker_print(r, sticker);
+	virtual CommandResult Set(const char *uri, const char *name, const char *value) {
+		sticker_database.StoreValue(sticker_type,
+					    ValidateUri(uri).c_str(),
+					    name,
+					    value);
 
 		return CommandResult::OK;
-	/* set song song_id id key */
-	} else if (args.size() == 5 && StringIsEqual(cmd, "set")) {
-		const LightSong *song = db.GetSong(args[2]);
-		assert(song != nullptr);
-		AtScopeExit(&db, song) { db.ReturnSong(song); };
+	}
 
-		sticker_song_set_value(sticker_database, *song,
-				       args[3], args[4]);
-		return CommandResult::OK;
-	/* delete song song_id [key] */
-	} else if ((args.size() == 3 || args.size() == 4) &&
-		   StringIsEqual(cmd, "delete")) {
-		const LightSong *song = db.GetSong(args[2]);
-		assert(song != nullptr);
-		AtScopeExit(&db, song) { db.ReturnSong(song); };
-
-		bool ret = args.size() == 3
-			? sticker_song_delete(sticker_database, *song)
-			: sticker_song_delete_value(sticker_database, *song,
-						    args[3]);
+	virtual CommandResult Delete(const char *uri, const char *name) {
+		std::string validated_uri = ValidateUri(uri);
+		uri = validated_uri.c_str();
+		bool ret = name == nullptr
+			   ? sticker_database.Delete(sticker_type, uri)
+			   : sticker_database.DeleteValue(sticker_type, uri, name);
 		if (!ret) {
-			r.Error(ACK_ERROR_NO_EXIST, "no such sticker");
+			response.FmtError(ACK_ERROR_NO_EXIST, "no such sticker: \"{}\"", name);
 			return CommandResult::ERROR;
 		}
 
 		return CommandResult::OK;
-	/* find song dir key */
-	} else if ((args.size() == 4 || args.size() == 6) &&
-		   StringIsEqual(cmd, "find")) {
-		/* "sticker find song a/directory name" */
+	}
 
-		const char *const base_uri = args[2];
+	virtual CommandResult List(const char *uri) {
+		const auto sticker = sticker_database.Load(sticker_type,
+							   ValidateUri(uri).c_str());
+		sticker_print(response, sticker);
 
-		StickerOperator op = StickerOperator::EXISTS;
-		const char *value = nullptr;
+		return CommandResult::OK;
+	}
 
-		if (args.size() == 6) {
-			/* match the value */
-
-			const char *op_s = args[4];
-			value = args[5];
-
-			if (StringIsEqual(op_s, "="))
-				op = StickerOperator::EQUALS;
-			else if (StringIsEqual(op_s, "<"))
-				op = StickerOperator::LESS_THAN;
-			else if (StringIsEqual(op_s, ">"))
-				op = StickerOperator::GREATER_THAN;
-			else {
-				r.Error(ACK_ERROR_ARG, "bad operator");
-				return CommandResult::ERROR;
-			}
-		}
-
-		struct sticker_song_find_data data = {
-			r,
-			args[3],
+	virtual CommandResult Find(const char *uri, const char *name, StickerOperator op, const char *value) {
+		auto data = CallbackContext{
+			.name = name,
+			.sticker_type = sticker_type,
+			.response = response,
+			.is_song = StringIsEqual("song", sticker_type)
 		};
 
-		sticker_song_find(sticker_database, db, base_uri, data.name,
+		auto callback = [](const char *found_uri, const char *found_value, void *user_data) {
+			auto context = reinterpret_cast<CallbackContext *>(user_data);
+			context->response.Fmt("{}: {}\n",
+ 					      context->is_song ? "file" : context->sticker_type, found_uri);
+			sticker_print_value(context->response, context->name, found_value);
+		};
+
+		sticker_database.Find(sticker_type,
+				      uri,
+				      name,
+				      op, value,
+				      callback, &data);
+
+		return CommandResult::OK;
+	}
+
+protected:
+	DomainHandler(Response &_response,
+		      const Database &_database,
+		      StickerDatabase &_sticker_database,
+		      const char *_sticker_type) :
+		sticker_type(_sticker_type),
+		response(_response),
+		database(_database),
+		sticker_database(_sticker_database) {
+	}
+
+	/**
+	 * Validate the command uri or throw std::runtime_error if not valid.
+	 *
+	 * @param uri the uri from the sticker command
+	 *
+	 * @return the uri to use in the sticker database query
+	 */
+	virtual std::string ValidateUri(const char *uri) {
+		return {uri};
+	}
+
+	const char *const sticker_type;
+	Response &response;
+	const Database &database;
+	StickerDatabase &sticker_database;
+
+private:
+	struct CallbackContext {
+		const char *const name;
+		const char *const sticker_type;
+		Response &response;
+		const bool is_song;
+	};
+};
+
+/**
+ * 'song' stickers handler
+ */
+class SongHandler final : public DomainHandler {
+public:
+	SongHandler(Response &_response,
+		    const Database &_database,
+		    StickerDatabase &_sticker_database) :
+		DomainHandler(_response, _database, _sticker_database, "song") {
+	}
+
+	~SongHandler() override {
+		if (song != nullptr)
+			database.ReturnSong(song);
+	}
+
+	CommandResult Find(const char *uri, const char *name, StickerOperator op, const char *value) override {
+		struct sticker_song_find_data data = {
+			response,
+			name,
+		};
+
+		sticker_song_find(sticker_database, database, uri, data.name,
 				  op, value,
 				  sticker_song_find_print_cb, &data);
 
 		return CommandResult::OK;
-	} else {
-		r.Error(ACK_ERROR_ARG, "bad request");
-		return CommandResult::ERROR;
 	}
-}
+
+protected:
+	std::string ValidateUri(const char *uri) override {
+		// will throw if song uri not found
+		song = database.GetSong(uri);
+		assert(song != nullptr);
+		return song->GetURI();
+	}
+
+private:
+	struct sticker_song_find_data {
+		Response &r;
+		const char *name;
+	};
+
+	static void
+	sticker_song_find_print_cb(const LightSong &song, const char *value,
+				   void *user_data)
+	{
+		auto *data = (struct sticker_song_find_data *)user_data;
+
+		song_print_uri(data->r, song);
+		sticker_print_value(data->r, data->name, value);
+	}
+
+	const LightSong* song = nullptr;
+};
+
+/**
+ * Base for Tag and Filter handlers
+ */
+class SelectionHandler : public DomainHandler {
+protected:
+	SelectionHandler(Response &_response,
+		   const Database &_database,
+		   StickerDatabase &_sticker_database,
+		   const char* _sticker_type) :
+		DomainHandler(_response, _database, _sticker_database, _sticker_type) {
+	}
+};
+
+/**
+ * Tag type stickers handler
+ */
+class TagHandler : public SelectionHandler {
+public:
+	TagHandler(Response &_response,
+		   const Database &_database,
+		   StickerDatabase &_sticker_database,
+		   TagType _tag_type) :
+		SelectionHandler(_response, _database, _sticker_database, tag_item_names[_tag_type]),
+		tag_type(_tag_type) {
+
+		assert(tag_type != TAG_NUM_OF_ITEM_TYPES);
+	}
+
+protected:
+	std::string ValidateUri(const char *uri) override {
+		if (tag_type == TAG_NUM_OF_ITEM_TYPES)
+			throw std::invalid_argument(fmt::format("no such tag: \"{}\"", sticker_type));
+
+		if (!sticker_allowed_tags[tag_type])
+			throw std::invalid_argument(fmt::format("unsupported tag: \"{}\"", sticker_type));
+
+		if (!TagExists(database, tag_type, uri))
+			throw std::invalid_argument(fmt::format("no such {}: \"{}\"", sticker_type, uri));
+
+		return {uri};
+	}
+
+private:
+	const TagType tag_type;
+};
+
+/**
+ * Filter stickers handler
+ *
+ * The URI is parsed as a SongFilter
+ */
+class FilterHandler : public SelectionHandler {
+public:
+	FilterHandler(Response &_response,
+		   const Database &_database,
+		   StickerDatabase &_sticker_database) :
+		SelectionHandler(_response, _database, _sticker_database, "filter") {
+	}
+
+protected:
+	std::string ValidateUri(const char *uri) override {
+
+		auto filter = MakeSongFilter(uri);
+
+		auto normalized = filter.ToExpression();
+
+		if (!FilterMatches(database, filter))
+			throw std::invalid_argument(fmt::format("no matches found: \"{}\"", normalized));
+
+		return normalized;
+	}
+};
+
+/**
+ * playlist stickers handler
+ */
+class PlaylistHandler : public DomainHandler {
+public:
+	PlaylistHandler(Response &_response,
+			const Database &_database,
+			StickerDatabase &_sticker_database) :
+		DomainHandler(_response, _database, _sticker_database, "playlist") {
+	}
+
+private:
+	std::string ValidateUri(const char *uri) override {
+		PlaylistVector playlists = ListPlaylistFiles();
+
+		const ScopeDatabaseLock protect;
+		if (!playlists.exists(uri))
+			throw std::invalid_argument(fmt::format("no such playlist: \"{}\"", uri));
+
+		return {uri};
+	}
+};
+
+} // namespace
 
 CommandResult
 handle_sticker(Client &client, Request args, Response &r)
 {
+	// must be enforced by the caller
 	assert(args.size() >= 3);
 
 	auto &instance = client.GetInstance();
@@ -165,14 +319,73 @@ handle_sticker(Client &client, Request args, Response &r)
 		return CommandResult::ERROR;
 	}
 
+	auto &db = client.GetPartition().GetDatabaseOrThrow();
 	auto &sticker_database = *instance.sticker_database;
 
-	if (StringIsEqual(args[1], "song"))
-		return handle_sticker_song(r, client.GetPartition(),
-					   sticker_database,
-					   args);
+	auto cmd = args.front();
+	auto sticker_type = args[1];
+	auto uri = args[2];
+	auto sticker_name = args.GetOptional(3);
+
+	std::unique_ptr<DomainHandler> handler;
+
+	if (StringIsEqual(sticker_type, "song"))
+		handler = std::make_unique<SongHandler>(r, db, sticker_database);
+
+	else if (StringIsEqual(sticker_type, "playlist"))
+		handler = std::make_unique<PlaylistHandler>(r, db, sticker_database);
+
+	else if (StringIsEqual(sticker_type, "filter"))
+		handler = std::make_unique<FilterHandler>(r, db, sticker_database);
+
+		// allow tags in the command to be case insensitive
+	// the handler will normalize the tag name with tag_item_names()
+	else if (auto tag_type = tag_name_parse_i(sticker_type); tag_type != TAG_NUM_OF_ITEM_TYPES)
+		handler = std::make_unique<TagHandler>(r, db, sticker_database, tag_type);
+
 	else {
-		r.Error(ACK_ERROR_ARG, "unknown sticker domain");
+		r.FmtError(ACK_ERROR_ARG, "unknown sticker domain \"{}\"", sticker_type);
 		return CommandResult::ERROR;
 	}
+
+	/* get */
+	if (args.size() == 4 && StringIsEqual(cmd, "get"))
+		return handler->Get(uri, sticker_name);
+
+	/* list */
+	if (args.size() == 3 && StringIsEqual(cmd, "list"))
+		return handler->List(uri);
+
+	/* set */
+	if (args.size() == 5 && StringIsEqual(cmd, "set"))
+		return handler->Set(uri, sticker_name, args[4]);
+
+	/* delete */
+	if ((args.size() == 3 || args.size() == 4) && StringIsEqual(cmd, "delete"))
+		return handler->Delete(uri, sticker_name);
+
+	/* find */
+	if ((args.size() == 4 || args.size() == 6) && StringIsEqual(cmd, "find")) {
+		bool has_op = args.size() > 4;
+		auto value = has_op ? args[5] : nullptr;
+		StickerOperator op = StickerOperator::EXISTS;
+		if (has_op) {
+			/* match the value */
+			auto op_s = args[4];
+			if (StringIsEqual(op_s, "="))
+				op = StickerOperator::EQUALS;
+			else if (StringIsEqual(op_s, "<"))
+				op = StickerOperator::LESS_THAN;
+			else if (StringIsEqual(op_s, ">"))
+				op = StickerOperator::GREATER_THAN;
+			else {
+				r.FmtError(ACK_ERROR_ARG, "bad operator \"{}\"", op_s);
+				return CommandResult::ERROR;
+			}
+		}
+		return handler->Find(uri, sticker_name, op, value);
+	}
+
+	r.Error(ACK_ERROR_ARG, "bad request");
+	return CommandResult::ERROR;
 }

--- a/src/db/PlaylistVector.cxx
+++ b/src/db/PlaylistVector.cxx
@@ -61,3 +61,12 @@ PlaylistVector::erase(std::string_view name) noexcept
 	erase(i);
 	return true;
 }
+
+bool
+PlaylistVector::exists(std::string_view name) const noexcept
+{
+	assert(holding_db_lock());
+
+	return std::find_if(begin(), end(),
+			    PlaylistInfo::CompareName(name)) != end();
+}

--- a/src/db/PlaylistVector.hxx
+++ b/src/db/PlaylistVector.hxx
@@ -51,6 +51,9 @@ public:
 	 * Caller must lock the #db_mutex.
 	 */
 	bool erase(std::string_view name) noexcept;
+
+	[[nodiscard]]
+	bool exists(std::string_view name) const noexcept;
 };
 
 #endif /* SONGVEC_H */

--- a/src/lib/sqlite/Util.hxx
+++ b/src/lib/sqlite/Util.hxx
@@ -173,6 +173,14 @@ ExecuteForEach(sqlite3_stmt *stmt, F &&f)
 	}
 }
 
+inline std::string
+ColumnToString(sqlite3_stmt *stmt, int column)
+{
+	auto text = (const char *) sqlite3_column_text(stmt, column);
+	auto bytes = static_cast<std::string::size_type>(sqlite3_column_bytes(stmt, column));
+	return {text, bytes};
+}
+
 } // namespace Sqlite
 
 #endif

--- a/src/sticker/AllowedTags.c
+++ b/src/sticker/AllowedTags.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2003-2022 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#include "AllowedTags.h"
+#include "tag/Type.h"
+
+const bool sticker_allowed_tags[TAG_NUM_OF_ITEM_TYPES] = {
+	[TAG_ARTIST] = true,
+	[TAG_ARTIST_SORT] = false,
+	[TAG_ALBUM] = true,
+	[TAG_ALBUM_SORT] = false,
+	[TAG_ALBUM_ARTIST] = true,
+	[TAG_ALBUM_ARTIST_SORT] = false,
+	[TAG_TITLE] = true,
+	[TAG_TITLE_SORT] = false,
+	[TAG_TRACK] = false,
+	[TAG_NAME] = false,
+	[TAG_GENRE] = true,
+	[TAG_MOOD] = false,
+	[TAG_DATE] = false,
+	[TAG_ORIGINAL_DATE] = false,
+	[TAG_COMPOSER] = true,
+	[TAG_COMPOSERSORT] = false,
+	[TAG_PERFORMER] = true,
+	[TAG_CONDUCTOR] = true,
+	[TAG_WORK] = true,
+	[TAG_MOVEMENT] = false,
+	[TAG_MOVEMENTNUMBER] = false,
+	[TAG_ENSEMBLE] = true,
+	[TAG_LOCATION] = true,
+	[TAG_GROUPING] = false,
+	[TAG_COMMENT] = false,
+	[TAG_DISC] = false,
+	[TAG_LABEL] = true,
+
+	/* MusicBrainz tags from http://musicbrainz.org/doc/MusicBrainzTag */
+	[TAG_MUSICBRAINZ_ARTISTID] = true,
+	[TAG_MUSICBRAINZ_ALBUMID] = true,
+	[TAG_MUSICBRAINZ_ALBUMARTISTID] = true,
+	[TAG_MUSICBRAINZ_TRACKID] = false,
+	[TAG_MUSICBRAINZ_RELEASETRACKID] = true,
+	[TAG_MUSICBRAINZ_WORKID] = true,
+};

--- a/src/sticker/AllowedTags.h
+++ b/src/sticker/AllowedTags.h
@@ -17,17 +17,16 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef MPD_STICKER_HXX
-#define MPD_STICKER_HXX
+#ifndef ALLOWEDTAGS_H
+#define ALLOWEDTAGS_H
 
-#include <map>
-#include <string>
-#include "util/Domain.hxx"
+#include <stdbool.h>
 
-static constexpr Domain sticker_domain("sticker");
+/**
+ * These are the tags that are allowed to have stickers.
+ *
+ * The size is TAG_NUM_OF_ITEM_TYPES
+ */
+extern const bool sticker_allowed_tags[];
 
-struct Sticker {
-	std::map<std::string, std::string> table;
-};
-
-#endif
+#endif //ALLOWEDTAGS_H

--- a/src/sticker/Print.cxx
+++ b/src/sticker/Print.cxx
@@ -23,11 +23,33 @@
 
 #include <fmt/format.h>
 
+/**
+ * The sticker name has to be escaped
+ * when printed in pair with its value i.e. name=value
+ * to allow for '=' character in the name
+ * and the client to split the name=value string
+ * on the first un-escaped '=' character.
+ */
+static std::string
+EscapeStickerName(std::string_view name)
+{
+	std::string result;
+	result.reserve(name.size() * 2);
+
+	for (char ch : name) {
+		if (ch == '=' || ch == '\\')
+			result.push_back('\\');
+		result.push_back(ch);
+	}
+
+	return result;
+}
+
 void
 sticker_print_value(Response &r,
 		    const char *name, const char *value)
 {
-	r.Fmt(FMT_STRING("sticker: {}={}\n"), name, value);
+	r.Fmt(FMT_STRING("sticker: {}={}\n"), EscapeStickerName(name), value);
 }
 
 void

--- a/src/sticker/StickerCleanupService.cxx
+++ b/src/sticker/StickerCleanupService.cxx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2003-2022 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "StickerCleanupService.hxx"
+
+#include "Sticker.hxx"
+#include "Database.hxx"
+#include "song/Filter.hxx"
+#include "TagSticker.hxx"
+#include "Log.hxx"
+#include "Instance.hxx"
+#include "thread/Name.hxx"
+
+StickerCleanupService::StickerCleanupService(Instance &_instance,
+					     StickerDatabase &_sticker_db,
+					     Database &_db) noexcept:
+	instance(_instance),
+	sticker_db(_sticker_db),
+	music_db(_db),
+	thread(BIND_THIS_METHOD(Task)),
+	defer(_instance.event_loop, BIND_THIS_METHOD(RunDeferred)) {
+
+}
+
+StickerCleanupService::~StickerCleanupService() noexcept
+{
+	// call only by the owning instance
+	assert(instance.event_loop.IsInside());
+
+	CancelAndJoin();
+}
+
+void
+StickerCleanupService::Start()
+{
+	// call only by the owning instance
+	assert(instance.event_loop.IsInside());
+
+	thread.Start();
+
+	FmtDebug(sticker_domain,
+		 "spawned thread for cleanup job");
+}
+
+void
+StickerCleanupService::RunDeferred() noexcept
+{
+	instance.OnSickerCleanupDone(this, deleted_count != 0);
+}
+
+namespace {
+inline
+std::size_t
+DeleteStickers(StickerDatabase &sticker_db, std::list<StickerDatabase::StickerTypeUriPair> &stickers)
+{
+	if (stickers.empty())
+		return 0;
+	sticker_db.BatchDeleteNoIdle(stickers);
+	auto count = stickers.size();
+	stickers.clear();
+	return count;
+}
+
+}//namespace
+
+void
+StickerCleanupService::Task() noexcept
+{
+	SetThreadName("sticker");
+
+	FmtDebug(sticker_domain, "begin cleanup");
+
+	try {
+		auto stickers = sticker_db.GetUniqueStickers();
+		auto iter = stickers.cbegin();
+		auto batch = std::list<StickerDatabase::StickerTypeUriPair>();
+		while (!cancel_flag && !stickers.empty()) {
+
+			const auto &sticker_type = iter->first;
+			const auto &sticker_uri = iter->second;
+
+			const auto filter = MakeSongFilterNoThrow(sticker_type, sticker_uri);
+
+			if (filter.IsEmpty() || FilterMatches(music_db, filter))
+				// skip if found a match or if not a valid sticker filter
+				iter = stickers.erase(iter);
+			else {
+				batch.splice(batch.end(), stickers, iter++);
+				if (batch.size() == DeleteBatchSize)
+					deleted_count += DeleteStickers(sticker_db, batch);
+			}
+		}
+		if (!cancel_flag)
+			deleted_count += DeleteStickers(sticker_db, batch);
+	}
+	catch (std::runtime_error &e) {
+		FmtError(sticker_domain, "cleanup failed: {}", e.what());
+	}
+
+	defer.Schedule();
+
+	FmtDebug(sticker_domain, "end cleanup: {} stickers deleted", deleted_count);
+}
+
+void
+StickerCleanupService::CancelAndJoin() noexcept
+{
+	if (thread.IsDefined()) {
+		cancel_flag = true;
+		thread.Join();
+	}
+}
+

--- a/src/sticker/StickerCleanupService.hxx
+++ b/src/sticker/StickerCleanupService.hxx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2003-2022 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef CLEAUPTHREAD_HXX
+#define CLEAUPTHREAD_HXX
+
+#include "event/InjectEvent.hxx"
+#include "thread/Thread.hxx"
+
+#include <atomic>
+
+class Database;
+class StickerDatabase;
+struct Instance;
+
+/**
+ * Delete stickers that no longer match items in the music database.
+ * <br/>
+ * When done calls Instance::OnSickerCleanupDone() in the instance event loop.
+ */
+class StickerCleanupService {
+public:
+	StickerCleanupService(Instance &_instance,
+			      StickerDatabase &_sticker_db,
+			      Database &_db) noexcept;
+
+	~StickerCleanupService() noexcept;
+
+	void Start();
+
+private:
+	void Task() noexcept;
+
+	void RunDeferred() noexcept;
+
+	void CancelAndJoin() noexcept;
+
+	/**
+	 * number of stickers to delete in one transaction
+	 */
+	static constexpr std::size_t DeleteBatchSize = 50;
+
+	Instance &instance;
+	StickerDatabase &sticker_db;
+	Database &music_db;
+	Thread thread;
+	InjectEvent defer;
+	std::size_t deleted_count{0};
+	std::atomic<bool> cancel_flag{false};
+};
+
+
+#endif // CLEAUPTHREAD_HXX

--- a/src/sticker/TagSticker.cxx
+++ b/src/sticker/TagSticker.cxx
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2003-2022 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "TagSticker.hxx"
+
+#include "tag/Type.h"
+#include "db/Interface.hxx"
+#include "db/Selection.hxx"
+#include "tag/Tag.hxx"
+#include "tag/ParseName.hxx"
+#include "song/LightSong.hxx"
+#include "song/Filter.hxx"
+#include "sticker/Database.hxx"
+#include "filter/Filter.hxx"
+#include "AllowedTags.h"
+
+namespace {
+class MatchFoundException: public std::exception {};
+}
+
+SongFilter
+MakeSongFilter(const char *filter_string)
+{
+	auto vars = std::array<const char *, 1>{filter_string};
+	auto args = std::span{vars};
+
+	auto filter = SongFilter();
+
+	filter.Parse(args, false);
+
+	filter.Optimize();
+
+	return filter;
+}
+
+SongFilter
+MakeSongFilter(TagType tag_type, const char *tag_value)
+{
+	if (!sticker_allowed_tags[tag_type])
+		throw std::runtime_error("tag type not allowed for sticker");
+
+	auto vars = std::array<const char *, 2>{tag_item_names[tag_type], tag_value};
+	auto args = std::span{vars};
+
+	auto filter = SongFilter();
+
+	filter.Parse(args, false);
+
+	filter.Optimize();
+
+	return filter;
+}
+
+SongFilter
+MakeSongFilter(const std::string &sticker_type, const std::string &sticker_uri)
+{
+	if (sticker_type == "filter")
+		return MakeSongFilter(sticker_uri.c_str());
+
+	if (auto tag_type = tag_name_parse_i(sticker_type); tag_type != TAG_NUM_OF_ITEM_TYPES)
+		return MakeSongFilter(tag_type, sticker_uri.c_str());
+
+	return {};
+}
+
+SongFilter
+MakeSongFilterNoThrow(const std::string &sticker_type, const std::string &sticker_uri) noexcept
+{
+	try {
+		return MakeSongFilter(sticker_type, sticker_uri);
+	}
+	catch (std::exception& e) {
+		// ignore
+	}
+	return {};
+}
+
+bool
+TagExists(const Database &database, TagType tag_type, const char* tag_value)
+{
+	return FilterMatches(database, MakeSongFilter(tag_type, tag_value));
+}
+
+bool
+FilterMatches(const Database &database, const SongFilter& filter) noexcept
+{
+	if (filter.IsEmpty())
+		return false;
+
+	const auto selection = DatabaseSelection{"", true, &filter};
+
+	// TODO: we just need to know if the tag selection has a match.
+	//       a visitor callback that can stop the db visit by return value
+	//       may be cleaner than throwing an exception.
+	try {
+		database.Visit(selection, [](const LightSong &) {
+			throw MatchFoundException{};
+		});
+	}
+	catch (MatchFoundException& found) {
+		return true;
+	}
+
+	return false;
+}

--- a/src/sticker/TagSticker.hxx
+++ b/src/sticker/TagSticker.hxx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2003-2022 The Music Player Daemon Project
+ * http://www.musicpd.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef TAG_STICKER_HXX
+#define TAG_STICKER_HXX
+
+#include <string>
+
+enum TagType : uint8_t;
+class Database;
+class StickerDatabase;
+class SongFilter;
+
+/**
+ * Parse a filter_string.
+ *
+ * @param filter_string a valid filter expression
+ *
+ * @return SongFilter
+ *
+ * @throws std::runtime_error if failed to parse filter string
+ */
+SongFilter
+MakeSongFilter(const char *filter_string);
+
+/**
+ * Make a song filter from tag and value e.g. album name
+ *
+ * @return SongFilter
+ *
+ * @throws std::runtime_error if failed to make song filter or tag type not allowd for sticker
+ */
+SongFilter
+MakeSongFilter(TagType tag_type, const char *tag_value);
+
+/**
+ * Make a song filter by sticker type and uri
+ *
+ * @param sticker_type	either one of the allowed tag names or "filter"
+ * @param sticker_uri	if the type is a tag name then this is the value,
+ * 			if the type if "filter" then this is a filter expression
+ *
+ * @return SongFilter
+ *
+ * @throws std::runtime_error if failed to make song filter or tag type not allowd for sticker
+ */
+SongFilter
+MakeSongFilter(const std::string &sticker_type, const std::string &sticker_uri);
+
+/**
+ * Like MakeSongFilter(const std::string &sticker_type, const std::string &sticker_uri)
+ * but return an empty filter instead of throwing
+ *
+ * @param sticker_type
+ * @param sticker_uri
+ *
+ * @return SongFilter
+ */
+SongFilter
+MakeSongFilterNoThrow(const std::string &sticker_type, const std::string &sticker_uri) noexcept;
+
+/**
+ * Try to make a selection on the database using the tag type and value
+ * from a sticker command.
+ *
+ * @return true if the selection returned at least one match or false otherwise
+ *
+ * @throws std::runtime_error if failed to make song filter
+ */
+bool
+TagExists(const Database& database, TagType tag_type, const char* tag_value);
+
+/**
+ * Try to make a selection on the database using a filter
+ * from a sticker command.
+ *
+ * @return true if the selection returned at least one match or false otherwise
+ */
+bool
+FilterMatches(const Database& database, const SongFilter& filter) noexcept;
+
+
+#endif //TAG_STICKER_HXX

--- a/src/tag/Builder.cxx
+++ b/src/tag/Builder.cxx
@@ -33,10 +33,9 @@
 TagBuilder::TagBuilder(const Tag &other) noexcept
 	:duration(other.duration), has_playlist(other.has_playlist)
 {
-	items.reserve(other.num_items);
-
 	const std::size_t n = other.num_items;
 	if (n > 0) {
+		items.reserve(other.num_items);
 		const std::scoped_lock<Mutex> protect(tag_pool_lock);
 		for (std::size_t i = 0; i != n; ++i)
 			items.push_back(tag_pool_dup_item(other.items[i]));
@@ -176,17 +175,17 @@ TagBuilder::Complement(const Tag &other) noexcept
 
 	has_playlist |= other.has_playlist;
 
-	/* build a table of tag types that were already present in
-	   this object, which will not be copied from #other */
-	std::array<bool, TAG_NUM_OF_ITEM_TYPES> present;
-	present.fill(false);
-	for (const TagItem *i : items)
-		present[i->type] = true;
-
-	items.reserve(items.size() + other.num_items);
-
 	const std::size_t n = other.num_items;
 	if (n > 0) {
+		/* build a table of tag types that were already present in
+		   this object, which will not be copied from #other */
+		std::array<bool, TAG_NUM_OF_ITEM_TYPES> present;
+		present.fill(false);
+		for (const TagItem *i : items)
+			present[i->type] = true;
+
+		items.reserve(items.size() + n);
+
 		const std::scoped_lock<Mutex> protect(tag_pool_lock);
 		for (std::size_t i = 0; i != n; ++i) {
 			TagItem *item = other.items[i];

--- a/src/tag/GenParseName.cxx
+++ b/src/tag/GenParseName.cxx
@@ -42,8 +42,16 @@ main(int argc, char **argv)
 	FILE *out = fopen(argv[1], "w");
 
 	std::map<std::string_view, TagType> names;
-	for (unsigned i = 0; i < unsigned(TAG_NUM_OF_ITEM_TYPES); ++i)
+	for (unsigned i = 0; i < unsigned(TAG_NUM_OF_ITEM_TYPES); ++i) {
+		if (tag_item_names[i] == nullptr) {
+			printf("**\n"
+			       "** Tag name missining at index %d\n"
+			       "** Update tag_item_names when updating enum TagType\n"
+			       "**\n", i);
+			exit(1);
+		}
 		names[tag_item_names[i]] = TagType(i);
+	}
 
 	fprintf(out,
 		"#include \"ParseName.hxx\"\n"

--- a/src/tag/Tag.cxx
+++ b/src/tag/Tag.cxx
@@ -29,15 +29,16 @@ Tag::Clear() noexcept
 	duration = SignedSongTime::Negative();
 	has_playlist = false;
 
-	{
+	if (num_items > 0) {
+		assert(items != nullptr);
 		const std::scoped_lock<Mutex> protect(tag_pool_lock);
 		for (unsigned i = 0; i < num_items; ++i)
 			tag_pool_put_item(items[i]);
+		num_items = 0;
 	}
 
 	delete[] items;
 	items = nullptr;
-	num_items = 0;
 }
 
 Tag::Tag(const Tag &other) noexcept


### PR DESCRIPTION
This PR adds support for stickers on playlists and on selected Tag types.

The URI for tag stickers can be a filter expression to allow clients to specifically target objects when the tag value alone is ambiguous. For example when multiple albums have identical title (see examples in the doc).

Stickers cleanup for playlists is done from ```Instance::OnPlaylistDeleted```.

Cleanup for tag stickers is called from ```Instance::OnDatabaseModified``` but this will have to be changed because the performance when there are many stickers (filter match on the database for each tag sticker).

Related to issues #608 and #114
