### PR TITLE
Store last loaded playlist

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -544,6 +544,7 @@ Querying :program:`MPD`'s status
       :ref:`audio_output_format` for a detailed explanation.
     - ``updating_db``: ``job id``
     - ``error``: if there is an error, returns message here
+    - ``lastloadedplaylist``: last loaded stored playlist [#since_0_24]_
 
     :program:`MPD` may omit lines which have no (known) value.  Older
     :program:`MPD` versions used to have a "magic" value for

--- a/src/command/PlayerCommands.cxx
+++ b/src/command/PlayerCommands.cxx
@@ -44,6 +44,7 @@
 #define COMMAND_STATUS_MIXRAMPDELAY	"mixrampdelay"
 #define COMMAND_STATUS_AUDIO		"audio"
 #define COMMAND_STATUS_UPDATING_DB	"updating_db"
+#define COMMAND_STATUS_LOADED_PLAYLIST  "lastloadedplaylist"
 
 CommandResult
 handle_play(Client &client, Request args, [[maybe_unused]] Response &r)
@@ -128,7 +129,8 @@ handle_status(Client &client, [[maybe_unused]] Request args, Response &r)
 			 COMMAND_STATUS_PLAYLIST ": {}\n"
 			 COMMAND_STATUS_PLAYLIST_LENGTH ": {}\n"
 			 COMMAND_STATUS_MIXRAMPDB ": {}\n"
-			 COMMAND_STATUS_STATE ": {}\n"),
+			 COMMAND_STATUS_STATE ": {}\n"
+			 COMMAND_STATUS_LOADED_PLAYLIST ": {}\n"),
 	      (unsigned)playlist.GetRepeat(),
 	      (unsigned)playlist.GetRandom(),
 	      SingleToString(playlist.GetSingle()),
@@ -137,7 +139,8 @@ handle_status(Client &client, [[maybe_unused]] Request args, Response &r)
 	      playlist.GetVersion(),
 	      playlist.GetLength(),
 	      pc.GetMixRampDb(),
-	      state);
+	      state,
+	      playlist.GetLastLoadedPlaylist());
 
 	if (pc.GetCrossFade() > FloatDuration::zero())
 		r.Fmt(FMT_STRING(COMMAND_STATUS_CROSSFADE ": {}\n"),

--- a/src/playlist/PlaylistQueue.cxx
+++ b/src/playlist/PlaylistQueue.cxx
@@ -55,6 +55,7 @@ playlist_load_into_queue(const char *uri, SongEnumerator &e,
 
 		dest.AppendSong(pc, std::move(*song));
 	}
+	dest.SetLastLoadedPlaylist(uri);
 }
 
 void

--- a/src/queue/Playlist.hxx
+++ b/src/queue/Playlist.hxx
@@ -102,6 +102,14 @@ struct playlist {
 	[[gnu::pure]]
 	int GetNextPosition() const noexcept;
 
+	const std::string_view GetLastLoadedPlaylist() const noexcept {
+		return queue.last_loaded_playlist;
+	}
+
+	void SetLastLoadedPlaylist(const char *playlist_name) noexcept {
+		queue.last_loaded_playlist = playlist_name;
+	}
+
 	/**
 	 * Returns the song object which is currently queued.  Returns
 	 * none if there is none (yet?) or if MPD isn't playing.

--- a/src/queue/PlaylistState.cxx
+++ b/src/queue/PlaylistState.cxx
@@ -36,6 +36,7 @@
 #define PLAYLIST_STATE_FILE_CROSSFADE		"crossfade: "
 #define PLAYLIST_STATE_FILE_MIXRAMPDB		"mixrampdb: "
 #define PLAYLIST_STATE_FILE_MIXRAMPDELAY	"mixrampdelay: "
+#define PLAYLIST_STATE_FILE_LOADED_PLAYLIST	"lastloadedplaylist: "
 #define PLAYLIST_STATE_FILE_PLAYLIST_BEGIN	"playlist_begin"
 #define PLAYLIST_STATE_FILE_PLAYLIST_END	"playlist_end"
 
@@ -85,6 +86,8 @@ playlist_state_save(BufferedOutputStream &os, const struct playlist &playlist,
 	       pc.GetMixRampDb());
 	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_MIXRAMPDELAY "{}\n"),
 	       pc.GetMixRampDelay().count());
+	os.Fmt(FMT_STRING(PLAYLIST_STATE_FILE_LOADED_PLAYLIST "{}\n"),
+	       playlist.GetLastLoadedPlaylist());
 	os.Write(PLAYLIST_STATE_FILE_PLAYLIST_BEGIN "\n");
 	queue_save(os, playlist.queue);
 	os.Write(PLAYLIST_STATE_FILE_PLAYLIST_END "\n");
@@ -156,6 +159,8 @@ playlist_state_restore(const StateFileConfig &config,
 			   prior to MPD 0.18 */
 			if (IsDigitASCII(*p))
 				pc.SetMixRampDelay(FloatDuration(ParseFloat(p)));
+		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_LOADED_PLAYLIST))) {
+			playlist.SetLastLoadedPlaylist(p);
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_RANDOM))) {
 			random_mode = StringIsEqual(p, "1");
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_CURRENT))) {

--- a/src/queue/Queue.cxx
+++ b/src/queue/Queue.cxx
@@ -270,6 +270,7 @@ Queue::Clear() noexcept
 	}
 
 	length = 0;
+	last_loaded_playlist.clear();
 }
 
 static void

--- a/src/queue/Queue.hxx
+++ b/src/queue/Queue.hxx
@@ -85,6 +85,9 @@ struct Queue {
 	/** play back songs in random order? */
 	bool random = false;
 
+	/** Last loaded playlist */
+	std::string last_loaded_playlist;
+
 	/** random number generator for shuffle and random mode */
 	LazyRandomEngine rand;
 


### PR DESCRIPTION
Stores the last loaded playlist uri in the queue struct. Last loaded playlist is set on load command and cleared with the clear command. The last loaded playlist is printed in the status command and saved / restored from the partition state file.

Resolves issue #938