### PR TITLE
decoder/ffmpeg: Fix build error with ffmpeg 6.1

### DIFF
--- a/src/decoder/plugins/FfmpegIo.cxx
+++ b/src/decoder/plugins/FfmpegIo.cxx
@@ -10,6 +10,9 @@
 
 extern "C" {
 #include <libavutil/mem.h>
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(58, 29, 100)
+#include <libavutil/error.h>
+#endif
 }
 
 AvioStream::~AvioStream()


### PR DESCRIPTION
Fixes build error 'AVERROR_EOF' was not declared in this scope with ffmpeg 6.1