### PR TITLE
decoder/openmpt: Fix build error with libopenmpt < 0.5

### DIFF
--- a/src/decoder/plugins/OpenmptDecoderPlugin.cxx
+++ b/src/decoder/plugins/OpenmptDecoderPlugin.cxx
@@ -26,10 +26,12 @@ static int openmpt_interpolation_filter;
 static bool openmpt_override_mptm_interp_filter;
 static int openmpt_volume_ramping;
 static bool openmpt_sync_samples;
-static std::string_view openmpt_at_end;
 static bool openmpt_emulate_amiga;
 #ifdef HAVE_LIBOPENMPT_VERSION_0_5
+static std::string_view openmpt_at_end;
 static std::string_view openmpt_emulate_amiga_type;
+#else
+static std::string openmpt_at_end;
 #endif
 
 static bool
@@ -82,7 +84,7 @@ mod_decode(DecoderClient &client, InputStream &is)
 #else
 	mod.ctl_set("seek.sync_samples", std::to_string((unsigned)openmpt_sync_samples));
 	mod.ctl_set("render.resampler.emulate_amiga", std::to_string((unsigned)openmpt_emulate_amiga));
-	mod.ctl_set("play.at_end", std::to_string((unsigned)openmpt_at_end));
+	mod.ctl_set("play.at_end", openmpt_at_end);
 #endif
 
 	static constexpr unsigned channels = 2;


### PR DESCRIPTION
openmpt_at_end is a string, not an integer