### PR TITLE
doc/plugins.rst: change command to list PipeWire targets

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -1145,7 +1145,7 @@ Connect to a `PipeWire <https://pipewire.org/>`_ server.  Requires
    * - **target NAME**
      - Link to the given target.  If not specified, let the PipeWire
        manager select a target.  To get a list of available targets,
-       type ``pw-cli dump short Node``
+       type ``pw-cli ls Node``
    * - **remote NAME**
      - The name of the remote to connect to.  The default is
        ``pipewire-0``.


### PR DESCRIPTION
The `dump` command [was dropped](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/50bdebe4e87c5e26acf966e7207a591332e33239) in favor of other tools.
