### PR TITLE
Set minimum meson_version to 0.63.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
           directory: output/full
           setup-options: -Ddocumentation=disabled -Dtest=true -Dsystemd=enabled -Dpcre=enabled
           options: --verbose
-          meson-version: 0.56.0
+          meson-version: 0.63.0
 
       - name: Unit Tests
         uses: BSFishy/meson-build@v1.0.3
@@ -106,7 +106,7 @@ jobs:
           directory: output/full
           setup-options: -Ddocumentation=disabled -Dtest=true -Dsystemd=enabled -Dpcre=enabled
           options: --verbose
-          meson-version: 0.56.0
+          meson-version: 0.63.0
 
       - name: Mini Build
         uses: BSFishy/meson-build@v1.0.3
@@ -115,7 +115,7 @@ jobs:
           directory: output/mini
           setup-options: -Dbuildtype=minsize -Dauto_features=disabled -Dtest=true -Ddaemon=false -Dinotify=false -Depoll=false -Deventfd=false -Dsignalfd=false -Dtcp=false -Ddsd=false -Ddatabase=false -Dneighbor=false -Dcue=false -Dfifo=false -Dhttpd=false -Dpipe=false -Drecorder=false -Dsnapcast=false
           options: --verbose
-          meson-version: 0.56.0
+          meson-version: 0.63.0
 
   build-macos:
     runs-on: macos-latest
@@ -161,7 +161,7 @@ jobs:
           directory: output
           setup-options: -Ddocumentation=disabled -Dtest=true
           options: --verbose
-          meson-version: 0.56.0
+          meson-version: 0.63.0
 
       - name: Unit Tests
         uses: BSFishy/meson-build@v1.0.3
@@ -170,4 +170,4 @@ jobs:
           directory: output
           setup-options: -Ddocumentation=disabled -Dtest=true
           options: --verbose
-          meson-version: 0.56.0
+          meson-version: 0.63.0

--- a/doc/user.rst
+++ b/doc/user.rst
@@ -58,7 +58,7 @@ and unpack it (or `clone the git repository
 In any case, you need:
 
 * a C++20 compiler (e.g. GCC 10 or clang 11)
-* `Meson 0.56.0 <http://mesonbuild.com/>`__ and `Ninja
+* `Meson 0.63.0 <http://mesonbuild.com/>`__ and `Ninja
   <https://ninja-build.org/>`__
 * pkg-config 
 
@@ -158,7 +158,7 @@ This section is about the latter.
 You need:
 
 * `mingw-w64 <http://mingw-w64.org/doku.php>`__
-* `Meson 0.56.0 <http://mesonbuild.com/>`__ and `Ninja
+* `Meson 0.63.0 <http://mesonbuild.com/>`__ and `Ninja
   <https://ninja-build.org/>`__
 * cmake
 * pkg-config
@@ -198,7 +198,7 @@ You need:
 
 * Android SDK (sdk platform 29, build tools 29.0.3)
 * `Android NDK r26b <https://developer.android.com/ndk/downloads>`_
-* `Meson 0.56.0 <http://mesonbuild.com/>`__ and `Ninja
+* `Meson 0.63.0 <http://mesonbuild.com/>`__ and `Ninja
   <https://ninja-build.org/>`__
 * cmake
 * pkg-config

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'mpd',
   ['c', 'cpp'],
   version: '0.24',
-  meson_version: '>= 0.56.0',
+  meson_version: '>= 0.63.0',
   default_options: [
     'c_std=c11',
     'build.c_std=c11',


### PR DESCRIPTION
Fixes following warning:
WARNING: Project specifies a minimum meson_version '>= 0.56.0' but uses features which were added in newer versions:
 * 0.63.0: {'Wrap files with diff_files'}