### PR TITLE
output/httpd: fix libfmt icy-metaint replacement field

### DIFF
--- a/src/output/plugins/httpd/IcyMetaDataServer.cxx
+++ b/src/output/plugins/httpd/IcyMetaDataServer.cxx
@@ -21,7 +21,7 @@ icy_server_metadata_header(const char *name,
 			   "icy-genre: {}\r\n"            /* TODO */
 			   "icy-url: {}\r\n"              /* TODO */
 			   "icy-pub:1\r\n"
-			   "icy-metaint:%d\r\n"
+			   "icy-metaint:{}\r\n"
 			   /* TODO "icy-br:%d\r\n" */
 			   "Content-Type: {}\r\n"
 			   "Connection: close\r\n"


### PR DESCRIPTION
Since using libfmt (commit: dfc5b49) ICY MetaData was broken. Eg MP3 streams encoded with LAME were affected resulting in missing stream titles on VLC or strange noises on Sonos hardware. This commit fixes the icy-metaint field.