### PR TITLE
android: build fixes for recent merges

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,7 +41,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_9
     }
     kotlinOptions {
-        jvmTarget = "1.9"
+        jvmTarget = "9"
     }
     packaging {
         resources {

--- a/android/app/src/main/java/org/musicpd/Receiver.java
+++ b/android/app/src/main/java/org/musicpd/Receiver.java
@@ -20,9 +20,9 @@ public class Receiver extends BroadcastReceiver {
 	@Override
 	public void onReceive(Context context, Intent intent) {
 		Log.d("Receiver", "onReceive: " + intent);
-		if (intent.getAction() == "android.intent.action.BOOT_COMPLETED") {
-			if (Settings.Preferences.getBoolean(context,
-							    Settings.Preferences.KEY_RUN_ON_BOOT,
+		if (BOOT_ACTIONS.contains(intent.getAction())) {
+			if (Preferences.getBoolean(context,
+							    Preferences.KEY_RUN_ON_BOOT,
 							    false)) {
 				final boolean wakelock =
 					Preferences.getBoolean(context,


### PR DESCRIPTION
Not really sure why but the boot change got stepped on by the other pr. 
Also fixes the jvm target since they changed the naming scheme there.