### PR TITLE
v0.23.x: RemoteTagCache: add missing include

### DIFF
--- a/src/RemoteTagCache.hxx
+++ b/src/RemoteTagCache.hxx
@@ -28,7 +28,11 @@
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/unordered_set.hpp>
 
+#include <array>
+#include <functional>
+#include <memory>
 #include <string>
+#include <utility>
 
 class RemoteTagCacheHandler;
 


### PR DESCRIPTION
Fix build with Boost 1.81.0. `<array>` was included by one of those boost headers, however, it's no longer included as of Boost 1.81.0.

`master` doesn't use `std::array` in this file.

While we're at it, add all necessary inclusion files.