### PR TITLE
add -k alias for --kill

### DIFF
--- a/src/CommandLine.cxx
+++ b/src/CommandLine.cxx
@@ -84,7 +84,7 @@ enum Option {
 };
 
 static constexpr OptionDef option_defs[] = {
-	{"kill", "kill the currently running mpd session"},
+	{"kill", 'k', "kill the currently running mpd session"},
 	{"no-config", "don't read from config"},
 	{"no-daemon", "don't detach from console"},
 #ifdef __linux__


### PR DESCRIPTION
In my opinion, this flag make sense and is present in other daemons' kill functions. The largest example that comes to mind is pulse. 
Plus it's shorter to type -k than --kill, which is something I type more often than --verbose or --no-daemon for example. 