### PR TITLE
doc/protocol.rst: fix time tag case

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -338,7 +338,7 @@ may contain :ref:`song tags <tags>` and other metadata, specifically:
 - ``duration``: the duration of the song in
   seconds; may contain a fractional part.
 
-- ``time``: like ``duration``,
+- ``Time``: like ``duration``,
   but as integer value.  This is deprecated and is only here
   for compatibility with older clients.  Do not use.
 


### PR DESCRIPTION
The `Time` song tag [starts with an uppercase letter](https://github.com/MusicPlayerDaemon/MPD/blob/a4c7041561fe9215a27dcb4e15bc40d1e48ef59e/src/SongPrint.cxx#L90).