### PR TITLE
Fix volume unchangable on wasapi hardware mixer, and various issues in windows

### DIFF
--- a/doc/mpdconf.example
+++ b/doc/mpdconf.example
@@ -314,6 +314,7 @@ input {
 ##	device		"Digital Audio (S/PDIF) (High Definition Audio Device)" # optional
 #		or
 ##	device		"0"		# optional
+##	mixer_type	"hardware"	# optional
 ## Exclusive mode blocks all other audio source, and get best audio quality without resampling.
 ##	exclusive	"no"		# optional
 ## Enumerate all devices in log.

--- a/python/build/libs.py
+++ b/python/build/libs.py
@@ -158,7 +158,7 @@ gme = CmakeProject(
         '-DBUILD_SHARED_LIBS=OFF',
         '-DENABLE_UBSAN=OFF',
         '-DZLIB_INCLUDE_DIR=OFF',
-        '-DSDL2_DIR=OFF',
+        '-DCMAKE_DISABLE_FIND_PACKAGE_SDL2=ON',
     ],
 )
 

--- a/src/decoder/plugins/FlacDecoderPlugin.cxx
+++ b/src/decoder/plugins/FlacDecoderPlugin.cxx
@@ -8,6 +8,7 @@
 #include "lib/xiph/FlacMetadataChain.hxx"
 #include "OggCodec.hxx"
 #include "input/InputStream.hxx"
+#include "input/LocalOpen.hxx"
 #include "fs/Path.hxx"
 #include "fs/NarrowPath.hxx"
 #include "Log.hxx"
@@ -51,16 +52,32 @@ flac_write_cb(const FLAC__StreamDecoder *dec, const FLAC__Frame *frame,
 }
 
 static bool
-flac_scan_file(Path path_fs, TagHandler &handler) noexcept
-{
+flac_scan_file(Path path_fs, TagHandler &handler) noexcept {
 	FlacMetadataChain chain;
-	if (!chain.Read(NarrowPath(path_fs))) {
+	const bool succeed = [&chain, &path_fs]() noexcept {
+		// read by NarrowPath
+		if (chain.Read(NarrowPath(path_fs))) {
+			return true;
+		}
+		if (std::is_same_v<Path::value_type, char> ||
+		    chain.GetStatus() != FLAC__METADATA_CHAIN_STATUS_ERROR_OPENING_FILE) {
+			return false;
+		}
+		// read by InputStream
+		Mutex mutex;
+		auto is = OpenLocalInputStream(path_fs, mutex);
+		if (is && chain.Read(*is)) {
+			return true;
+		}
+		return false;
+	}();
+
+	if (!succeed) {
 		FmtDebug(flac_domain,
 			 "Failed to read FLAC tags: {}",
 			 chain.GetStatusString());
 		return false;
 	}
-
 	chain.Scan(handler);
 	return true;
 }

--- a/src/thread/WindowsFuture.hxx
+++ b/src/thread/WindowsFuture.hxx
@@ -114,7 +114,7 @@ public:
 
 	void set_value(const T &value) {
 		std::unique_lock<CriticalSection> lock(mutex);
-		if (!std::holds_alternative<std::monostate>(&result)) {
+		if (!std::holds_alternative<std::monostate>(result)) {
 			throw WinFutureError(WinFutureErrc::promise_already_satisfied);
 		}
 		result.template emplace<T>(value);

--- a/src/win32/ComWorker.hxx
+++ b/src/win32/ComWorker.hxx
@@ -40,17 +40,17 @@ public:
 		using R = std::invoke_result_t<std::decay_t<Function>>;
 		auto promise = std::make_shared<Promise<R>>();
 		auto future = promise->get_future();
-		Push([function = std::forward<Function>(function),
-			      promise = std::move(promise)]() mutable {
+		Push([func = std::forward<Function>(function),
+			      prom = std::move(promise)]() mutable {
 			try {
 				if constexpr (std::is_void_v<R>) {
-					std::invoke(std::forward<Function>(function));
-					promise->set_value();
+					std::invoke(std::forward<Function>(func));
+					prom->set_value();
 				} else {
-					promise->set_value(std::invoke(std::forward<Function>(function)));
+					prom->set_value(std::invoke(std::forward<Function>(func)));
 				}
 			} catch (...) {
-				promise->set_exception(std::current_exception());
+				prom->set_exception(std::current_exception());
 			}
 		});
 		return future;


### PR DESCRIPTION
* win32/ComWorker: rename variable name to prevent ambiguous
* thread/WindowsFuture: remove wrong address_of operator
* doc/mpdconf.example: add hardware mixer example config for wasapi
* flac: Try `InputStream` interface if flac failed to read through a `wchar_t` path
* python/build/libs.py: use right cmake variable to disable SDL