### PR TITLE
Change the semantic of the searchplaylist protocol command

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -996,7 +996,7 @@ remote playlists (absolute URI with a supported scheme).
 
 .. _command_searchplaylist:
 
-:command:`searchplaylist {NAME} {FILTER} [{START:END}]`
+:command:`searchplaylist {NAME} {FILTER} [window {START:END}]`
     Search the playlist for songs matching
     ``FILTER`` (see :ref:`Filters <filter_syntax>`).  Playlist
     plugins are supported. A range may be specified to list

--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -176,7 +176,7 @@ static constexpr struct command commands[] = {
 	{ "searchaddpl", PERMISSION_CONTROL, 2, -1, handle_searchaddpl },
 	{ "searchcount", PERMISSION_READ, 1, -1, handle_searchcount },
 #endif
-	{ "searchplaylist", PERMISSION_READ, 2, 3, handle_searchplaylist },
+	{ "searchplaylist", PERMISSION_READ, 2, 4, handle_searchplaylist },
 	{ "seek", PERMISSION_PLAYER, 2, 2, handle_seek },
 	{ "seekcur", PERMISSION_PLAYER, 1, 1, handle_seekcur },
 	{ "seekid", PERMISSION_PLAYER, 2, 2, handle_seekid },

--- a/src/command/PlaylistCommands.cxx
+++ b/src/command/PlaylistCommands.cxx
@@ -164,8 +164,10 @@ handle_searchplaylist(Client &client, Request args, Response &r)
 	args.shift();
 
 	RangeArg window = RangeArg::All();
-	if (args.size() == 2) {
+	if (args.size() == 3 && StringIsEqual(args[args.size() - 2], "window")) {
 		window = args.ParseRange(args.size() - 1);
+
+		args.pop_back();
 		args.pop_back();
 	}
 


### PR DESCRIPTION
Old: searchplaylist {NAME} {FILTER} [{START:END}]
New: searchplaylist {NAME} {FILTER} [window {START:END}]

This is more similar to the other search commands and we can reuse search specific functions in libmpdclient.