### PR TITLE
meson: Use correct prefix for systemd_system_unit_dir

### DIFF
--- a/systemd/system/meson.build
+++ b/systemd/system/meson.build
@@ -4,7 +4,7 @@ if systemd_system_unit_dir == ''
   if systemd.found()
       systemd_system_unit_dir = systemd.get_variable(
         pkgconfig: 'systemdsystemunitdir',
-        pkgconfig_define: ['prefix', get_option('prefix')],
+        pkgconfig_define: ['rootprefix', get_option('prefix')],
       )
   endif
 endif


### PR DESCRIPTION
systemd uses "rootprefix", not "prefix" for this value

https://github.com/systemd/systemd/blob/059b1b31ade7f1d716f56c5e6fd657ce22ce2032/src/core/systemd.pc.in#L23