### PR TITLE
Make suffixes functions ignore case

### DIFF
--- a/src/decoder/DecoderPlugin.hxx
+++ b/src/decoder/DecoderPlugin.hxx
@@ -4,6 +4,8 @@
 #ifndef MPD_DECODER_PLUGIN_HXX
 #define MPD_DECODER_PLUGIN_HXX
 
+#include "util/StringUtil.hxx"
+
 #include <forward_list>  // IWYU pragma: export
 #include <set>
 #include <string>
@@ -17,6 +19,8 @@ class DecoderClient;
 class DetachedSong;
 
 struct DecoderPlugin {
+	using SuffixSet = std::set<std::string, IgnoreCaseComparator>;
+
 	const char *name;
 
 	/**
@@ -40,7 +44,7 @@ struct DecoderPlugin {
 	 * instead of #suffixes if the supported suffixes can only be
 	 * determined at runtime.
 	 */
-	std::set<std::string, std::less<>> (*suffixes_function)() noexcept = nullptr;
+	SuffixSet (*suffixes_function)() noexcept = nullptr;
 
 	/**
 	 * Return a set of supported protocols.
@@ -159,7 +163,7 @@ struct DecoderPlugin {
 		return copy;
 	}
 
-	constexpr auto WithSuffixes(std::set<std::string, std::less<>> (*_suffixes)() noexcept) const noexcept {
+	constexpr auto WithSuffixes(SuffixSet (*_suffixes)() noexcept) const noexcept {
 		auto copy = *this;
 		copy.suffixes_function = _suffixes;
 		return copy;

--- a/src/decoder/plugins/FfmpegDecoderPlugin.cxx
+++ b/src/decoder/plugins/FfmpegDecoderPlugin.cxx
@@ -692,10 +692,10 @@ ffmpeg_protocols() noexcept
 	return protocols;
 }
 
-static std::set<std::string, std::less<>>
+static DecoderPlugin::SuffixSet
 ffmpeg_suffixes() noexcept
 {
-	std::set<std::string, std::less<>> suffixes;
+	DecoderPlugin::SuffixSet suffixes;
 
 	void *demuxer_opaque = nullptr;
 	while (const auto input_format = av_demuxer_iterate(&demuxer_opaque)) {

--- a/src/util/StringUtil.hxx
+++ b/src/util/StringUtil.hxx
@@ -4,6 +4,7 @@
 #ifndef STRING_UTIL_HXX
 #define STRING_UTIL_HXX
 
+#include <cctype>
 #include <cstddef>
 #include <string_view>
 
@@ -27,5 +28,23 @@ StringArrayContainsCase(const char *const*haystack,
  */
 void
 ToUpperASCII(char *dest, const char *src, size_t size) noexcept;
+
+/**
+ * Comparator that does case-insensitive comparisons.
+ * Used for comparing suffixes/extensions so that
+ * e.g. .mp3 and .MP3 are treated the same.
+*/
+struct IgnoreCaseComparator {
+	using is_transparent = void;
+
+	bool operator()(std::string_view a, std::string_view b) const {
+		return std::lexicographical_compare(a.begin(), a.end(),
+			b.begin(), b.end(),
+			[](char left, char right) {
+				return std::tolower(left) < std::tolower(right);
+			}
+		);
+	}
+};
 
 #endif


### PR DESCRIPTION
Previously, when using a suffixes function in a decoder plugin, suffixes were directly compared in a case-sensitive manner, so a file ending in e.g. .mp3 would not be treated the same as .MP3, and then no decoder plugin might be found for the .MP3 file.

This commit introduces a comparator that makes comparisons ignore case by always lowering the case on both inputs.

The long and tiring std::set<std::string, std::less<>> is replaced with DecoderPlugin::SuffixSet so suffixes functions no longer have to depend on an arbitrary type that may change in the future, and can from now on use this abstraction.

Credit for the comparator goes to:
Kevin "Alipha" Spinar, from #C++ on libera.chat