### PR TITLE
Extend robustness of cdda playback

### DIFF
--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -224,7 +224,10 @@ input_cdio_open(const char *uri,
 	if (speed > 0) {
 		FmtDebug(cdio_domain, "Attempting to set CD speed to {}x",
 			 speed);
-		cdio_cddap_speed_set(drv,speed);
+		/* Negative value indicate error (e.g. -405: not supported) */
+		if (cdio_cddap_speed_set(drv,speed) < 0)
+			FmtDebug(cdio_domain, "Failed to set CD speed to {}x",
+				 speed);
 	}
 
 	bool reverse_endian;

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -257,11 +257,11 @@ input_cdio_open(const char *uri,
 
 	lsn_t lsn_from, lsn_to;
 	if (parsed_uri.track >= 0) {
-		lsn_from = cdio_get_track_lsn(cdio, parsed_uri.track);
-		lsn_to = cdio_get_track_last_lsn(cdio, parsed_uri.track);
+		lsn_from = cdio_cddap_track_firstsector(drv, parsed_uri.track);
+		lsn_to = cdio_cddap_track_lastsector(drv, parsed_uri.track);
 	} else {
-		lsn_from = 0;
-		lsn_to = cdio_get_disc_last_lsn(cdio);
+		lsn_from = cdio_cddap_disc_firstsector(drv);
+		lsn_to = cdio_cddap_disc_lastsector(drv);
 	}
 
 	return std::make_unique<CdioParanoiaInputStream>(uri, mutex,

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -264,6 +264,16 @@ input_cdio_open(const char *uri,
 		lsn_to = cdio_cddap_disc_lastsector(drv);
 	}
 
+	/* LSNs < 0 indicate errors (e.g. -401: Invaid track, -402: no pregap) */
+	if(lsn_from < 0 || lsn_to < 0)
+		throw FmtRuntimeError("Error {} on track {}",
+				      lsn_from < 0 ? lsn_from : lsn_to, parsed_uri.track);
+
+	/* Only check for audio track if not pregap or whole CD */
+	if (!cdio_cddap_track_audiop(drv, parsed_uri.track) && parsed_uri.track > 0)
+		throw FmtRuntimeError("No audio track: {}",
+				      parsed_uri.track);
+
 	return std::make_unique<CdioParanoiaInputStream>(uri, mutex,
 							 drv, cdio,
 							 reverse_endian,

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -214,16 +214,17 @@ input_cdio_open(const char *uri,
 	}
 
 	cdio_cddap_verbose_set(drv, CDDA_MESSAGE_FORGETIT, CDDA_MESSAGE_FORGETIT);
-	if (speed > 0) {
-		FmtDebug(cdio_domain, "Attempting to set CD speed to {}x",
-			 speed);
-		cdio_cddap_speed_set(drv,speed);
-	}
 
 	if (0 != cdio_cddap_open(drv)) {
 		cdio_cddap_close_no_free_cdio(drv);
 		cdio_destroy(cdio);
 		throw std::runtime_error("Unable to open disc.");
+	}
+
+	if (speed > 0) {
+		FmtDebug(cdio_domain, "Attempting to set CD speed to {}x",
+			 speed);
+		cdio_cddap_speed_set(drv,speed);
 	}
 
 	bool reverse_endian;


### PR DESCRIPTION
This PR tries to address some CDDA playback issues.

**Changes:**
1. Moved speed adjutment after `cdio_cddap_open` as done in cd-paranoia (this seems to prevent errors on speed adjustment)
2. Use sector functions from libcdio-paranoia (`cdio_cddap_*`) to detect sectors (this seems to increase the robustness on special cases like hidden tracks or multisession CDs)
3. Added checks for errors on lsns and non audio tracks

**Improvments:**
* playback of hidden audio tracks (track 0) if present
* complete playback of last track on cd-extra CDs (multisession CDs)
* skipping of tracks on errors like no hidden track, out of range (> num-tracks) or non audio tracks