### PR TITLE
android: Github actions build fixes.

### DIFF
--- a/android/build.py
+++ b/android/build.py
@@ -13,7 +13,7 @@ ndk_path = sys.argv[2]
 android_abi = sys.argv[3]
 configure_args = sys.argv[4:]
 
-if not os.path.isfile(os.path.join(sdk_path, 'tools', 'android')):
+if not os.path.isfile(os.path.join(sdk_path, 'licenses', 'android-sdk-license')):
     print("SDK not found in", sdk_path, file=sys.stderr)
     sys.exit(1)
 

--- a/android/meson.build
+++ b/android/meson.build
@@ -5,8 +5,8 @@ android_ndk = get_option('android_ndk')
 android_sdk = get_option('android_sdk')
 android_abi = get_option('android_abi')
 
-android_sdk_build_tools_version = '29.0.3'
-android_sdk_platform = 'android-29'
+android_sdk_build_tools_version = '34.0.0'
+android_sdk_platform = 'android-34'
 
 android_build_tools_dir = join_paths(android_sdk, 'build-tools', android_sdk_build_tools_version)
 android_sdk_platform_dir = join_paths(android_sdk, 'platforms', android_sdk_platform)

--- a/doc/user.rst
+++ b/doc/user.rst
@@ -196,7 +196,7 @@ Compiling for Android
 
 You need:
 
-* Android SDK (sdk platform 29, build tools 29.0.3)
+* Android SDK (sdk platform 34, build tools 34.0.0)
 * `Android NDK r26b <https://developer.android.com/ndk/downloads>`_
 * `Meson 0.56.0 <http://mesonbuild.com/>`__ and `Ninja
   <https://ninja-build.org/>`__


### PR DESCRIPTION
The `android` command was depricated and has been removed from new installs of the sdk
The license file existing is about all that is stable between different sdk versions and cli vs Android studio installs.

This also bumps the SDK version used to build the bridge header to 34 since we're already using that to build the app and  Github actions doesn't include 29 by default anymore.