### PR TITLE
Add "reset" subcommand to tagtypes.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,7 +16,7 @@ ver 0.24 (not yet released)
   - "sticker find" supports sort and window parameter and new sticker compare operators "eq", "lt", "gt", "contains" and "starts_with"
   - consume only idle flags that were subscribed to
   - volume command is no longer deprecated
-  - new "available" subcommand for tagtypes
+  - new "available" and "reset" subcommands for tagtypes
   - searching stored playlists respond now with song position
 * database
   - attribute "added" shows when each song was added to the database

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1688,6 +1688,11 @@ Connection settings
     Shows the list of tag types configured
     by the ``metadata_to_use`` setting.
 
+:command:`tagtypes reset {NAME...}`
+    Clear the list of tag types and Re-enable one or more tags
+    from the list of tag types for this client.  These will no
+    longer be hidden from responses to this client.
+
 .. _command_protocol:
 
 :command:`protocol`

--- a/src/command/ClientCommands.cxx
+++ b/src/command/ClientCommands.cxx
@@ -107,6 +107,10 @@ handle_tagtypes(Client &client, Request request, Response &r)
 	} else if (StringIsEqual(cmd, "available")) {
 		tag_print_types_available(r);
 		return CommandResult::OK;
+	} else if (StringIsEqual(cmd, "reset")) {
+		client.tag_mask = TagMask::None();
+		client.tag_mask |= ParseTagMask(request);
+		return CommandResult::OK;
 	} else {
 		r.Error(ACK_ERROR_ARG, "Unknown sub command");
 		return CommandResult::ERROR;


### PR DESCRIPTION
This subcommand combines "clear" and "enable" in one command.