### PR TITLE
lib/fmt: support build with libfmt-11.0.0

### DIFF
--- a/src/lib/ffmpeg/LibFmt.hxx
+++ b/src/lib/ffmpeg/LibFmt.hxx
@@ -13,7 +13,7 @@ template<>
 struct fmt::formatter<AVSampleFormat> : formatter<string_view>
 {
 	template<typename FormatContext>
-	auto format(const AVSampleFormat format, FormatContext &ctx) {
+	auto format(const AVSampleFormat format, FormatContext &ctx) const {
 		const char *name = av_get_sample_fmt_name(format);
 		if (name == nullptr)
 			name = "?";

--- a/src/lib/fmt/AudioFormatFormatter.hxx
+++ b/src/lib/fmt/AudioFormatFormatter.hxx
@@ -13,7 +13,7 @@ template<>
 struct fmt::formatter<SampleFormat> : formatter<string_view>
 {
 	template<typename FormatContext>
-	auto format(const SampleFormat format, FormatContext &ctx) {
+	auto format(const SampleFormat format, FormatContext &ctx) const {
 		return formatter<string_view>::format(sample_format_to_string(format),
 						      ctx);
 	}
@@ -23,7 +23,7 @@ template<>
 struct fmt::formatter<AudioFormat> : formatter<string_view>
 {
 	template<typename FormatContext>
-	auto format(const AudioFormat &af, FormatContext &ctx) {
+	auto format(const AudioFormat &af, FormatContext &ctx) const {
 		return formatter<string_view>::format(ToString(af).c_str(),
 						      ctx);
 	}

--- a/src/lib/fmt/ExceptionFormatter.hxx
+++ b/src/lib/fmt/ExceptionFormatter.hxx
@@ -12,7 +12,7 @@ template<>
 struct fmt::formatter<std::exception_ptr> : formatter<string_view>
 {
 	template<typename FormatContext>
-	auto format(std::exception_ptr e, FormatContext &ctx) {
+	auto format(std::exception_ptr e, FormatContext &ctx) const {
 		return formatter<string_view>::format(GetFullMessage(e), ctx);
 	}
 };

--- a/src/lib/fmt/PathFormatter.hxx
+++ b/src/lib/fmt/PathFormatter.hxx
@@ -13,7 +13,7 @@ template<std::convertible_to<Path> T>
 struct fmt::formatter<T> : formatter<string_view>
 {
 	template<typename FormatContext>
-	auto format(Path path, FormatContext &ctx) {
+	auto format(Path path, FormatContext &ctx) const {
 		return formatter<string_view>::format(path.ToUTF8(), ctx);
 	}
 };


### PR DESCRIPTION
Upstream libfmt commit fmtlib/fmt@d707292
now requires the format function to be const.

Adjust the function prototype so it is const and can compile.

- fixes #2068 

tested with both libfmt-10.2.1 and libfmt-11.0.0