### PR TITLE
protocol: command 'binarylimit' without an argument returns the curre…

### DIFF
--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1646,6 +1646,21 @@ Connection settings
 
 .. _command_binarylimit:
 
+:command:`binarylimit` [#since_0_24]_
+
+    Shows the current value of ``binarylimit`` and the min, max, and default binary limit.
+
+    Example:
+
+    .. code-block:: none
+
+      binarylimit
+      binarylimit: 8192
+      binarylimit_min: 64
+      binarylimit_max: 4206592
+      binarylimit_default: 8192
+      OK
+
 :command:`binarylimit SIZE` [#since_0_22_4]_
 
     Set the maximum :ref:`binary response <binary>` size for the

--- a/src/client/Client.hxx
+++ b/src/client/Client.hxx
@@ -74,7 +74,9 @@ public:
 	 * The maximum number of bytes transmitted in a binary
 	 * response.  Can be changed with the "binarylimit" command.
 	 */
-	size_t binary_limit = 8192;
+	static constexpr size_t BINARY_LIMIT_DEFAULT = 8192;
+	static constexpr size_t BINARY_LIMIT_MIN = 64;
+	size_t binary_limit = BINARY_LIMIT_DEFAULT;
 
 	/**
 	 * This caches the last "albumart" InputStream instance, to

--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -74,7 +74,7 @@ static constexpr struct command commands[] = {
 	{ "addid", PERMISSION_ADD, 1, 2, handle_addid },
 	{ "addtagid", PERMISSION_ADD, 3, 3, handle_addtagid },
 	{ "albumart", PERMISSION_READ, 2, 2, handle_album_art },
-	{ "binarylimit", PERMISSION_NONE, 1, 1, handle_binary_limit },
+	{ "binarylimit", PERMISSION_NONE, 0, 1, handle_binary_limit },
 	{ "channels", PERMISSION_READ, 0, 0, handle_channels },
 	{ "clear", PERMISSION_PLAYER, 0, 0, handle_clear },
 	{ "clearerror", PERMISSION_PLAYER, 0, 0, handle_clearerror },

--- a/src/command/ClientCommands.cxx
+++ b/src/command/ClientCommands.cxx
@@ -29,14 +29,23 @@ CommandResult
 handle_binary_limit(Client &client, Request args,
 		    [[maybe_unused]] Response &r)
 {
-	size_t value = args.ParseUnsigned(0, client.GetOutputMaxSize() - 4096);
-	if (value < 64) {
-		r.Error(ACK_ERROR_ARG, "Value too small");
-		return CommandResult::ERROR;
+	const size_t binary_limit_max = client.GetOutputMaxSize() - 4096;
+	if (args.empty()) {
+		r.Fmt(FMT_STRING("binarylimit: {}\nbinarylimit_min: {}\nbinarylimit_max: {}\nbinarylimit_default: {}\n"),
+		      client.binary_limit,
+		      Client::BINARY_LIMIT_MIN,
+		      binary_limit_max,
+		      Client::BINARY_LIMIT_DEFAULT);
 	}
+	else {
+		size_t value = args.ParseUnsigned(0, binary_limit_max);
+		if (value < Client::BINARY_LIMIT_MIN) {
+			r.FmtError(ACK_ERROR_ARG, "Value too small: min = {}", Client::BINARY_LIMIT_MIN);
+			return CommandResult::ERROR;
+		}
 
-	client.binary_limit = value;
-
+		client.binary_limit = value;
+	}
 	return CommandResult::OK;
 }
 


### PR DESCRIPTION
…nt binary limit and it's min, max, and default values