### PR TITLE
Resolve deprecation warnings by replacing use of sprintf with FmtBuffer

### DIFF
--- a/src/lib/ffmpeg/Filter.cxx
+++ b/src/lib/ffmpeg/Filter.cxx
@@ -22,6 +22,7 @@
 #include "SampleFormat.hxx"
 #include "pcm/AudioFormat.hxx"
 #include "lib/fmt/RuntimeError.hxx"
+#include "lib/fmt/ToBuffer.hxx"
 
 #include <cinttypes>
 
@@ -80,10 +81,9 @@ MakeAudioBufferSource(AudioFormat &audio_format,
 			break;
 		}
 	}
-
-	char abuffer_args[256];
-	sprintf(abuffer_args,
-		"sample_rate=%u:sample_fmt=%s:channel_layout=0x%" PRIx64 ":time_base=1/%u",
+	
+	StringBuffer abuffer_args = FmtBuffer<256>(
+		"sample_rate={0:d}:sample_fmt={1}:channel_layout={2:#x}:time_base=1/{3:d}",
 		audio_format.sample_rate,
 		av_get_sample_fmt_name(src_format),
 		ToFfmpegChannelLayout(audio_format.channels),
@@ -119,15 +119,14 @@ MakeAformat(AudioFormat &audio_format,
 		}
 	}
 
-	char args[256];
-	sprintf(args,
-		"sample_rates=%u:sample_fmts=%s:channel_layouts=0x%" PRIx64,
+	StringBuffer args = FmtBuffer<256>(
+		"sample_rates={0:d}:sample_fmts={1}:channel_layouts={2:#x}",
 		audio_format.sample_rate,
 		av_get_sample_fmt_name(dest_format),
 		ToFfmpegChannelLayout(audio_format.channels));
 
 	return CreateFilter(RequireFilterByName("aformat"), "aformat",
-			    args, nullptr, graph_ctx);
+			    args.data(), nullptr, graph_ctx);
 }
 
 AVFilterContext &

--- a/src/net/Resolver.cxx
+++ b/src/net/Resolver.cxx
@@ -34,6 +34,7 @@
 #include "AddressInfo.hxx"
 #include "HostParser.hxx"
 #include "lib/fmt/RuntimeError.hxx"
+#include "lib/fmt/ToBuffer.hxx"
 #include "util/CharUtil.hxx"
 
 #ifdef _WIN32
@@ -96,8 +97,9 @@ FindAndResolveInterfaceName(char *host, size_t size)
 	const unsigned i = if_nametoindex(interface);
 	if (i == 0)
 		throw FmtRuntimeError("No such interface: {}", interface);
-
-	sprintf(interface, "%u", i);
+	
+	StringBuffer ifx = FmtBuffer<64>("{d}", i);
+	strcpy(interface, ifx);
 }
 
 #endif

--- a/src/net/Resolver.cxx
+++ b/src/net/Resolver.cxx
@@ -98,7 +98,7 @@ FindAndResolveInterfaceName(char *host, size_t size)
 	if (i == 0)
 		throw FmtRuntimeError("No such interface: {}", interface);
 	
-	StringBuffer ifx = FmtBuffer<64>("{d}", i);
+	StringBuffer ifx = FmtBuffer<64>("{0:d}", i);
 	strcpy(interface, ifx);
 }
 

--- a/src/pcm/AudioFormat.cxx
+++ b/src/pcm/AudioFormat.cxx
@@ -19,6 +19,7 @@
 
 #include "AudioFormat.hxx"
 #include "util/StringBuffer.hxx"
+#include "lib/fmt/ToBuffer.hxx"
 
 #include <cassert>
 
@@ -47,30 +48,32 @@ ToString(const AudioFormat af) noexcept
 {
 	StringBuffer<24> buffer;
 	char *p = buffer.data();
+	StringBuffer<24> wp;
 
 	if (af.format == SampleFormat::DSD && af.sample_rate > 0 &&
 	    af.sample_rate % 44100 == 0) {
 		/* use shortcuts such as "dsd64" which implies the
 		   sample rate */
-		p += sprintf(p, "dsd%u:", af.sample_rate * 8 / 44100);
+		wp = FmtBuffer<24>("dsd:{d}", af.sample_rate * 8 / 44100);
 	} else {
 		const char *sample_format = af.format != SampleFormat::UNDEFINED
 			? sample_format_to_string(af.format)
 			: "*";
 
 		if (af.sample_rate > 0)
-			p += sprintf(p, "%u:%s:", af.sample_rate,
-				     sample_format);
+			wp = FmtBuffer<24>("{0}:{1}:", af.sample_rate, sample_format);
 		else
-			p += sprintf(p, "*:%s:", sample_format);
+			wp = FmtBuffer<24>("*:{}:", sample_format);
 	}
+	strcpy(p, wp);
+	p += strlen(wp);
 
 	if (af.channels > 0)
-		p += sprintf(p, "%u", af.channels);
+		wp = FmtBuffer<24>("{}", af.channels);
 	else {
-		*p++ = '*';
-		*p = 0;
+		wp = FmtBuffer<24>("{}", "*");
 	}
+	strcpy(p, wp);
 
 	return buffer;
 }

--- a/src/pcm/AudioFormat.cxx
+++ b/src/pcm/AudioFormat.cxx
@@ -54,7 +54,7 @@ ToString(const AudioFormat af) noexcept
 	    af.sample_rate % 44100 == 0) {
 		/* use shortcuts such as "dsd64" which implies the
 		   sample rate */
-		wp = FmtBuffer<24>("dsd:{0:d}", af.sample_rate * 8 / 44100);
+		wp = FmtBuffer<24>("dsd:{0:d}:", af.sample_rate * 8 / 44100);
 	} else {
 		const char *sample_format = af.format != SampleFormat::UNDEFINED
 			? sample_format_to_string(af.format)

--- a/src/pcm/AudioFormat.cxx
+++ b/src/pcm/AudioFormat.cxx
@@ -54,7 +54,7 @@ ToString(const AudioFormat af) noexcept
 	    af.sample_rate % 44100 == 0) {
 		/* use shortcuts such as "dsd64" which implies the
 		   sample rate */
-		wp = FmtBuffer<24>("dsd:{0:d}:", af.sample_rate * 8 / 44100);
+		wp = FmtBuffer<24>("dsd{0:d}:", af.sample_rate * 8 / 44100);
 	} else {
 		const char *sample_format = af.format != SampleFormat::UNDEFINED
 			? sample_format_to_string(af.format)

--- a/src/pcm/AudioFormat.cxx
+++ b/src/pcm/AudioFormat.cxx
@@ -54,7 +54,7 @@ ToString(const AudioFormat af) noexcept
 	    af.sample_rate % 44100 == 0) {
 		/* use shortcuts such as "dsd64" which implies the
 		   sample rate */
-		wp = FmtBuffer<24>("dsd:{d}", af.sample_rate * 8 / 44100);
+		wp = FmtBuffer<24>("dsd:{0:d}", af.sample_rate * 8 / 44100);
 	} else {
 		const char *sample_format = af.format != SampleFormat::UNDEFINED
 			? sample_format_to_string(af.format)

--- a/src/pcm/MixRampGlue.cxx
+++ b/src/pcm/MixRampGlue.cxx
@@ -24,6 +24,7 @@
 #include "MusicChunk.hxx"
 #include "util/Compiler.h"
 #include "util/SpanCast.hxx"
+#include "lib/fmt/ToBuffer.hxx"
 
 #include <stdio.h>
 
@@ -37,8 +38,7 @@ StartToString(const MixRampArray &a) noexcept
 		if (i.time < FloatDuration{} || i == last)
 			continue;
 
-		char buffer[64];
-		sprintf(buffer, "%.2f %.2f;", i.volume, i.time.count());
+		StringBuffer buffer = FmtBuffer<64>("{0} {1};", i.volume, i.time.count());
 		last = i;
 
 		s.append(buffer);
@@ -57,8 +57,7 @@ EndToString(const MixRampArray &a, FloatDuration total_time) noexcept
 		if (i.time < FloatDuration{} || i == last)
 			continue;
 
-		char buffer[64];
-		sprintf(buffer, "%.2f %.2f;",
+		StringBuffer buffer = FmtBuffer<64>("{0} {1};",
 			i.volume, (total_time - i.time).count());
 		last = i;
 

--- a/src/unix/PidFile.hxx
+++ b/src/unix/PidFile.hxx
@@ -24,6 +24,7 @@
 #include "fs/FileSystem.hxx"
 #include "fs/AllocatedPath.hxx"
 #include "lib/fmt/SystemError.hxx"
+#include "lib/fmt/ToBuffer.hxx"
 
 #include <cassert>
 
@@ -71,10 +72,9 @@ public:
 		if (fd < 0)
 			return;
 
-		char buffer[64];
-		sprintf(buffer, "%lu\n", (unsigned long)pid);
+		StringBuffer fb = FmtBuffer<64>("{}\n", (unsigned long)pid);
 
-		write(fd, buffer, strlen(buffer));
+		write(fd, fb, strlen(fb));
 		close(fd);
 	}
 


### PR DESCRIPTION
As I am sure you are aware, there some subtle and some not so subtle differences between sprintf format specs and libfmt format specs. libfmt seems to be better at picking reasonable format specs for cases where you simply use {} for substitution. I have no way to actually test some of the changes because I run on macOS Ventura 13.2. PidFile.hxx is the only change that I am sure was tested. To compensate for that problem, I wrote a small program where I tested the new format specs.