### PR TITLE
meson: use correct prefix for systemd dirs

### DIFF
--- a/systemd/system/meson.build
+++ b/systemd/system/meson.build
@@ -2,7 +2,10 @@ systemd_system_unit_dir = get_option('systemd_system_unit_dir')
 if systemd_system_unit_dir == ''
   systemd = dependency('systemd', required: false)
   if systemd.found()
-      systemd_system_unit_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
+      systemd_system_unit_dir = systemd.get_variable(
+        pkgconfig: 'systemdsystemunitdir',
+        pkgconfig_define: ['prefix', get_option('prefix')],
+      )
   endif
 endif
 if systemd_system_unit_dir == ''

--- a/systemd/user/meson.build
+++ b/systemd/user/meson.build
@@ -2,7 +2,10 @@ systemd_user_unit_dir = get_option('systemd_user_unit_dir')
 if systemd_user_unit_dir == ''
   systemd = dependency('systemd', required: false)
   if systemd.found()
-    systemd_user_unit_dir = systemd.get_variable(pkgconfig: 'systemduserunitdir')
+    systemd_user_unit_dir = systemd.get_variable(
+      pkgconfig: 'systemduserunitdir',
+      pkgconfig_define: ['prefix', get_option('prefix')],
+    )
   endif
 endif
 if systemd_user_unit_dir == ''


### PR DESCRIPTION
See https://www.bassi.io/articles/2018/03/15/pkg-config-and-paths/, and https://github.com/ibus/ibus/pull/2388 for a previous instance of this.

Fixes the build in nixpkgs. Without this patch, the build fails because MPD tries to install its unit files in `/nix/store/...-systemd/etc/systemd/system` instead of `/nix/store/...-mpd/etc/systemd/system`.