### PR TITLE
Add "searchcount" for case-insensitive count

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1286,6 +1286,16 @@ The music database
     The ``position`` parameter specifies where the songs will be
     inserted. [#since_0_23_4]_
 
+.. _command_searchcount:
+
+:command:`searchcount {FILTER} [group {GROUPTYPE}]`
+    Count the number of songs and their total playtime in
+    the database matching ``FILTER`` (see
+    :ref:`Filters <filter_syntax>`).
+
+    Parameters have the same meaning as for :ref:`count <command_search>`
+    except the search is not case sensitive.
+
 .. _command_update:
 
 :command:`update [URI]`

--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -189,6 +189,7 @@ static constexpr struct command commands[] = {
 	{ "search", PERMISSION_READ, 1, -1, handle_search },
 	{ "searchadd", PERMISSION_ADD, 1, -1, handle_searchadd },
 	{ "searchaddpl", PERMISSION_CONTROL, 2, -1, handle_searchaddpl },
+	{ "searchcount", PERMISSION_READ, 1, -1, handle_searchcount },
 #endif
 	{ "seek", PERMISSION_PLAYER, 2, 2, handle_seek },
 	{ "seekcur", PERMISSION_PLAYER, 1, 1, handle_seekcur },

--- a/src/command/DatabaseCommands.cxx
+++ b/src/command/DatabaseCommands.cxx
@@ -231,8 +231,8 @@ handle_searchaddpl(Client &client, Request args, Response &)
 	return CommandResult::OK;
 }
 
-CommandResult
-handle_count(Client &client, Request args, Response &r)
+static CommandResult
+handle_count_internal(Client &client, Request args, Response &r, bool fold_case)
 {
 	TagType group = TAG_NUM_OF_ITEM_TYPES;
 	if (args.size() >= 2 && StringIsEqual(args[args.size() - 2], "group")) {
@@ -251,7 +251,7 @@ handle_count(Client &client, Request args, Response &r)
 	SongFilter filter;
 	if (!args.empty()) {
 		try {
-			filter.Parse(args, false);
+			filter.Parse(args, fold_case);
 		} catch (...) {
 			r.Error(ACK_ERROR_ARG,
 				GetFullMessage(std::current_exception()).c_str());
@@ -263,6 +263,18 @@ handle_count(Client &client, Request args, Response &r)
 
 	PrintSongCount(r, client.GetPartition(), "", &filter, group);
 	return CommandResult::OK;
+}
+
+CommandResult
+handle_count(Client &client, Request args, Response &r)
+{
+	return handle_count_internal(client, args, r, false);
+}
+
+CommandResult
+handle_searchcount(Client &client, Request args, Response &r)
+{
+	return handle_count_internal(client, args, r, true);
 }
 
 CommandResult

--- a/src/command/DatabaseCommands.hxx
+++ b/src/command/DatabaseCommands.hxx
@@ -48,6 +48,9 @@ CommandResult
 handle_searchaddpl(Client &client, Request request, Response &response);
 
 CommandResult
+handle_searchcount(Client &client, Request request, Response &response);
+
+CommandResult
 handle_count(Client &client, Request request, Response &response);
 
 CommandResult

--- a/src/tag/Fallback.hxx
+++ b/src/tag/Fallback.hxx
@@ -49,6 +49,14 @@ ApplyTagFallback(TagType type, F &&f) noexcept
 		/* fall back to "Album" if no "AlbumSort" was found */
 		return f(TAG_ALBUM);
 
+	if (type == TAG_TITLE_SORT)
+		/* fall back to "Title" if no "TitleSort" was found */
+		return f(TAG_TITLE);
+
+	if (type == TAG_COMPOSERSORT)
+		/* fall back to "Composer" if no "ComposerSort" was found */
+		return f(TAG_COMPOSER);
+
 	return false;
 }
 


### PR DESCRIPTION
The `count` command isn't case-insensitive. This PR adds `searchcount` which is a case-insensitive version of `count`.