### PR TITLE
Add "added" timestamp to song database

### DIFF
--- a/src/SongPrint.cxx
+++ b/src/SongPrint.cxx
@@ -77,6 +77,9 @@ song_print_info(Response &r, const LightSong &song, bool base) noexcept
 	if (!IsNegative(song.mtime))
 		time_print(r, "Last-Modified", song.mtime);
 
+	if (!IsNegative(song.added))
+		time_print(r, "Added", song.added);
+
 	if (song.audio_format.IsDefined())
 		r.Fmt(FMT_STRING("Format: {}\n"), song.audio_format);
 
@@ -99,6 +102,9 @@ song_print_info(Response &r, const DetachedSong &song, bool base) noexcept
 
 	if (!IsNegative(song.GetLastModified()))
 		time_print(r, "Last-Modified", song.GetLastModified());
+
+	if (!IsNegative(song.GetAdded()))
+		time_print(r, "Added", song.GetAdded());
 
 	if (const auto &f = song.GetAudioFormat(); f.IsDefined())
 		r.Fmt(FMT_STRING("Format: {}\n"), f);

--- a/src/SongSave.cxx
+++ b/src/SongSave.cxx
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 
 #define SONG_MTIME "mtime"
+#define SONG_ADDED "added"
 #define SONG_END "song_end"
 
 static void
@@ -54,6 +55,10 @@ song_save(BufferedOutputStream &os, const Song &song)
 	if (!IsNegative(song.mtime))
 		os.Fmt(FMT_STRING(SONG_MTIME ": {}\n"),
 		       std::chrono::system_clock::to_time_t(song.mtime));
+
+	if (!IsNegative(song.added))
+		os.Fmt(FMT_STRING(SONG_ADDED ": {}\n"),
+		       std::chrono::system_clock::to_time_t(song.added));
 	os.Write(SONG_END "\n");
 }
 
@@ -69,6 +74,10 @@ song_save(BufferedOutputStream &os, const DetachedSong &song)
 	if (!IsNegative(song.GetLastModified()))
 		os.Fmt(FMT_STRING(SONG_MTIME ": {}\n"),
 		       std::chrono::system_clock::to_time_t(song.GetLastModified()));
+
+	if (!IsNegative(song.GetAdded()))
+		os.Fmt(FMT_STRING(SONG_ADDED ": {}\n"),
+		       std::chrono::system_clock::to_time_t(song.GetAdded()));
 	os.Write(SONG_END "\n");
 }
 
@@ -109,6 +118,8 @@ song_load(LineReader &file, const char *uri,
 			tag.SetHasPlaylist(StringIsEqual(value, "yes"));
 		} else if (StringIsEqual(line, SONG_MTIME)) {
 			song.SetLastModified(std::chrono::system_clock::from_time_t(atoi(value)));
+		} else if (StringIsEqual(line, SONG_ADDED)) {
+			song.SetAdded(std::chrono::system_clock::from_time_t(atoi(value)));
 		} else if (StringIsEqual(line, "Range")) {
 			char *endptr;
 

--- a/src/command/DatabaseCommands.cxx
+++ b/src/command/DatabaseCommands.cxx
@@ -51,6 +51,9 @@ ParseSortTag(const char *s)
 	if (StringIsEqualIgnoreCase(s, "Last-Modified"))
 		return TagType(SORT_TAG_LAST_MODIFIED);
 
+	if (StringIsEqualIgnoreCase(s, "Added"))
+		return TagType(SORT_TAG_ADDED);
+
 	TagType tag = tag_name_parse_i(s);
 	if (tag == TAG_NUM_OF_ITEM_TYPES)
 		throw ProtocolError(ACK_ERROR_ARG, "Unknown sort tag");

--- a/src/command/QueueCommands.cxx
+++ b/src/command/QueueCommands.cxx
@@ -276,6 +276,9 @@ ParseSortTag(const char *s)
 	if (StringIsEqualIgnoreCase(s, "Last-Modified"))
 		return TagType(SORT_TAG_LAST_MODIFIED);
 
+	if (StringIsEqualIgnoreCase(s, "Added"))
+		return TagType(SORT_TAG_ADDED);
+
 	if (StringIsEqualIgnoreCase(s, "prio"))
 		return TagType(SORT_TAG_PRIO);
 

--- a/src/db/VHelper.cxx
+++ b/src/db/VHelper.cxx
@@ -60,6 +60,13 @@ DatabaseVisitorHelper::Commit()
 						 ? a.GetLastModified() > b.GetLastModified()
 						 : a.GetLastModified() < b.GetLastModified();
 				 });
+	else if (sort == TagType(SORT_TAG_ADDED))
+		std::stable_sort(songs.begin(), songs.end(),
+				 [descending](const DetachedSong &a, const DetachedSong &b){
+					 return descending
+						 ? a.GetAdded() > b.GetAdded()
+						 : a.GetAdded() < b.GetAdded();
+				 });
 	else
 		std::stable_sort(songs.begin(), songs.end(),
 				 [sort, descending](const DetachedSong &a,

--- a/src/db/plugins/simple/Song.cxx
+++ b/src/db/plugins/simple/Song.cxx
@@ -19,6 +19,7 @@ Song::Song(DetachedSong &&other, Directory &_parent) noexcept
 	 filename(other.GetURI()),
 	 tag(std::move(other.WritableTag())),
 	 mtime(other.GetLastModified()),
+	 added(other.GetAdded()),
 	 start_time(other.GetStartTime()),
 	 end_time(other.GetEndTime()),
 	 audio_format(other.GetAudioFormat())
@@ -117,6 +118,9 @@ Song::Export() const noexcept
 	dest.mtime = IsNegative(mtime) && target_song != nullptr
 		? target_song->mtime
 		: mtime;
+	dest.added = IsNegative(added) && target_song != nullptr
+		? target_song->added
+		: added;
 	dest.start_time = start_time.IsZero() && target_song != nullptr
 		? target_song->start_time
 		: start_time;

--- a/src/db/plugins/simple/Song.hxx
+++ b/src/db/plugins/simple/Song.hxx
@@ -57,6 +57,13 @@ struct Song : IntrusiveListHook<> {
 		std::chrono::system_clock::time_point::min();
 
 	/**
+	 * The time stamp when the file was added. A negative
+	 * value means that this is unknown/unavailable.
+	 */
+	std::chrono::system_clock::time_point added =
+		std::chrono::system_clock::time_point::min();
+
+	/**
 	 * Start of this sub-song within the file.
 	 */
 	SongTime start_time = SongTime::zero();

--- a/src/db/update/UpdateSong.cxx
+++ b/src/db/update/UpdateSong.cxx
@@ -50,6 +50,7 @@ try {
 		}
 
 		new_song->mark = true;
+		new_song->added = std::chrono::system_clock::now();
 
 		{
 			const ScopeDatabaseLock protect;

--- a/src/playlist/PlaylistSong.cxx
+++ b/src/playlist/PlaylistSong.cxx
@@ -25,6 +25,7 @@ merge_song_metadata(DetachedSong &add, const DetachedSong &base) noexcept
 	}
 
 	add.SetLastModified(base.GetLastModified());
+	add.SetAdded(base.GetAdded());
 
 	if (add.GetStartTime().IsZero()) {
 		add.SetStartTime(base.GetStartTime());

--- a/src/queue/PlaylistUpdate.cxx
+++ b/src/queue/PlaylistUpdate.cxx
@@ -33,6 +33,7 @@ UpdatePlaylistSong(const Database &db, DetachedSong &song)
 	}
 
 	song.SetLastModified(original->mtime);
+	song.SetAdded(original->added);
 	song.SetTag(original->tag);
 
 	db.ReturnSong(original);

--- a/src/queue/Print.cxx
+++ b/src/queue/Print.cxx
@@ -127,6 +127,17 @@ PrintSortedQueue(Response &r, const Queue &queue,
 
 					 return a.GetLastModified() < b.GetLastModified();
 				 });
+	else if (sort == TagType(SORT_TAG_ADDED))
+		std::stable_sort(v.begin(), v.end(),
+				 [&queue, descending](unsigned a_pos, unsigned b_pos){
+					 if (descending)
+						 std::swap(a_pos, b_pos);
+
+					 const auto &a = queue.Get(a_pos);
+					 const auto &b = queue.Get(b_pos);
+
+					 return a.GetAdded() < b.GetAdded();
+				 });
 	else if (sort == TagType(SORT_TAG_PRIO))
 		std::stable_sort(v.begin(), v.end(),
 				 [&queue, descending](unsigned a_pos, unsigned b_pos){

--- a/src/song/DetachedSong.cxx
+++ b/src/song/DetachedSong.cxx
@@ -11,6 +11,7 @@ DetachedSong::DetachedSong(const LightSong &other) noexcept
 	 real_uri(other.real_uri != nullptr ? other.real_uri : ""),
 	 tag(other.tag),
 	 mtime(other.mtime),
+	 added(other.added),
 	 start_time(other.start_time),
 	 end_time(other.end_time),
 	 audio_format(other.audio_format) {}
@@ -21,6 +22,7 @@ DetachedSong::operator LightSong() const noexcept
 	result.directory = nullptr;
 	result.real_uri = real_uri.empty() ? nullptr : real_uri.c_str();
 	result.mtime = mtime;
+	result.added = added;
 	result.start_time = start_time;
 	result.end_time = end_time;
 	return result;

--- a/src/song/DetachedSong.hxx
+++ b/src/song/DetachedSong.hxx
@@ -7,6 +7,7 @@
 #include "tag/Tag.hxx"
 #include "pcm/AudioFormat.hxx"
 #include "Chrono.hxx"
+#include "time/ChronoUtil.hxx"
 
 #include <chrono>
 #include <string>
@@ -56,6 +57,13 @@ class DetachedSong {
 	 * value means that this is unknown/unavailable.
 	 */
 	std::chrono::system_clock::time_point mtime =
+		std::chrono::system_clock::time_point::min();
+
+	/**
+	 * The time stamp when the file was added to db. A negative
+	 * value means that this is unknown/unavailable.
+	 */
+	std::chrono::system_clock::time_point added =
 		std::chrono::system_clock::time_point::min();
 
 	/**
@@ -210,6 +218,16 @@ public:
 
 	void SetLastModified(std::chrono::system_clock::time_point _value) noexcept {
 		mtime = _value;
+	}
+
+	std::chrono::system_clock::time_point GetAdded() const noexcept {
+		return IsNegative(added)
+			? mtime
+			: added;
+	}
+
+	void SetAdded(std::chrono::system_clock::time_point _value) noexcept {
+		added = _value;
 	}
 
 	SongTime GetStartTime() const noexcept {

--- a/src/song/Filter.hxx
+++ b/src/song/Filter.hxx
@@ -21,6 +21,11 @@
  */
 #define SORT_TAG_PRIO (TAG_NUM_OF_ITEM_TYPES + 4)
 
+/**
+ * Special value for the db_selection_print() sort parameter.
+ */
+#define SORT_TAG_ADDED (TAG_NUM_OF_ITEM_TYPES + 5)
+
 enum TagType : uint8_t;
 struct LightSong;
 

--- a/src/song/LightSong.hxx
+++ b/src/song/LightSong.hxx
@@ -52,6 +52,12 @@ struct LightSong {
 	std::chrono::system_clock::time_point mtime = std::chrono::system_clock::time_point::min();
 
 	/**
+	 * The time stamp when the file was added. A negative
+	 * value means that this is unknown/unavailable.
+	 */
+	std::chrono::system_clock::time_point added = std::chrono::system_clock::time_point::min();
+
+	/**
 	 * Start of this sub-song within the file.
 	 */
 	SongTime start_time = SongTime::zero();


### PR DESCRIPTION
addedtime is only set to mtime, if a new song is added to the database.

Code for proxy plugin is missing, this needs a patch for libmpdclient.

closes #378