### PR TITLE
android: null check intent in onStartCommand

### DIFF
--- a/android/app/src/main/java/org/musicpd/Main.java
+++ b/android/app/src/main/java/org/musicpd/Main.java
@@ -133,11 +133,11 @@ public class Main extends Service implements Runnable {
 
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
-		if (Objects.equals(intent.getAction(), SHUTDOWN_ACTION)) {
+		if (intent != null && Objects.equals(intent.getAction(), SHUTDOWN_ACTION)) {
 			stop();
 		} else {
 			start();
-			if (intent.getBooleanExtra("wakelock", false))
+			if (intent != null && intent.getBooleanExtra("wakelock", false))
 				setWakelockEnabled(true);
 		}
 		return START_STICKY;


### PR DESCRIPTION
For some reason the type annotations here show @NonNull but that is actually false according to the documentation under service.

This may be null if the service is being restarted after its process has gone away, and it had previously returned anything except START_STICKY_COMPATIBILITY.