### PR TITLE
lib/fmt: remove the rest of the broken use of FMT_STRING

### DIFF
--- a/src/command/FingerprintCommands.cxx
+++ b/src/command/FingerprintCommands.cxx
@@ -62,7 +62,7 @@ protected:
 	void Run() override;
 
 	void SendResponse(Response &r) noexcept override {
-		r.Fmt(FMT_STRING("chromaprint: {}\n"),
+		r.Fmt("chromaprint: {}\n",
 		      GetFingerprint());
 	}
 

--- a/src/command/NeighborCommands.cxx
+++ b/src/command/NeighborCommands.cxx
@@ -46,8 +46,8 @@ handle_listneighbors(Client &client, [[maybe_unused]] Request args, Response &r)
 	}
 
 	for (const auto &i : neighbors->GetList())
-		r.Fmt(FMT_STRING("neighbor: {}\n"
-				 "name: {}\n"),
+		r.Fmt("neighbor: {}\n"
+		      "name: {}\n",
 		      i.uri,
 		      i.display_name);
 	return CommandResult::OK;

--- a/src/output/plugins/PipeWireOutputPlugin.cxx
+++ b/src/output/plugins/PipeWireOutputPlugin.cxx
@@ -685,7 +685,7 @@ PipeWireOutput::ParamChanged([[maybe_unused]] uint32_t id,
 				::SetVolume(*stream, channels, volume);
 			} catch (...) {
 				FmtError(pipewire_output_domain,
-					 FMT_STRING("Failed to restore volume: {}"),
+					 "Failed to restore volume: {}",
 					 std::current_exception());
 			}
 		}


### PR DESCRIPTION
Fixes: 9db7144d0fa4512335070a984690f3f5034210a5

Still had build failures with a more maximalist build. So I grepped for other uses and removed them.

I didn't remove use from src/lib/icu/Converter.cxx as it was correct.