### PR TITLE
Determine mp3 duration on stream size if size unknown.

### DIFF
--- a/src/decoder/plugins/Mpg123DecoderPlugin.cxx
+++ b/src/decoder/plugins/Mpg123DecoderPlugin.cxx
@@ -353,6 +353,10 @@ mpd_mpg123_stream_decode(DecoderClient &client, InputStream &is)
 	};
 
 	mpd_mpg123_open_stream(*handle, iohandle);
+
+	if (is.KnownSize())
+	    mpg123_set_filesize(handle, is.GetSize());
+
 	Decode(client, *handle, is.IsSeekable());
 }
 


### PR DESCRIPTION
For certain mp3 streams mpg123 is unable to calculate the duration of a song resulting in `0:00`. If the size of the stream is known we can pass that to mpg123.  

The line:
https://github.com/MusicPlayerDaemon/MPD/blob/f7790430a0323eadaaa8e0dacce24dda7331d583/src/decoder/plugins/Mpg123DecoderPlugin.cxx#L250 still (correctly) overrides the duration if is has the the right information.

[Documentation for mpg123_set_filesize](https://www.mpg123.de/api/group__mpg123__status.shtml#gad0301e80dbc3f48e47e27d39cd328755)
> Override the value for file size in bytes. Useful for getting sensible track length values in feed mode or for HTTP streams.
