### PR TITLE
output/Source: fix Close()

### DIFF
--- a/src/output/Source.cxx
+++ b/src/output/Source.cxx
@@ -53,9 +53,9 @@ AudioOutputSource::Close() noexcept
 	assert(in_audio_format.IsValid());
 	in_audio_format.Clear();
 
-	Cancel();
-
 	CloseFilter();
+
+	Cancel();
 }
 
 void


### PR DESCRIPTION
Close the filter before cancelling when closing a source. Fixes #2148