### PR TITLE
Save consume and single oneshot as string

### DIFF
--- a/src/queue/PlaylistState.cxx
+++ b/src/queue/PlaylistState.cxx
@@ -76,9 +76,9 @@ playlist_state_save(BufferedOutputStream &os, const struct playlist &playlist,
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_REPEAT "{}\n"),
 	       (unsigned)playlist.queue.repeat);
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_SINGLE "{}\n"),
-		   (unsigned)playlist.queue.single);
+		   SingleToString(playlist.queue.single));
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_CONSUME "{}\n"),
-	       (unsigned)playlist.queue.consume);
+	       ConsumeToString(playlist.queue.consume));
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_CROSSFADE "{}\n"),
 	       pc.GetCrossFade().count());
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_MIXRAMPDB "{}\n"),


### PR DESCRIPTION
Consume and single oneshot should be saved as string.

closes #1853