### PR TITLE
HTTPD output: Added support for HTTP Basic authentication

### DIFF
--- a/doc/mpdconf.example
+++ b/doc/mpdconf.example
@@ -283,6 +283,7 @@ input {
 #	bitrate		"128"			# do not define if quality is defined
 #	format		"44100:16:1"
 #	max_clients	"0"			# optional 0=no limit
+#	password		"secretPassword"	# optional, enables HTTP Basic authentication with set password
 #}
 #
 # An example of a pulseaudio output (streaming to a remote pulseaudio server)

--- a/doc/mpdconf.example
+++ b/doc/mpdconf.example
@@ -283,7 +283,7 @@ input {
 #	bitrate		"128"			# do not define if quality is defined
 #	format		"44100:16:1"
 #	max_clients	"0"			# optional 0=no limit
-#	password		"secretPassword"	# optional, enables HTTP Basic authentication with set password
+#	password		"secretPassword"	# optional, enables HTTP Basic authentication with set password (needs base64 support)
 #}
 #
 # An example of a pulseaudio output (streaming to a remote pulseaudio server)

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -1036,6 +1036,7 @@ It is highly recommended to configure a fixed format, because a stream cannot sw
      - Requires HTTP Basic authentication with set password when set to non-empty string.
        Username is ignored and can contain any printable characters except colon (':').
        Be aware that the password is transmitted over unencrypted connection only base64 encoded, and is therefore visible to anyone listening to your traffic.
+       Requires base64 support.
 
 
 The `name` from the `audio_output` block that uses this output plugin will be reflected as the stream name in the `icy-name` header of the stream.

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -1032,6 +1032,11 @@ It is highly recommended to configure a fixed format, because a stream cannot sw
      - The genre of the stream. Will be reflected in the `icy-genre` header of the stream.
    * - **website URL**
      - The website of the stream. Will be reflected in the `icy-url` header of the stream.
+   * - **password passwd**
+     - Requires HTTP Basic authentication with set password when set to non-empty string.
+       Username is ignored and can contain any printable characters except colon (':').
+       Be aware that the password is transmitted over unencrypted connection only base64 encoded, and is therefore visible to anyone listening to your traffic.
+
 
 The `name` from the `audio_output` block that uses this output plugin will be reflected as the stream name in the `icy-name` header of the stream.
 

--- a/src/output/plugins/httpd/HttpdClient.cxx
+++ b/src/output/plugins/httpd/HttpdClient.cxx
@@ -8,7 +8,6 @@
 #include "util/AllocatedString.hxx"
 #include "Page.hxx"
 #include "IcyMetaDataServer.hxx"
-#include "lib/crypto/Base64.hxx"
 #include "net/SocketError.hxx"
 #include "net/UniqueSocketDescriptor.hxx"
 #include "util/SpanCast.hxx"
@@ -24,7 +23,6 @@
 #ifdef HAVE_BASE64
 #include "lib/crypto/Base64.hxx"
 #endif
-
 
 HttpdClient::~HttpdClient() noexcept
 {
@@ -115,14 +113,13 @@ HttpdClient::HandleLine(const char *line) noexcept
 			return true;
 		}
 
-
-		#ifdef HAVE_BASE64
+#ifdef HAVE_BASE64
 		if (const char *b64 = StringAfterPrefixIgnoreCase(line, "Authorization: Basic ")) {
 			auto decodedBytes = DecodeBase64(b64);
 			auto [username, pw] = Split(ToStringView(decodedBytes), ':');
 			provided_password = std::string{pw};
 		}
-		#endif
+#endif
 
 		if (StringEqualsCaseASCII(line, "Icy-MetaData: 1", 15) ||
 		    StringEqualsCaseASCII(line, "Icy-MetaData:1", 14)) {
@@ -200,8 +197,7 @@ HttpdClient::HttpdClient(HttpdOutput &_httpd, UniqueSocketDescriptor _fd,
 			 bool _metadata_supported)
 	:BufferedSocket(_fd.Release(), _loop),
 	 httpd(_httpd),
-	 metadata_supported(_metadata_supported),
-	 provided_password{""}
+	 metadata_supported(_metadata_supported)
 {
 }
 

--- a/src/output/plugins/httpd/HttpdClient.hxx
+++ b/src/output/plugins/httpd/HttpdClient.hxx
@@ -4,6 +4,7 @@
 #ifndef MPD_OUTPUT_HTTPD_CLIENT_HXX
 #define MPD_OUTPUT_HTTPD_CLIENT_HXX
 
+#include "config.h"
 #include "Page.hxx"
 #include "event/BufferedSocket.hxx"
 #include "util/IntrusiveList.hxx"
@@ -120,7 +121,9 @@ class HttpdClient final
 	/**
 	 * Provided password (using HTTP basic auth)
 	 */
+#ifdef HAVE_BASE64
 	std::string provided_password;
+#endif
 
 public:
 	/**

--- a/src/output/plugins/httpd/HttpdClient.hxx
+++ b/src/output/plugins/httpd/HttpdClient.hxx
@@ -69,6 +69,12 @@ class HttpdClient final
 	 */
 	bool should_reject = false;
 
+	/**
+	 * Should we reject this request as unauthorized?
+	 */
+	bool should_reject_unauthorized = false;
+
+
 	/* ICY */
 
 	/**
@@ -110,6 +116,11 @@ class HttpdClient final
 	 * since the last icy information was sent.
 	 */
 	unsigned metadata_fill = 0;
+
+	/**
+	 * Provided password (using HTTP basic auth)
+	 */
+	std::string provided_password;
 
 public:
 	/**

--- a/src/output/plugins/httpd/HttpdInternal.hxx
+++ b/src/output/plugins/httpd/HttpdInternal.hxx
@@ -118,8 +118,7 @@ private:
 	/**
 	 * The configured password.
 	 */
-	char const *password;
-
+	char const *const password;
 
 private:
 	/**

--- a/src/output/plugins/httpd/HttpdInternal.hxx
+++ b/src/output/plugins/httpd/HttpdInternal.hxx
@@ -115,6 +115,12 @@ private:
 	 */
 	char const *const website;
 
+	/**
+	 * The configured password.
+	 */
+	char const *password;
+
+
 private:
 	/**
 	 * A linked list containing all clients which are currently

--- a/src/output/plugins/httpd/HttpdInternal.hxx
+++ b/src/output/plugins/httpd/HttpdInternal.hxx
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "config.h"
 #include "HttpdClient.hxx"
 #include "output/Interface.hxx"
 #include "output/Timer.hxx"
@@ -118,7 +119,9 @@ private:
 	/**
 	 * The configured password.
 	 */
+#ifdef HAVE_BASE64
 	char const *const password;
+#endif
 
 private:
 	/**

--- a/src/output/plugins/httpd/HttpdOutputPlugin.cxx
+++ b/src/output/plugins/httpd/HttpdOutputPlugin.cxx
@@ -44,6 +44,8 @@ HttpdOutput::HttpdOutput(EventLoop &_loop, const ConfigBlock &block)
 			ServerSocket::SetDscpClass(value);
 		});
 
+	password = block.GetBlockValue("password");
+
 	/* set up bind_to_address */
 
 	ServerSocketAddGeneric(*this, block.GetBlockValue("bind_to_address"), block.GetBlockValue("port", 8000U));

--- a/src/output/plugins/httpd/HttpdOutputPlugin.cxx
+++ b/src/output/plugins/httpd/HttpdOutputPlugin.cxx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright The Music Player Daemon Project
 
+#include "config.h"
 #include "HttpdOutputPlugin.hxx"
 #include "HttpdInternal.hxx"
 #include "HttpdClient.hxx"
@@ -33,8 +34,10 @@ HttpdOutput::HttpdOutput(EventLoop &_loop, const ConfigBlock &block)
 	 name(block.GetBlockValue("name", "Set name in config")),
 	 genre(block.GetBlockValue("genre", "Set genre in config")),
 	 website(block.GetBlockValue("website", "Set website in config")),
-	 clients_max(block.GetBlockValue("max_clients", 0U)),
-	 password(block.GetBlockValue("password"))
+#ifdef HAVE_BASE64
+	 password(block.GetBlockValue("password")),
+#endif
+	 clients_max(block.GetBlockValue("max_clients", 0U))
 {
 	if (const auto *p = block.GetBlockParam("dscp_class"))
 		p->With([this](const char *s){

--- a/src/output/plugins/httpd/HttpdOutputPlugin.cxx
+++ b/src/output/plugins/httpd/HttpdOutputPlugin.cxx
@@ -33,7 +33,8 @@ HttpdOutput::HttpdOutput(EventLoop &_loop, const ConfigBlock &block)
 	 name(block.GetBlockValue("name", "Set name in config")),
 	 genre(block.GetBlockValue("genre", "Set genre in config")),
 	 website(block.GetBlockValue("website", "Set website in config")),
-	 clients_max(block.GetBlockValue("max_clients", 0U))
+	 clients_max(block.GetBlockValue("max_clients", 0U)),
+	 password(block.GetBlockValue("password"))
 {
 	if (const auto *p = block.GetBlockParam("dscp_class"))
 		p->With([this](const char *s){
@@ -43,8 +44,6 @@ HttpdOutput::HttpdOutput(EventLoop &_loop, const ConfigBlock &block)
 
 			ServerSocket::SetDscpClass(value);
 		});
-
-	password = block.GetBlockValue("password");
 
 	/* set up bind_to_address */
 

--- a/src/output/plugins/meson.build
+++ b/src/output/plugins/meson.build
@@ -36,7 +36,7 @@ if get_option('httpd')
     'httpd/HttpdClient.cxx',
     'httpd/HttpdOutputPlugin.cxx',
   ]
-  output_plugins_deps += [ event_dep, net_dep ]
+  output_plugins_deps += [ event_dep, net_dep, crypto_base64_dep ]
   need_encoder = true
 endif
 


### PR DESCRIPTION
I want to have a publicly available streaming MPD server available from internet. However I want to protect the output with password - if not for anything else then for legal reasons (the moment someone other than me opens the stream I break the law).

This adds new optional "password" option for "httpd" output in mpd.conf. If it is specified and non-empty, it requires HTTP Basic authentication with arbitrary user and set password.

(It's been some time since I've wrote anything in C++, so please check the code if I haven't made any stupid mistakes. I've tested it and it seems to be working as intended in both cases.)