### PR TITLE
output/PipeWire: lock thread loop in SendTag

### DIFF
--- a/src/output/plugins/PipeWireOutputPlugin.cxx
+++ b/src/output/plugins/PipeWireOutputPlugin.cxx
@@ -962,6 +962,8 @@ PipeWireOutput::SendTag(const Tag &tag)
 
 	struct spa_dict dict = SPA_DICT_INIT(items, n_items);
 
+	const PipeWire::ThreadLoopLock lock(thread_loop);
+
 	auto rc = pw_stream_update_properties(stream, &dict);
 	if (rc < 0)
 		LogWarning(pipewire_output_domain, "Error updating properties");


### PR DESCRIPTION
Fixes https://github.com/MusicPlayerDaemon/MPD/issues/1753, see https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/3062#note_1805001