### PR TITLE
android: Check playlist state before changing track

### DIFF
--- a/src/Main.cxx
+++ b/src/Main.cxx
@@ -621,7 +621,9 @@ Java_org_musicpd_Bridge_playNext(JNIEnv *, jclass)
 	if (global_instance != nullptr)
 		BlockingCall(global_instance->event_loop, [&](){
 			for (auto &partition : global_instance->partitions)
-				partition.PlayNext();
+				if (partition.playlist.playing) {
+					partition.PlayNext();
+				}
 		});
 }
 
@@ -632,7 +634,9 @@ Java_org_musicpd_Bridge_playPrevious(JNIEnv *, jclass)
 	if (global_instance != nullptr)
 		BlockingCall(global_instance->event_loop, [&](){
 			for (auto &partition : global_instance->partitions)
-				partition.PlayPrevious();
+				if (partition.playlist.playing) {
+					partition.PlayPrevious();
+				}
 		});
 }
 


### PR DESCRIPTION
Playlist will throw an exception if we call next or previous track when it is not in the "playing" state