### PR TITLE
Clarifications on client-to-client and idle commands 

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -447,7 +447,8 @@ Querying :program:`MPD`'s status
     - ``partition``: a partition was added, removed or changed
     - ``sticker``: the sticker database has been modified.
     - ``subscription``: a client has subscribed or unsubscribed to a channel
-    - ``message``: a message was received on a channel this client is subscribed to; this event is only emitted when the queue is empty
+    - ``message``: a message was received on a channel this client is subscribed to;
+      this event is only emitted when the client's message queue is empty
     - ``neighbor``: a neighbor was found or lost
     - ``mount``: the mount list has changed
 


### PR DESCRIPTION
- Document client-to-client message limits (client can subscribe to 16 channels max; client can have 64 unread messages max).
- Add note about handling idle events with care when using client-to-client messages to not miss the `message` idle event (see also commit message of 8fe563422fddcc7d41c979d07495dc98b2bdfa06 for a possible scenario).
- Add note about possibility of missing idle events of other subsystems when idling on particular subsystem(s).
- Clarify `message` idle event description.