### PR TITLE
doc/user: update windows build meson version

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -160,7 +160,7 @@ This section is about the latter.
 You need:
 
 * `mingw-w64 <http://mingw-w64.org/doku.php>`__
-* `Meson 0.56.0 <http://mesonbuild.com/>`__ and `Ninja
+* `Meson 1.0.0 <http://mesonbuild.com/>`__ and `Ninja
   <https://ninja-build.org/>`__
 * cmake
 * pkg-config


### PR DESCRIPTION
Since 0.23.17 it's no longer possible to cross compile for Windows on Linux using win32/build.py with meson 0.56.0 due to subprojects like id3tag utilizing meson features not available in 0.56.0.