### PR TITLE
Some fixes and enhancements about cue files in satellite setup

### DIFF
--- a/src/SongPrint.cxx
+++ b/src/SongPrint.cxx
@@ -49,6 +49,42 @@ song_print_uri(Response &r, const DetachedSong &song, bool base) noexcept
 }
 
 static void
+song_print_real_uri(Response &r, const char *real_uri, bool base) noexcept
+{
+	std::string allocated;
+
+	if (base) {
+		real_uri = PathTraitsUTF8::GetBase(real_uri);
+	} else {
+		allocated = uri_remove_auth(real_uri);
+		if (!allocated.empty())
+			real_uri = allocated.c_str();
+	}
+
+	r.Fmt(FMT_STRING("RealUri: {}\n"), real_uri);
+}
+
+static void
+song_print_real_uri(Response &r, const LightSong &song, bool base) noexcept
+{
+	if (song.real_uri == nullptr)
+		return;
+
+	if (!base && song.directory != nullptr)
+		r.Fmt(FMT_STRING("RealUri: {}\n"),
+		      song.real_uri);
+	else
+		song_print_real_uri(r, song.real_uri, base);
+}
+
+static void
+song_print_real_uri(Response &r, const DetachedSong &song, bool base) noexcept
+{
+	if (song.HasRealURI())
+		song_print_real_uri(r, song.GetRealURI(), base);
+}
+
+static void
 PrintRange(Response &r, SongTime start_time, SongTime end_time) noexcept
 {
 	const unsigned start_ms = start_time.ToMS();
@@ -70,6 +106,8 @@ void
 song_print_info(Response &r, const LightSong &song, bool base) noexcept
 {
 	song_print_uri(r, song, base);
+
+	song_print_real_uri(r, song, base);
 
 	PrintRange(r, song.start_time, song.end_time);
 
@@ -93,6 +131,8 @@ void
 song_print_info(Response &r, const DetachedSong &song, bool base) noexcept
 {
 	song_print_uri(r, song, base);
+
+	song_print_real_uri(r, song, base);
 
 	PrintRange(r, song.GetStartTime(), song.GetEndTime());
 

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -211,8 +211,8 @@ ProxySong::ProxySong(const mpd_song *song)
 	if (_mtime > 0)
 		mtime = std::chrono::system_clock::from_time_t(_mtime);
 
-	start_time = SongTime::FromS(mpd_song_get_start(song));
-	end_time = SongTime::FromS(mpd_song_get_end(song));
+	start_time = SongTime::FromMS(mpd_song_get_start_ms(song));
+	end_time = SongTime::FromMS(mpd_song_get_end_ms(song));
 
 	const auto *af = mpd_song_get_audio_format(song);
 	if (af != nullptr) {

--- a/src/db/plugins/ProxyDatabasePlugin.cxx
+++ b/src/db/plugins/ProxyDatabasePlugin.cxx
@@ -203,6 +203,10 @@ Copy(TagBuilder &tag, TagType d_tag,
 ProxySong::ProxySong(const mpd_song *song)
 	:LightSong(mpd_song_get_uri(song), tag2)
 {
+	const auto _real_uri = mpd_song_get_real_uri(song);
+	if (_real_uri != nullptr)
+		real_uri = _real_uri;
+
 	const auto _mtime = mpd_song_get_last_modified(song);
 	if (_mtime > 0)
 		mtime = std::chrono::system_clock::from_time_t(_mtime);

--- a/src/input/plugins/CurlInputPlugin.cxx
+++ b/src/input/plugins/CurlInputPlugin.cxx
@@ -534,7 +534,7 @@ CurlInputStream::SeekInternal(offset_type new_offset)
 
 	if (offset > 0)
 		request->SetOption(CURLOPT_RANGE,
-				   fmt::format_int{offset}.c_str());
+				   fmt::format("{}-", offset).c_str());
 
 	StartRequest();
 }

--- a/src/player/Thread.cxx
+++ b/src/player/Thread.cxx
@@ -903,7 +903,10 @@ PlayerControl::LockUpdateSongTag(DetachedSong &song,
 		   streams may change tags dynamically */
 		return;
 
-	song.SetTag(new_tag);
+	if (!song.GetEndTime().IsZero())
+		song.SetTag(Tag::Merge(song.GetTag(), new_tag));
+	else
+		song.SetTag(new_tag);
 
 	LockSetTaggedSong(song);
 


### PR DESCRIPTION
This pr contains a series of commits which fixes issues around cue files in satellite setup, and some enhancements related to cue files. As `ProxyDatabasePlugin` uses `libmpdclient` for retrieving information from server, a [pull request](https://github.com/MusicPlayerDaemon/libmpdclient/pull/100) has also been created in `libmpdclient` repository.

## Fixes
- SongPrint: include real_uri in song_print_info
- db/ProxyDatabasePlugin: read real_uri from server's song info
- (libmpdclient) Add real_uri into mpd_song

These commits add `real_uri` info into printed song info, and add the ability to read it in `libmpdclient` and `ProxyDatabasePlugin`. CUE virtual playlists is currently implemented by accessing `real_uri` file with range. But the `real_uri` is not included in the protocol now, thus `ProxyDatabasePlugin` is not able to retreive this information, and cannot access the corresponding file. This should fix #907.

- input/CurlInputPlugin: fix malformed value for HTTP Range header

`CURLOPT_RANGE` value requires the format "X-Y", where X or Y can be omitted. The current value provided to libcurl is only `offset` without the hyphen character and will cause HTTP error while accessing song files with range, the format string went wrong in 415de497, and this commit fixes it.

## Enhancements
- db/ProxyDatabasePlugin: read millisecond values for range start and end
- (libmpdclient) Add range start and end in milliseconds into mpd_song

Range `start` and `end` values in `mpd_song` is stored in seconds only, which makes range times in `ProxySong` truncated to seconds. This leads to precision loss on cue tracks. These commits adds `start_ms` and `end_ms`, which represents range start and end in milliseconds, into libmpdclient parsing procedure.

- player/Thread: merge tag for songs have range instead of replacing with `chunk->tag`

On current code base (with patches above), while playing the first track of the cue virtual playlist on the satellite client, the `currentsong` status will lose cue metadata. It's due to tag being replaced by `tag` of `MusicChunk` in [`PlayerControl::PlayChunk`](https://github.com/MusicPlayerDaemon/MPD/blob/a57bcd02382947abbd961594cdf00302c0c7866a/src/player/Thread.cxx#L922), which is produced in `DecoderBridge::SubmitAudio` and `DecoderBridge::SubmitTag`.

In local cue files, [`song_tag`](https://github.com/MusicPlayerDaemon/MPD/blob/a57bcd02382947abbd961594cdf00302c0c7866a/src/decoder/Bridge.hxx#L75) is used to form the `stream_tag` in [`DecoderBridge::UpdateStreamTag`](https://github.com/MusicPlayerDaemon/MPD/blob/a57bcd02382947abbd961594cdf00302c0c7866a/src/decoder/Bridge.cxx#L232), and then merged into `chunk->tag`. However, `song_tag` only works for local files. While playing cue tracks in satellite client, the tags are replaced by decoded tags in the whole album audio file.

This commit fixes this problem by merging song's tag with `chunk->tag` **when the song's end_time is not zero**. In the code base, end_time is only set while copying from other song objects, loading from database, parsing cue and the `rangeid` command. So this change will only affect behaviour when the user uses `rangeid` command to set range for a song in remote stream, and the user needs the tags from remote stream to replace tags in database instead of merging them. I think this is a much more rare scenario compared to the issue to be fixed.