### PR TITLE
Fixes hide_playlist_targets not working after server restart

### DIFF
--- a/src/SongSave.cxx
+++ b/src/SongSave.cxx
@@ -48,6 +48,8 @@ song_save(BufferedOutputStream &os, const Song &song)
 	if (song.audio_format.IsDefined())
 		os.Fmt(FMT_STRING("Format: {}\n"), song.audio_format);
 
+	os.Fmt(FMT_STRING("InPlaylist: {}\n"), song.in_playlist ? "yes" : "no");
+
 	if (!IsNegative(song.mtime))
 		os.Fmt(FMT_STRING(SONG_MTIME ": {}\n"),
 		       std::chrono::system_clock::to_time_t(song.mtime));
@@ -71,7 +73,7 @@ song_save(BufferedOutputStream &os, const DetachedSong &song)
 
 DetachedSong
 song_load(LineReader &file, const char *uri,
-	  std::string *target_r)
+	  std::string *target_r, bool *in_playlist_r)
 {
 	DetachedSong song(uri);
 
@@ -116,6 +118,9 @@ song_load(LineReader &file, const char *uri,
 
 			song.SetStartTime(SongTime::FromMS(start_ms));
 			song.SetEndTime(SongTime::FromMS(end_ms));
+		} else if (StringIsEqual(line, "InPlaylist")) {
+			if (in_playlist_r != nullptr)
+				*in_playlist_r = StringIsEqual(value, "yes");
 		} else {
 			throw FmtRuntimeError("unknown line in db: {}", line);
 		}

--- a/src/SongSave.hxx
+++ b/src/SongSave.hxx
@@ -28,6 +28,6 @@ song_save(BufferedOutputStream &os, const DetachedSong &song);
  */
 DetachedSong
 song_load(LineReader &file, const char *uri,
-	  std::string *target_r=nullptr);
+	  std::string *target_r=nullptr, bool *in_playlist_r=nullptr);
 
 #endif

--- a/src/db/plugins/simple/DirectorySave.cxx
+++ b/src/db/plugins/simple/DirectorySave.cxx
@@ -154,12 +154,14 @@ directory_load(LineReader &file, Directory &directory)
 						      name);
 
 			std::string target;
+			bool in_playlist = false;
 			auto detached_song = song_load(file, name,
-						       &target);
+						       &target, &in_playlist);
 
 			auto song = std::make_unique<Song>(std::move(detached_song),
 							   directory);
 			song->target = std::move(target);
+			song->in_playlist = in_playlist;
 
 			directory.AddSong(std::move(song));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_META_BEGIN))) {


### PR DESCRIPTION
Currently, `hide_playlists_targets` works by skipping songs with `in_playlist` value set to true in [`Directory::Walk`](https://github.com/MusicPlayerDaemon/MPD/blob/a57bcd02382947abbd961594cdf00302c0c7866a/src/db/plugins/simple/Directory.cxx#L237). But `in_playlist` is not stored and only updated in [`UpdateWalk::PurgeDanglingFromPlaylists`](https://github.com/MusicPlayerDaemon/MPD/blob/a57bcd02382947abbd961594cdf00302c0c7866a/src/db/update/Playlist.cxx#L139), which will only be executed while updating DB.

This causes the problem that playlist target songs are correctly hidden after database update, but will remain visible after mpd server restarted. This pr solves the problem by storing `in_playlist` value of songs into the `SimpleDatabase` file.