### PR TITLE
reorder ffmpeg to be lower priority than gme

### DIFF
--- a/src/decoder/DecoderList.cxx
+++ b/src/decoder/DecoderList.cxx
@@ -96,11 +96,11 @@ constinit const struct DecoderPlugin *const decoder_plugins[] = {
 #ifdef ENABLE_ADPLUG
 	&adplug_decoder_plugin,
 #endif
-#ifdef ENABLE_FFMPEG
-	&ffmpeg_decoder_plugin,
-#endif
 #ifdef ENABLE_GME
 	&gme_decoder_plugin,
+#endif
+#ifdef ENABLE_FFMPEG
+	&ffmpeg_decoder_plugin,
 #endif
 	&pcm_decoder_plugin,
 	nullptr


### PR DESCRIPTION
This should prevent ffmpeg from taking priority over the gme plugin. The ffmpeg plugin is more buggy than gme.
One of the prominent bugs of preferring ffmpeg over gme is that ffmpeg cannot seek SAP files while gme can. This should prevent that from happening.