### PR TITLE
Add sticker sub-commands inc and dec

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ ver 0.24 (not yet released)
   - volume command is no longer deprecated
   - new "available" and "reset" subcommands for tagtypes
   - searching stored playlists respond now with song position
+  - new sticker subcommand "inc" and "dec"
 * database
   - attribute "added" shows when each song was added to the database
   - fix integer overflows with 64-bit inode numbers

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1518,6 +1518,20 @@ the database for songs).
     sticker item with that name already exists, it is
     replaced.
 
+.. _command_sticker_inc:
+
+:command:`sticker inc {TYPE} {URI} {NAME} {VALUE}`
+    Adds a sticker value to the specified object.  If a
+    sticker item with that name already exists, it is
+    incremented by supplied value.
+
+.. _command_sticker_dec:
+
+:command:`sticker dec {TYPE} {URI} {NAME} {VALUE}`
+    Adds a sticker value to the specified object.  If a
+    sticker item with that name already exists, it is
+    decremented by supplied value.
+
 .. _command_sticker_delete:
 
 :command:`sticker delete {TYPE} {URI} [NAME]`

--- a/src/command/StickerCommands.cxx
+++ b/src/command/StickerCommands.cxx
@@ -58,6 +58,24 @@ public:
 		return CommandResult::OK;
 	}
 
+	virtual CommandResult Inc(const char *uri, const char *name, const char *value) {
+		sticker_database.IncValue(sticker_type,
+					  ValidateUri(uri).c_str(),
+					  name,
+					  value);
+
+		return CommandResult::OK;
+	}
+
+	virtual CommandResult Dec(const char *uri, const char *name, const char *value) {
+		sticker_database.DecValue(sticker_type,
+					  ValidateUri(uri).c_str(),
+					  name,
+					  value);
+
+		return CommandResult::OK;
+	}
+
 	virtual CommandResult Delete(const char *uri, const char *name) {
 		std::string validated_uri = ValidateUri(uri);
 		uri = validated_uri.c_str();
@@ -442,6 +460,14 @@ handle_sticker(Client &client, Request args, Response &r)
 	/* set */
 	if (args.size() == 5 && StringIsEqual(cmd, "set"))
 		return handler->Set(uri, sticker_name, args[4]);
+	
+	/* inc */
+	if (args.size() == 5 && StringIsEqual(cmd, "inc"))
+		return handler->Inc(uri, sticker_name, args[4]);
+
+	/* dec */
+	if (args.size() == 5 && StringIsEqual(cmd, "dec"))
+		return handler->Dec(uri, sticker_name, args[4]);
 
 	/* delete */
 	if ((args.size() == 3 || args.size() == 4) && StringIsEqual(cmd, "delete"))

--- a/src/sticker/Database.hxx
+++ b/src/sticker/Database.hxx
@@ -54,6 +54,8 @@ class StickerDatabase {
 		  SQL_NAMES,
 		  SQL_NAMES_TYPES,
 		  SQL_NAMES_TYPES_BY_TYPE,
+		  STICKER_SQL_INC,
+		  STICKER_SQL_DEC,
 
 		  SQL_COUNT
 	};
@@ -118,6 +120,24 @@ public:
 	 */
 	void StoreValue(const char *type, const char *uri,
 			const char *name, const char *value);
+	
+	/**
+	 * Increments a sticker by value in the specified object.  Inserts
+	 * the value if object does not exist.
+	 *
+	 * Throws #SqliteError on error.
+	 */
+	void IncValue(const char *type, const char *uri,
+		      const char *name, const char *value);
+
+	/**
+	 * Decrements a sticker by value in the specified object.  Inserts
+	 * the value if object does not exist.
+	 *
+	 * Throws #SqliteError on error.
+	 */
+	void DecValue(const char *type, const char *uri,
+		      const char *name, const char *value);
 
 	/**
 	 * Deletes a sticker from the database.  All sticker values of the

--- a/src/sticker/SongSticker.cxx
+++ b/src/sticker/SongSticker.cxx
@@ -30,6 +30,24 @@ sticker_song_set_value(StickerDatabase &db,
 	db.StoreValue("song", uri.c_str(), name, value);
 }
 
+void
+sticker_song_inc_value(StickerDatabase &db,
+		       const LightSong &song,
+		       const char *name, const char *value)
+{
+	const auto uri = song.GetURI();
+	db.IncValue("song", uri.c_str(), name, value);
+}
+
+void
+sticker_song_dec_value(StickerDatabase &db,
+		       const LightSong &song,
+		       const char *name, const char *value)
+{
+	const auto uri = song.GetURI();
+	db.DecValue("song", uri.c_str(), name, value);
+}
+
 bool
 sticker_song_delete(StickerDatabase &db, const char *uri)
 {

--- a/src/sticker/SongSticker.hxx
+++ b/src/sticker/SongSticker.hxx
@@ -35,6 +35,28 @@ sticker_song_set_value(StickerDatabase &db,
 		       const char *name, const char *value);
 
 /**
+ * Increments a sticker by value in the specified object.  Inserts
+ * the value if object does not exist.
+ *
+ * Throws #SqliteError on error.
+ */
+void
+sticker_song_inc_value(StickerDatabase &db,
+		       const LightSong &song,
+		       const char *name, const char *value);
+
+/**
+ * Decrements a sticker by value in the specified object.  Inserts
+ * the value if object does not exist.
+ *
+ * Throws #SqliteError on error.
+ */
+void
+sticker_song_dec_value(StickerDatabase &db,
+		       const LightSong &song,
+		       const char *name, const char *value);
+
+/**
  * Deletes a sticker from the database.  All values are deleted.
  *
  * Throws #SqliteError on error.


### PR DESCRIPTION
Let sqlite do the work for incrementing or decrementing a sticker value. This sub-commands are usefull to track playcounts with sticker values and saves us one roundtrip.