### PR TITLE
Add config option to disable the listing of playlists in the root folder for the lsinfo command.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -67,6 +67,7 @@ ver 0.24 (not yet released)
 * require libfmt 9 or later
 * documentation: switch to sphinx-rtd-theme
 * require Meson 1.0
+* option to disable listing of playlists with lsinfo in the root folder
 
 ver 0.23.15 (2023/12/20)
 * decoder

--- a/doc/mpd.conf.5.rst
+++ b/doc/mpd.conf.5.rst
@@ -139,6 +139,10 @@ save_absolute_paths_in_playlists <yes or no>
   This specifies whether relative or absolute paths for song filenames are used
   when saving playlists. The default is "no".
 
+list_playlists_in_root <yes or no>
+  This specifies whether the lsinfo command should list playlists for the root
+  folder.
+
 auto_update <yes or no>
   This specifies the whether to support automatic update of music database
   when files are changed in music_directory. The default is to disable

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1261,7 +1261,8 @@ The music database
 
     When listing the root directory, this currently returns
     the list of stored playlists.  This behavior is
-    deprecated; use "listplaylists" instead.
+    deprecated; use "listplaylists" instead. This behavior can be
+    disabled with the config option ``list_playlists_in_root``.
 
     This command may be used to list metadata of remote
     files (e.g. URI beginning with "http://" or "smb://").

--- a/src/PlaylistFile.cxx
+++ b/src/PlaylistFile.cxx
@@ -35,6 +35,7 @@ static const char PLAYLIST_COMMENT = '#';
 
 static unsigned playlist_max_length;
 bool playlist_saveAbsolutePaths = DEFAULT_PLAYLIST_SAVE_ABSOLUTE_PATHS;
+bool list_playlists_in_root = DEFAULT_LIST_PLAYLISTS_IN_ROOT;
 
 void
 spl_global_init(const ConfigData &config)
@@ -46,6 +47,10 @@ spl_global_init(const ConfigData &config)
 	playlist_saveAbsolutePaths =
 		config.GetBool(ConfigOption::SAVE_ABSOLUTE_PATHS,
 			       DEFAULT_PLAYLIST_SAVE_ABSOLUTE_PATHS);
+
+	list_playlists_in_root =
+		config.GetBool(ConfigOption::LIST_PLAYLISTS_IN_ROOT,
+			       DEFAULT_LIST_PLAYLISTS_IN_ROOT);
 }
 
 bool

--- a/src/PlaylistFile.hxx
+++ b/src/PlaylistFile.hxx
@@ -18,6 +18,7 @@ class PlaylistVector;
 typedef std::vector<std::string> PlaylistFileContents;
 
 extern bool playlist_saveAbsolutePaths;
+extern bool list_playlists_in_root;
 
 class PlaylistFileEditor {
 	const AllocatedPath path;

--- a/src/command/OtherCommands.cxx
+++ b/src/command/OtherCommands.cxx
@@ -160,7 +160,8 @@ handle_lsinfo_relative(Client &client, Response &r, const char *uri)
 	(void)client;
 #endif
 
-	if (isRootDirectory(uri)) {
+	if ( list_playlists_in_root &&
+	     isRootDirectory(uri)) {
 		try {
 			print_spl_list(r, ListPlaylistFiles());
 		} catch (...) {

--- a/src/config/Defaults.hxx
+++ b/src/config/Defaults.hxx
@@ -5,5 +5,6 @@
 #define MPD_CONFIG_DEFAULTS_HXX
 
 static constexpr bool DEFAULT_PLAYLIST_SAVE_ABSOLUTE_PATHS = false;
+static constexpr bool DEFAULT_LIST_PLAYLISTS_IN_ROOT = true;
 
 #endif

--- a/src/config/Option.hxx
+++ b/src/config/Option.hxx
@@ -61,6 +61,7 @@ enum class ConfigOption {
 	AUTO_UPDATE_DEPTH,
 
 	MIXRAMP_ANALYZER,
+	LIST_PLAYLISTS_IN_ROOT,
 
 	MAX
 };

--- a/src/config/Templates.cxx
+++ b/src/config/Templates.cxx
@@ -58,6 +58,7 @@ const ConfigTemplate config_param_templates[] = {
 	{ "auto_update" },
 	{ "auto_update_depth" },
 	{ "mixramp_analyzer" },
+	{ "list_playlists_in_root"},
 };
 
 static constexpr unsigned n_config_param_templates =


### PR DESCRIPTION
Default is enabled to keep backward compatibility.