### PR TITLE
Fix macOS build with nfs enabled

### DIFF
--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -12,6 +12,7 @@ input_api = static_library(
   include_directories: inc,
   dependencies: [
     thread_dep,
+    nfs_dep,
   ],
 )
 


### PR DESCRIPTION
I don't really know why this does compile on Linux but not on macOS, but regardless, this fixes it. Needed for the `nfsc/libnfs-raw-nfs.h` include in `input/Error.cxx`.