### PR TITLE
Fix bin install location on linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -601,7 +601,7 @@ if is_android
 else
   target_type = 'executable'
   target_name = 'mpd'
-  install_dir = ''
+  install_dir = get_option('bindir')
 endif
 
 mpd = build_target(


### PR DESCRIPTION
Fix bin install location on linux.
For Linux, Meson's default value for bindir is 'bin' [1].
This commit restores mpd's previous functionality of installation in ${prefix}/bin.

[1] https://mesonbuild.com/Builtin-options.html

Fixes #2043 