### PR TITLE
fs/glue/StandardDirectory: Add standard directories for macOS

### DIFF
--- a/src/config/Path.cxx
+++ b/src/config/Path.cxx
@@ -77,7 +77,6 @@ GetVariable(std::string_view name)
 {
 	if (name == "HOME"sv)
 		return GetConfiguredHome();
-#ifdef USE_XDG
 	else if (name == "XDG_CONFIG_HOME"sv)
 		return GetUserConfigDir();
 	else if (name == "XDG_MUSIC_DIR"sv)
@@ -86,7 +85,6 @@ GetVariable(std::string_view name)
 		return GetUserCacheDir();
 	else if (name == "XDG_RUNTIME_DIR"sv)
 		return GetUserRuntimeDir();
-#endif
 	else
 		throw FmtRuntimeError("Unknown variable: {:?}", name);
 }

--- a/src/fs/glue/StandardDirectory.cxx
+++ b/src/fs/glue/StandardDirectory.cxx
@@ -23,7 +23,6 @@
 #endif
 
 #ifdef USE_XDG
-#include "util/StringSplit.hxx"
 #include "util/StringStrip.hxx"
 #include "util/StringCompare.hxx"
 #include "io/FileLineReader.hxx"


### PR DESCRIPTION
Third time's the charm. In this PR is just added the standard directories for macOS.

I still personally think it is really useful if the `XDG...` variables on every setup/system would expand to the path set in said environment variable, as environment variable expansion is technically not something that is "part of XDG", it just an environment variable that happens to have an XDG prefix. For example as it stands, this part of the documentation is wrong:

>MPD searches for a config file in $XDG_CONFIG_HOME/mpd/mpd.conf then ~/.mpdconf then ~/.mpd/mpd.conf then /etc/mpd.conf or uses CONF_FILE.

On my system, the environment variable `XDG_CONFIG_HOME` *is* set, but no config is found because it only expands the variable when `USE_XDG` is true. To fix this each of the `get*Dir` functions would need to have the check at the top, but I couldn't make up from out previous conversation if you thought this was something you wanted or not, so I didn't include it. Example:

```cpp
AllocatedPath
GetUserConfigDir() noexcept
{
// Always try to expand environment variables first, regardless of system.
if (const auto path = GetExistingEnvDirectory("XDG_CONFIG_HOME");
    path != nullptr)
	return AllocatedPath{path};

#if defined(_WIN32)
	return GetStandardDir(CSIDL_LOCAL_APPDATA);
#elif defined(__APPLE__)
	if (const auto home = GetHomeDir(); !home.IsNull()) {
		auto fallback = home / Path::FromFS("Library/Application Support");
		if (IsValidDir(fallback))
			return fallback;
	}

	return nullptr;
#elif defined(USE_XDG)
	if (const auto home = GetHomeDir(); !home.IsNull()) {
		auto fallback = home / Path::FromFS(".config");
		if (IsValidDir(fallback))
			return fallback;
	}

	return nullptr;
#else
	return nullptr;
#endif
}
```

Love to hear what you think.