### PR TITLE
Fix meson build warning for get_pkgconfig_variable

### DIFF
--- a/systemd/system/meson.build
+++ b/systemd/system/meson.build
@@ -2,7 +2,7 @@ systemd_system_unit_dir = get_option('systemd_system_unit_dir')
 if systemd_system_unit_dir == ''
   systemd = dependency('systemd', required: false)
   if systemd.found()
-      systemd_system_unit_dir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
+      systemd_system_unit_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
   endif
 endif
 if systemd_system_unit_dir == ''

--- a/systemd/user/meson.build
+++ b/systemd/user/meson.build
@@ -2,7 +2,7 @@ systemd_user_unit_dir = get_option('systemd_user_unit_dir')
 if systemd_user_unit_dir == ''
   systemd = dependency('systemd', required: false)
   if systemd.found()
-    systemd_user_unit_dir = systemd.get_pkgconfig_variable('systemduserunitdir')
+    systemd_user_unit_dir = systemd.get_variable(pkgconfig: 'systemduserunitdir')
   endif
 endif
 if systemd_user_unit_dir == ''


### PR DESCRIPTION
Otherwise, building will generate these warnings:

systemd/system/meson.build:5: WARNING: Project targeting '>= 0.56.0' but tried to use feature deprecated since '0.56.0': Dependency.get_pkgconfig_variable. use Dependency.get_variable(pkgconfig : ...) instead
systemd/user/meson.build:5: WARNING: Project targeting '>= 0.56.0' but tried to use feature deprecated since '0.56.0': Dependency.get_pkgconfig_variable. use Dependency.get_variable(pkgconfig : ...) instead