### PR TITLE
CommandLine: fix typo

### DIFF
--- a/src/CommandLine.cxx
+++ b/src/CommandLine.cxx
@@ -137,7 +137,7 @@ static void version()
 
 	fmt::print("\n"
 		   "\n"
-		   "Decoders plugins:\n");
+		   "Decoder plugins:\n");
 
 	decoder_plugins_for_each([](const DecoderPlugin &plugin){
 		fmt::print(" [{}]", plugin.name);


### PR DESCRIPTION
I believe this is a typo since all other sections have the form "<Singular> plugins", e.g. "Encoder plugins".