### PR TITLE
Allow titlesort and composersort to fall back to title and composer

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -796,8 +796,9 @@ Whenever possible, ids should be used.
     ``sort`` sorts the result by the specified tag.  The sort is
     descending if the tag is prefixed with a minus ('-').  Only the
     first tag value will be used, if multiple of the same type exist.
-    To sort by "Artist", "Album" or "AlbumArtist", you should specify
-    "ArtistSort", "AlbumSort" or "AlbumArtistSort" instead.  These
+    To sort by "Title", "Artist", "Album", "AlbumArtist" or "Composer",
+    you should specify "TitleSort", "ArtistSort", "AlbumSort",
+    "AlbumArtistSort" or "ComposerSort" instead.  These
     will automatically fall back to the former if "\*Sort" doesn't
     exist.  "AlbumArtist" falls back to just "Artist".  The type
     "Last-Modified" can sort by file modification time, and "prio"

--- a/src/tag/Fallback.hxx
+++ b/src/tag/Fallback.hxx
@@ -49,6 +49,14 @@ ApplyTagFallback(TagType type, F &&f) noexcept
 		/* fall back to "Album" if no "AlbumSort" was found */
 		return f(TAG_ALBUM);
 
+	if (type == TAG_TITLE_SORT)
+		/* fall back to "Title" if no "TitleSort" was found */
+		return f(TAG_TITLE);
+
+	if (type == TAG_COMPOSERSORT)
+		/* fall back to "Composer" if no "ComposerSort" was found */
+		return f(TAG_COMPOSER);
+
 	return false;
 }
 


### PR DESCRIPTION
Unlike album, artist and albumartist, title and composer were not used as a fallback when titlesort and composersort were specified but unavailable - this patch fixes that.