### PR TITLE
event/TimerList: Add custom compare for android

### DIFF
--- a/src/event/TimerList.hxx
+++ b/src/event/TimerList.hxx
@@ -4,11 +4,22 @@
 
 #pragma once
 
+#include <compare>
+
 #include "Chrono.hxx"
 #include "event/Features.h"
 #include "util/IntrusiveTreeSet.hxx"
 
 class FineTimerEvent;
+
+struct custom_compare {
+  auto operator()(const std::chrono::steady_clock::time_point& lhs,
+                  const std::chrono::steady_clock::time_point& rhs) const {
+    return lhs < rhs ? std::strong_ordering::less
+           : lhs == rhs ? std::strong_ordering::equal
+                        : std::strong_ordering::greater;
+  }
+};
 
 /**
  * A list of #FineTimerEvent instances sorted by due time point.
@@ -19,7 +30,7 @@ class TimerList final {
 	};
 
 	IntrusiveTreeSet<FineTimerEvent,
-			 IntrusiveTreeSetOperators<FineTimerEvent, GetDue>> timers;
+			 IntrusiveTreeSetOperators<FineTimerEvent, GetDue, custom_compare>> timers;
 
 public:
 	TimerList();


### PR DESCRIPTION
NDK doesn't seem to support using std::compare_three_way for time_point so this implements that.