### PR TITLE
New command tagtypes available

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,7 @@ ver 0.24 (not yet released)
   - "sticker find" supports sort and window parameter and new sticker compare operators "eq", "lt" and "gt"
   - consume only idle flags that were subscribed to
   - volume command is no longer deprecated
+  - new "available" subcommand for tagtypes
 * database
   - attribute "added" shows when each song was added to the database
   - fix integer overflows with 64-bit inode numbers

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1678,6 +1678,12 @@ Connection settings
     Announce that this client is interested in all tag
     types.  This is the default setting for new clients.
 
+.. _command_tagtypes_available:
+
+:command:`tagtypes available`
+    Shows the list of tag types configured
+    by the ``metadata_to_use`` setting.
+
 .. _partition_commands:
 
 Partition commands

--- a/src/TagPrint.cxx
+++ b/src/TagPrint.cxx
@@ -19,6 +19,14 @@ tag_print_types(Response &r) noexcept
 }
 
 void
+tag_print_types_available(Response &r) noexcept
+{
+	for (unsigned i = 0; i < TAG_NUM_OF_ITEM_TYPES; i++)
+		if (global_tag_mask.Test(TagType(i)))
+			r.Fmt(FMT_STRING("tagtype: {}\n"), tag_item_names[i]);
+}
+
+void
 tag_print(Response &r, TagType type, std::string_view value) noexcept
 {
 	r.Fmt(FMT_STRING("{}: {}\n"), tag_item_names[type], value);

--- a/src/TagPrint.hxx
+++ b/src/TagPrint.hxx
@@ -16,6 +16,9 @@ void
 tag_print_types(Response &response) noexcept;
 
 void
+tag_print_types_available(Response &response) noexcept;
+
+void
 tag_print(Response &response, TagType type, std::string_view value) noexcept;
 
 void

--- a/src/command/ClientCommands.cxx
+++ b/src/command/ClientCommands.cxx
@@ -104,6 +104,9 @@ handle_tagtypes(Client &client, Request request, Response &r)
 	} else if (StringIsEqual(cmd, "disable")) {
 		client.tag_mask &= ~ParseTagMask(request);
 		return CommandResult::OK;
+	} else if (StringIsEqual(cmd, "available")) {
+		tag_print_types_available(r);
+		return CommandResult::OK;
 	} else {
 		r.Error(ACK_ERROR_ARG, "Unknown sub command");
 		return CommandResult::ERROR;


### PR DESCRIPTION
Shows the list of tag types configured by the ``metadata_to_use`` setting.