### PR TITLE
doc: debian build, add pkconf build dep.

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -70,7 +70,7 @@ dependencies on Debian Bookworm:
 
 .. code-block:: none
 
-    apt install meson g++ \
+    apt install meson g++ pkgconf \
       libfmt-dev \
       libpcre2-dev \
       libmad0-dev libmpg123-dev libid3tag0-dev \


### PR DESCRIPTION
Build dep on pkconf is not explicitly needed because other dependencies pull pkconf indirectly (ie libid3tag0-dev), but explicit declaration of a direct MPD build dep is better IMHO.