### PR TITLE
subprojects: properly export id3tag include headers

### DIFF
--- a/subprojects/packagefiles/id3tag/meson.build
+++ b/subprojects/packagefiles/id3tag/meson.build
@@ -1,3 +1,5 @@
+fs = import('fs')
+
 project(
   'libid3tag', 'c',
   version: '0.15.1b',
@@ -30,7 +32,10 @@ libid3tag = static_library(
   'genre.c', 'frame.c', 'crc.c', 'util.c', 'tag.c', 'file.c',
 )
 
+copy = fs.copyfile('id3tag.h', 'include/id3tag.h')
+
 libid3tag_dep = declare_dependency(
   link_with: libid3tag,
-  include_directories: include_directories('.'),
+  dependencies: [copy]
+  include_directories: include_directories('include'),
 )


### PR DESCRIPTION
According to the Makefile.am from libid3 only i3dtag.h should be installed to the include directory. include_HEADERS =	id3tag.h