### PR TITLE
Rename generated version header to avoid conflict on case insensitive filesystems

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -104,7 +104,7 @@ version_conf.set_quoted('PACKAGE', meson.project_name())
 version_conf.set_quoted('PACKAGE_NAME', meson.project_name())
 version_conf.set_quoted('VERSION', meson.project_version())
 version_conf.set_quoted('PROTOCOL_VERSION', '0.24.0')
-configure_file(output: 'Version.h', configuration: version_conf)
+configure_file(output: 'MPDVersion.h', configuration: version_conf)
 
 conf = configuration_data()
 conf.set_quoted('SYSTEM_CONFIG_FILE_LOCATION', join_paths(get_option('prefix'), get_option('sysconfdir'), 'mpd.conf'))

--- a/src/CommandLine.cxx
+++ b/src/CommandLine.cxx
@@ -26,7 +26,7 @@
 #include "cmdline/OptionDef.hxx"
 #include "cmdline/OptionParser.hxx"
 #include "util/Domain.hxx"
-#include "Version.h"
+#include "MPDVersion.h"
 
 #ifdef _WIN32
 #include "system/Error.hxx"

--- a/src/LogBackend.cxx
+++ b/src/LogBackend.cxx
@@ -6,7 +6,7 @@
 #include "util/Compiler.h"
 #include "util/Domain.hxx"
 #include "util/StringStrip.hxx"
-#include "Version.h"
+#include "MPDVersion.h"
 #include "config.h"
 
 #include <cassert>

--- a/src/client/New.cxx
+++ b/src/client/New.cxx
@@ -13,7 +13,7 @@
 #include "net/SocketAddress.hxx"
 #include "util/SpanCast.hxx"
 #include "Log.hxx"
-#include "Version.h"
+#include "MPDVersion.h"
 
 #include <cassert>
 

--- a/src/db/plugins/simple/DatabaseSave.cxx
+++ b/src/db/plugins/simple/DatabaseSave.cxx
@@ -12,7 +12,7 @@
 #include "tag/Settings.hxx"
 #include "fs/Charset.hxx"
 #include "util/StringCompare.hxx"
-#include "Version.h"
+#include "MPDVersion.h"
 
 #include <fmt/format.h>
 

--- a/src/decoder/plugins/MikmodDecoderPlugin.cxx
+++ b/src/decoder/plugins/MikmodDecoderPlugin.cxx
@@ -10,7 +10,7 @@
 #include "fs/Path.hxx"
 #include "util/Domain.hxx"
 #include "Log.hxx"
-#include "Version.h"
+#include "MPDVersion.h"
 
 #include <mikmod.h>
 

--- a/src/fs/glue/StandardDirectory.cxx
+++ b/src/fs/glue/StandardDirectory.cxx
@@ -40,7 +40,7 @@
 #endif
 
 #ifdef USE_XDG
-#include "Version.h" // for PACKAGE_NAME
+#include "MPDVersion.h" // for PACKAGE_NAME
 #define APP_FILENAME PATH_LITERAL(PACKAGE_NAME)
 static constexpr Path app_filename = Path::FromFS(APP_FILENAME);
 #endif

--- a/src/lib/curl/Setup.cxx
+++ b/src/lib/curl/Setup.cxx
@@ -3,7 +3,7 @@
 
 #include "Setup.hxx"
 #include "Easy.hxx"
-#include "Version.h"
+#include "MPDVersion.h"
 
 namespace Curl {
 


### PR DESCRIPTION
On macOS the compiler was not correctly choosing between the Version.h header from MPD or the version.h header in mpdclient.