### PR TITLE
event/ServerSocket: consider AddFD'd listeners good

### DIFF
--- a/src/event/ServerSocket.cxx
+++ b/src/event/ServerSocket.cxx
@@ -210,10 +210,13 @@ ServerSocket::Open()
 		assert(i.GetSerial() > 0);
 		assert(good == nullptr || i.GetSerial() >= good->GetSerial());
 
-		if (i.IsDefined())
+		if (i.IsDefined()) {
 			/* already open - was probably added by
 			   AddFD() */
+			if (good == nullptr)
+				good = &i;
 			continue;
+		}
 
 		if (bad != nullptr && i.GetSerial() != bad->GetSerial()) {
 			Close();


### PR DESCRIPTION
this fixes listening on the XDG runtime dir socket if binding to the configured tcp port fails.

while listen_global_init() does in fact start listening on the XDG runtime dir socket, a failure to listen to the configured port causes all listener fd's, including the perfectly valid unix socket, to be closed:

	(gdb) bt
	#0  close (fd=10) at src/unistd/close.c:15
	#1  0x00005555555b2db7 in FileDescriptor::Close (this=0x7fffec777f80)
	    at ../src/io/FileDescriptor.hxx:201
	#2  0x0000555555635a51 in SocketEvent::Close (this=0x7fffec777f58) at ../src/event/SocketEvent.cxx:46
	#3  0x00005555556385a0 in ServerSocket::OneServerSocket::Close (this=0x7fffec777f50)
	    at ../src/event/ServerSocket.cxx:83
	#4  0x0000555555637777 in ServerSocket::Close (this=0x7fffef911f90)
	    at ../src/event/ServerSocket.cxx:270
	#5  0x00005555556374d5 in ServerSocket::Open (this=0x7fffef911f90)
	    at ../src/event/ServerSocket.cxx:260
	#6  0x00005555555bb0a4 in listen_global_init (config=..., listener=...) at ../src/Listen.cxx:139
	#7  0x0000555555583c9b in MainConfigured (options=..., raw_config=...) at ../src/Main.cxx:355
	#8  0x000055555558467e in MainOrThrow (argc=3, argv=0x7fffffffe738) at ../src/Main.cxx:663
	#9  0x00005555555846fa in mpd_main (argc=3, argv=0x7fffffffe738) at ../src/Main.cxx:669
	#10 0x000055555558475d in main (argc=3, argv=0x7fffffffe738) at ../src/Main.cxx:681

to fix that, consider listeners added by AddFD "good" so that it is kept open even if the tcp listens fail.