### PR TITLE
doc/user.rst: use explicit meson setup command

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -103,7 +103,7 @@ Now configure the source tree:
 
 .. code-block:: none
 
- meson . output/release --buildtype=debugoptimized -Db_ndebug=true
+ meson setup . output/release --buildtype=debugoptimized -Db_ndebug=true
 
 The following command shows a list of compile-time options:
 


### PR DESCRIPTION
Currently running `meson . output/release --buildtype=debugoptimized -Db_ndebug=true` will issue a warning:

> Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.

The [implicit setup](https://mesonbuild.com/Commands.html#setup) command is deprecated since 0.64.0.