### PR TITLE
song/Filter: Fix spacing error on nested AND

### DIFF
--- a/src/song/Filter.cxx
+++ b/src/song/Filter.cxx
@@ -326,7 +326,7 @@ SongFilter::ParseExpression(const char *&s, bool fold_case)
 	if (*s == '(') {
 		auto first = ParseExpression(s, fold_case);
 		if (*s == ')') {
-			++s;
+			s = StripLeft(s + 1);
 			return first;
 		}
 
@@ -340,7 +340,7 @@ SongFilter::ParseExpression(const char *&s, bool fold_case)
 			and_filter->AddItem(ParseExpression(s, fold_case));
 
 			if (*s == ')') {
-				++s;
+				s = StripLeft(s + 1);
 				return and_filter;
 			}
 


### PR DESCRIPTION
Previously, `AND` expressions were the only filters which used `++s` instead of `s = StripLeft(s + 1)` making them sensitive to spacing issues. This caused nested AND expressions (like e.g. `(((A) AND (B)) AND (C))`) to needlessly be rejected with the following error message: `{find} Word expected` due to the fact that the inner AND expression would leave the cursor `s` at a space rather than the beginning of the next word (remainder was ` AND (C))` rather than `AND (C)`).

This commit fixes this by consistently using `s = StripLeft(s + 1)` instead of `++s` when parsing AND expressions. Although it is not strictly necessary to resolve the AND nesting bug, the case of trivial AND expressions (consisting basically of only superfluous parentheses) is also changed to the new handling. This should be more robust although I expect that case to be even less common than the direct nesting of AND expressions.

see MusicPlayerDaemon/MPD#2100