### PR TITLE
build: Remove absolute path on pkg-config

### DIFF
--- a/build/pkg-config.sh
+++ b/build/pkg-config.sh
@@ -10,4 +10,4 @@ ROOT=`dirname "$BIN"`
 export PKG_CONFIG_DIR=
 export PKG_CONFIG_LIBDIR="${ROOT}/lib/pkgconfig:${ROOT}/share/pkgconfig"
 
-exec /usr/bin/pkg-config "$@"
+exec pkg-config "$@"


### PR DESCRIPTION
This allows it to be found on macOS and should fix linking libnfs with builds of the Android app