### PR TITLE
[v0.23.x] Add fmt 10 support.

### DIFF
--- a/src/util/StringBuffer.hxx
+++ b/src/util/StringBuffer.hxx
@@ -30,6 +30,8 @@
 #ifndef STRING_BUFFER_HXX
 #define STRING_BUFFER_HXX
 
+#include <fmt/format.h>
+
 #include <array>
 
 /**
@@ -106,5 +108,15 @@ public:
 
 template<std::size_t CAPACITY>
 class StringBuffer : public BasicStringBuffer<char, CAPACITY> {};
+
+#if FMT_VERSION >= 90000
+template <std::size_t CAPACITY>
+struct fmt::formatter<StringBuffer<CAPACITY>> : formatter<string_view> {
+	auto format(const StringBuffer<CAPACITY> &buffer, format_context &ctx) const {
+		const string_view view{buffer.begin(), CAPACITY};
+		return formatter<string_view>::format(view, ctx);
+	}
+};
+#endif
 
 #endif

--- a/src/util/StringView.hxx
+++ b/src/util/StringView.hxx
@@ -33,6 +33,8 @@
 #include "ConstBuffer.hxx"
 #include "StringAPI.hxx"
 
+#include <fmt/format.h>
+
 #include <cstddef>
 #include <string_view>
 #include <utility>
@@ -237,5 +239,15 @@ struct StringView : BasicStringView<char> {
 	constexpr StringView(BasicStringView<value_type> src) noexcept
 		:BasicStringView(src) {}
 };
+
+#if FMT_VERSION >= 90000
+template <>
+struct fmt::formatter<StringView> : formatter<string_view> {
+	auto format(const StringView &view, format_context &ctx) const {
+		string_view std_view{view.begin(), view.size};
+		return formatter<string_view>::format(std_view, ctx);
+	}
+};
+#endif
 
 #endif


### PR DESCRIPTION
This adds support for fmt 10 on the v0.23.x branch (see #1813).

This is done by adding formatter specialisation for the custom `StringView` and `StringBuffer` types.