### PR TITLE
In Tag and TagBuild: skip unnecessary code when num_items is 0

### DIFF
--- a/src/tag/Builder.cxx
+++ b/src/tag/Builder.cxx
@@ -33,10 +33,9 @@
 TagBuilder::TagBuilder(const Tag &other) noexcept
 	:duration(other.duration), has_playlist(other.has_playlist)
 {
-	items.reserve(other.num_items);
-
 	const std::size_t n = other.num_items;
 	if (n > 0) {
+		items.reserve(other.num_items);
 		const std::scoped_lock<Mutex> protect(tag_pool_lock);
 		for (std::size_t i = 0; i != n; ++i)
 			items.push_back(tag_pool_dup_item(other.items[i]));
@@ -176,17 +175,17 @@ TagBuilder::Complement(const Tag &other) noexcept
 
 	has_playlist |= other.has_playlist;
 
-	/* build a table of tag types that were already present in
-	   this object, which will not be copied from #other */
-	std::array<bool, TAG_NUM_OF_ITEM_TYPES> present;
-	present.fill(false);
-	for (const TagItem *i : items)
-		present[i->type] = true;
-
-	items.reserve(items.size() + other.num_items);
-
 	const std::size_t n = other.num_items;
 	if (n > 0) {
+		/* build a table of tag types that were already present in
+		   this object, which will not be copied from #other */
+		std::array<bool, TAG_NUM_OF_ITEM_TYPES> present;
+		present.fill(false);
+		for (const TagItem *i : items)
+			present[i->type] = true;
+
+		items.reserve(items.size() + n);
+
 		const std::scoped_lock<Mutex> protect(tag_pool_lock);
 		for (std::size_t i = 0; i != n; ++i) {
 			TagItem *item = other.items[i];

--- a/src/tag/Tag.cxx
+++ b/src/tag/Tag.cxx
@@ -29,15 +29,16 @@ Tag::Clear() noexcept
 	duration = SignedSongTime::Negative();
 	has_playlist = false;
 
-	{
+	if (num_items > 0) {
+		assert(items != nullptr);
 		const std::scoped_lock<Mutex> protect(tag_pool_lock);
 		for (unsigned i = 0; i < num_items; ++i)
 			tag_pool_put_item(items[i]);
+		num_items = 0;
 	}
 
 	delete[] items;
 	items = nullptr;
-	num_items = 0;
 }
 
 Tag::Tag(const Tag &other) noexcept


### PR DESCRIPTION
Especially `Tag::Clear()` avoiding `tag_pool_lock` has a noticeable effect on performance.