### PR TITLE
meson.build: support building with ICU 76

### DIFF
--- a/src/lib/icu/meson.build
+++ b/src/lib/icu/meson.build
@@ -1,5 +1,7 @@
-icu_dep = dependency('icu-i18n', version: '>= 50', required: get_option('icu'))
-conf.set('HAVE_ICU', icu_dep.found())
+icu_i18n_dep = dependency('icu-i18n', version: '>= 50', required: get_option('icu'))
+icu_uc_dep = dependency('icu-uc', version: '>= 50', required: get_option('icu'))
+have_icu = icu_i18n_dep.found() and icu_uc_dep.found()
+conf.set('HAVE_ICU', have_icu)
 
 icu_sources = [
   'Canonicalize.cxx',
@@ -13,7 +15,7 @@ if is_windows
 endif
 
 iconv_dep = []
-if icu_dep.found()
+if have_icu
   icu_sources += [
     'Init.cxx',
     'Util.cxx',
@@ -31,7 +33,8 @@ icu = static_library(
   icu_sources,
   include_directories: inc,
   dependencies: [
-    icu_dep,
+    icu_i18n_dep,
+    icu_uc_dep,
     iconv_dep,
     fmt_dep,
   ],


### PR DESCRIPTION
ICU 76 decided to reduce overlinking[^1] thus `icu-i18n` will no longer add `icu-uc` when linking to shared libraries. This results in failure:
```
src/lib/icu/libicu.a.p/Converter.cxx.o: undefined reference to symbol 'ucnv_fromUnicode_76'
```

---

ICU 76:

```console
$ objdump -p libicui18n.so | grep icuuc
  NEEDED               libicuuc.so.76

$ pkg-config --libs-only-l icu-i18n
-licui18n

$ pkg-config --libs-only-l --static icu-i18n
-licui18n -licuuc -licudata -lpthread -lm

$ pkg-config --libs-only-l icu-i18n icu-uc
-licui18n -licuuc
```

ICU 75

```console
$ objdump -p libicui18n.so | grep icuuc
  NEEDED               libicuuc.so.75

$ pkg-config --libs-only-l icu-i18n
-licui18n -licuuc -licudata

$ pkg-config --libs-only-l --static icu-i18n
-licui18n -licuuc -licudata -lpthread -lm

$ pkg-config --libs-only-l icu-i18n icu-uc
-licui18n -licuuc -licudata
```

[^1]: https://github.com/unicode-org/icu/commit/199bc827021ffdb43b6579d68e5eecf54c7f6f56
