### PR TITLE
sndfile: fix compilation with clang's libc++

### DIFF
--- a/src/decoder/plugins/SndfileDecoderPlugin.cxx
+++ b/src/decoder/plugins/SndfileDecoderPlugin.cxx
@@ -212,7 +212,7 @@ sndfile_stream_decode(DecoderClient &client, InputStream &is)
 			break;
 
 		cmd = client.SubmitAudio(is,
-					 std::span{buffer, num_frames * frame_size},
+					 std::span{buffer, static_cast<size_t>(num_frames) * frame_size},
 					 0);
 		if (cmd == DecoderCommand::SEEK) {
 			sf_count_t c = client.GetSeekFrame();


### PR DESCRIPTION
error: non-constant-expression cannot be narrowed from type 'sf_count_t' (aka 'long long') to 'size_type' (aka 'unsigned int') in initializer list
 [-Wc++11-narrowing]
  215 |                      std::span{buffer, num_frames * frame_size},
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~
note: insert an explicit cast to silence this issue
  215 |                      std::span{buffer, num_frames * frame_size},
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~
      |                                        static_cast<size_type>()
