### PR TITLE
Dynamically update remote stream tags by merge instead of replace - i…

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -957,6 +957,10 @@ Whenever possible, ids should be used.
     the server, and the data is gone when the song gets
     removed from the queue.
 
+    Tags received from the server are merged [#since_0_24]_, i.e.
+    only received tags are overwritten, but other tags are not affected
+    (previously they were removed).
+
 .. _command_cleartagid:
 
 :command:`cleartagid {SONGID} [TAG]`

--- a/src/player/Thread.cxx
+++ b/src/player/Thread.cxx
@@ -904,7 +904,7 @@ PlayerControl::LockUpdateSongTag(DetachedSong &song,
 		   streams may change tags dynamically */
 		return;
 
-	song.SetTag(new_tag);
+	song.MergeTag(new_tag);
 
 	LockSetTaggedSong(song);
 

--- a/src/song/DetachedSong.hxx
+++ b/src/song/DetachedSong.hxx
@@ -204,6 +204,10 @@ public:
 		tag = std::move(other.tag);
 	}
 
+	void MergeTag(const Tag &_tag) noexcept {
+		tag = Tag::Merge(tag, _tag);
+	}
+
 	/**
 	 * Similar to the MoveTagFrom(), but move only the #TagItem
 	 * array.


### PR DESCRIPTION
…ssue #1400

Clients can use addtagid to set tags for remote streams. For example a radio station genre. Then when the song title is updated from the remote stream, only the title is updated but other tags are preserved.