### PR TITLE
Add `bind_to_address` parameter to docs

### DIFF
--- a/doc/mpd.conf.5.rst
+++ b/doc/mpd.conf.5.rst
@@ -89,6 +89,9 @@ user <username>
    initialization. Do not use this option if you start MPD as an unprivileged
    user.
 
+bind_to_address <address>
+   Set the interface address that mpd listens on. The default is 0.0.0.0 (all interfaces).
+
 port <port>
    This specifies the port that mpd listens on. The default is 6600.
 


### PR DESCRIPTION
Hi there!

While enjoying my favourite tunes with MPD, I wondered how to fix this error message on startup:

> server_socket: bind to '0.0.0.0:6600' failed (continuing anyway, because binding to '[::]:6600' succeeded): Failed to bind socket: Address already in use

The solution for that is to specify the `bind_to_address` parameter in the config file `mpd.conf`, as stated for example in [this Arch Linux Wiki section](https://wiki.archlinux.org/title/Music_Player_Daemon/Troubleshooting#Binding_to_IPV6_before_IPV4).

I noticed that this parameter is missing in the docs I read with `man 5 mpd.conf`. So, I decided to add it.

Do you agree with the description?