### PR TITLE
pcm: declare IsSilentSample as const

### DIFF
--- a/src/pcm/ReplayGainAnalyzer.cxx
+++ b/src/pcm/ReplayGainAnalyzer.cxx
@@ -86,7 +86,8 @@ CalcStereoRMS(std::span<const ReplayGainAnalyzer::Frame> src) noexcept
 	return 10 * std::log10(sum / src.size()) + 90.0 - 3.0;
 }
 
-static constexpr bool
+[[gnu::const]]
+static bool
 IsSilentSample(float value) noexcept
 {
 	return std::fabs(value) <= 1e-10f;


### PR DESCRIPTION
GNU libstdc++ declares cmath functions as constexpr, but libc++ does not. The C++ standards state the standard library functions should not be declared constexpr unless explicitly required.