### PR TITLE
Docs: added custom.css to override default hyphenation and text alignment

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,0 +1,7 @@
+div.body p, div.body dd, div.body li, div.body blockquote {
+    text-align: left !important;
+    -moz-hyphens: manual;
+    -ms-hyphens: manual;
+    -webkit-hyphens: manual;
+    hyphens: manual;
+}

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,7 +1,3 @@
-div.body p, div.body dd, div.body li, div.body blockquote {
-    text-align: left !important;
-    -moz-hyphens: manual;
-    -ms-hyphens: manual;
-    -webkit-hyphens: manual;
-    hyphens: manual;
-}
+/*
+ * css to override sphinx theme
+ */

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -103,14 +103,20 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'classic'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
 # html_theme_options = {}
-html_theme_options = {"sidebarwidth": "300px"}
+html_theme_options = {
+    'navigation_depth': -1,
+    'sticky_navigation': False,
+    'includehidden': True,
+    'prev_next_buttons_location': 'both',
+    'github_url': "https://github.com/MusicPlayerDaemon/"
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -140,6 +140,10 @@ html_theme_options = {"sidebarwidth": "300px"}
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_css_files = [
+        'css/custom.css',
+]
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -17,6 +17,7 @@ if get_option('html_manual')
       'client.rst',
       'protocol.rst',
       'conf.py',
+      '_static/css/custom.css'
     ],
     command: [sphinx, '-q', '-b', 'html', '-d', '@OUTDIR@/doctrees', meson.current_source_dir(), '@OUTPUT@'],
     build_by_default: true,


### PR DESCRIPTION
Followed [this sphinx doc](https://docs.readthedocs.io/en/stable/guides/adding-custom-css.html#adding-custom-css-or-javascript-to-sphinx-documentation) to add a custom css.

It overrides text alignment to left instead of justified, and hyphenation to manual instead of auto.

Seems to be more readable this way without words getting broken by an hyphen.