### PR TITLE
Repair curl storage database update by preventing malformed PROPFIND requests

### DIFF
--- a/src/storage/plugins/CurlStorage.cxx
+++ b/src/storage/plugins/CurlStorage.cxx
@@ -512,8 +512,8 @@ private:
 			/* regular file */
 			return path;
 		else if (slash + 1 == path.size())
-			/* trailing slash: collection; strip the slash */
-			return path.substr(0, slash);
+			/* trailing slash: collection; still do not strip the slash */
+			return path;
 		else
 			/* strange, better ignore it */
 			return {};


### PR DESCRIPTION
As mentioned in #1768, the modified line allowed the formation of a PROPFIND request on a collection without a trailing slash, which resulted with some WEBDAV server implementations (`lighttpd`, for instance) returning a null-sized response after a timeout, which means that a database update with curl storage took a very long time (some O(number of directories * timeout size in seconds) seconds).

I am not entirely sure why this trailing slash was removed in the first place. There seems to be some code to re-add it, which definitely did not work in the current situation. Not sure whether this code is still needed.
https://github.com/MusicPlayerDaemon/MPD/blob/53ec02d5e968b0af3b01b42cdbb812a141d7cd6e/src/storage/plugins/CurlStorage.cxx#L548-L552

Fix #1768 