### PR TITLE
New commands outputlist and output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ ver 0.24 (not yet released)
   - volume command is no longer deprecated
   - new "available" and "reset" subcommands for tagtypes
   - searching stored playlists respond now with song position
+  - new commands "outputlist" and "output"
 * database
   - attribute "added" shows when each song was added to the database
   - fix integer overflows with 64-bit inode numbers

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1809,6 +1809,13 @@ Audio output devices
     - ``outputname``: Name of the output. It can be any.
     - ``outputenabled``: Status of the output. 0 if disabled, 1 if enabled.
 
+:command:`outputlist`
+    Shows information about all outputs. This is a more compact version of
+    the `outputs` command that does not print attributes.
+
+:command:`output {ID}`
+    Shows information about specified output.
+
 .. _command_outputset:
 
 :command:`outputset {ID} {NAME} {VALUE}`

--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -133,6 +133,8 @@ static constexpr struct command commands[] = {
 	{ "newpartition", PERMISSION_ADMIN, 1, 1, handle_newpartition },
 	{ "next", PERMISSION_PLAYER, 0, 0, handle_next },
 	{ "notcommands", PERMISSION_NONE, 0, 0, handle_not_commands },
+	{ "output", PERMISSION_READ, 1, 1, handle_device },
+	{ "outputlist", PERMISSION_READ, 0, 0, handle_devicelist },
 	{ "outputs", PERMISSION_READ, 0, 0, handle_devices },
 	{ "outputset", PERMISSION_ADMIN, 3, 3, handle_outputset },
 	{ "partition", PERMISSION_READ, 1, 1, handle_partition },

--- a/src/command/OutputCommands.cxx
+++ b/src/command/OutputCommands.cxx
@@ -113,3 +113,29 @@ handle_devices(Client &client, [[maybe_unused]] Request args, Response &r)
 	printAudioDevices(r, client.GetPartition().outputs);
 	return CommandResult::OK;
 }
+
+CommandResult
+handle_device(Client &client, [[maybe_unused]] Request args, Response &r)
+{
+	assert(args.size() == 1);
+
+	const unsigned idx = args.ParseUnsigned(0);
+
+	auto &outputs = client.GetPartition().outputs;
+	if (idx >= outputs.Size()) {
+		r.Error(ACK_ERROR_NO_EXIST, "No such audio output");
+		return CommandResult::ERROR;
+	}
+
+	printAudioDevice(r, outputs, idx, true);
+	return CommandResult::OK;
+}
+
+CommandResult
+handle_devicelist(Client &client, [[maybe_unused]] Request args, Response &r)
+{
+	assert(args.empty());
+
+	printAudioDeviceList(r, client.GetPartition().outputs);
+	return CommandResult::OK;
+}

--- a/src/command/OutputCommands.hxx
+++ b/src/command/OutputCommands.hxx
@@ -25,4 +25,10 @@ handle_outputset(Client &client, Request request, Response &response);
 CommandResult
 handle_devices(Client &client, Request request, Response &response);
 
+CommandResult
+handle_device(Client &client, Request request, Response &response);
+
+CommandResult
+handle_devicelist(Client &client, Request request, Response &response);
+
 #endif

--- a/src/output/Print.cxx
+++ b/src/output/Print.cxx
@@ -16,18 +16,32 @@ void
 printAudioDevices(Response &r, const MultipleOutputs &outputs)
 {
 	for (unsigned i = 0, n = outputs.Size(); i != n; ++i) {
-		const auto &ao = outputs.Get(i);
+		printAudioDevice(r, outputs, i, true);
+	}
+}
 
-		r.Fmt(FMT_STRING("outputid: {}\n"
-				 "outputname: {}\n"
-				 "plugin: {}\n"
-				 "outputenabled: {}\n"),
-		      i,
-		      ao.GetName(), ao.GetPluginName(),
-		      (unsigned)ao.IsEnabled());
+void
+printAudioDevice(Response &r, const MultipleOutputs &outputs, unsigned idx, bool attributes)
+{
+	const auto &ao = outputs.Get(idx);
 
+	r.Fmt(FMT_STRING("outputid: {}\n"
+				"outputname: {}\n"
+				"plugin: {}\n"
+				"outputenabled: {}\n"),
+		idx,
+		ao.GetName(), ao.GetPluginName(),
+		(unsigned)ao.IsEnabled());
+	if (attributes)
 		for (const auto &[attribute, value] : ao.GetAttributes())
 			r.Fmt(FMT_STRING("attribute: {}={}\n"),
-			      attribute, value);
+				attribute, value);
+}
+
+void
+printAudioDeviceList(Response &r, const MultipleOutputs &outputs)
+{
+	for (unsigned i = 0, n = outputs.Size(); i != n; ++i) {
+		printAudioDevice(r, outputs, i, false);
 	}
 }

--- a/src/output/Print.hxx
+++ b/src/output/Print.hxx
@@ -14,5 +14,9 @@ class MultipleOutputs;
 
 void
 printAudioDevices(Response &r, const MultipleOutputs &outputs);
+void
+printAudioDevice(Response &r, const MultipleOutputs &outputs, unsigned idx, bool attributes);
+void
+printAudioDeviceList(Response &r, const MultipleOutputs &outputs);
 
 #endif


### PR DESCRIPTION
- `outputlist` is a more compact version of the outputs command that does not print attributes.
- `output {ID}` prints the details of specified output id.