### PR TITLE
Update user.rst

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -1140,6 +1140,8 @@ excluded.  Example::
   *.opus
   99*
 
+NB: MPD does not recognize file names with square brackets (i.e., "[ ]") in .mpdignore files.  In order for MPD to recognize these file names the square bracket characters MUST be individually escaped (i.e., single or double quoting the entire song is not recognized).  E.g., ' [24] - Artist - Song [ text ].flac ' needs to be entered into the .mpdignore file as ' \[24\] - Artist - Song \[ text \].flac '.
+
 Subject to pattern matching is the file/directory name.  It is (not
 yet) possible to match nested path names, e.g. something like
 ``foo/*.flac`` is not possible.


### PR DESCRIPTION
MPD does not recognize file names in .mpdignore files that contain square brackets.  There may be other characters to which this also applies but I haven't found any.  FWIW '>' *does* work which is good because it is in a lot of bootleg song names.