### PR TITLE
apple/ErrorRef.hxx: define CFErrorDomain if undefined

### DIFF
--- a/src/apple/ErrorRef.hxx
+++ b/src/apple/ErrorRef.hxx
@@ -8,6 +8,10 @@
 
 #include <utility>
 
+#ifndef CFErrorDomain
+typedef CFStringRef CFErrorDomain;
+#endif
+
 namespace Apple {
 
 class ErrorRef {


### PR DESCRIPTION
A trivial fix. While Apple documentation does not say when `CFErrorDomain` was added, as a matter of fact it is undefined on some macOS versions.

```
FAILED: src/apple/libapple.a.p/Throw.cxx.o 
/opt/local/bin/g++-mp-14 -Isrc/apple/libapple.a.p -Isrc/apple -I../mpd-0.24/src/apple -Isrc -I../mpd-0.24/src -I. -I../mpd-0.24 -I/opt/local/libexec/boost/1.76/include -I/opt/local/include -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -Wall -Winvalid-pch -Wextra -Wpedantic -std=c++20 -O0 -g -ffast-math -ftree-vectorize -Wcast-qual -Wdouble-promotion -Wmissing-declarations -Wshadow -Wunused -Wvla -Wwrite-strings -Wno-stringop-overflow -fno-threadsafe-statics -fmerge-all-constants -Wcomma-subscript -Wextra-semi -Wmismatched-tags -Woverloaded-virtual -Wsign-promo -Wsuggest-override -Wvolatile -Wvirtual-inheritance -Wno-missing-field-initializers -Wno-non-virtual-dtor -fvisibility=hidden -D_GNU_SOURCE -pipe -isystem /opt/local/var/macports/sources/rsync.macports.org/macports/release/tarballs/ports/audio/mpd/files/wrappers -Os -D_GLIBCXX_USE_CXX11_ABI=0 -arch ppc -MD -MQ src/apple/libapple.a.p/Throw.cxx.o -MF src/apple/libapple.a.p/Throw.cxx.o.d -o src/apple/libapple.a.p/Throw.cxx.o -c ../mpd-0.24/src/apple/Throw.cxx
In file included from ../mpd-0.24/src/apple/Throw.cxx:5:
../mpd-0.24/src/apple/ErrorRef.hxx:20:44: error: 'CFErrorDomain' has not been declared
   20 |         ErrorRef(CFAllocatorRef allocator, CFErrorDomain domain,
      |                                            ^~~~~~~~~~~~~
../mpd-0.24/src/apple/ErrorRef.hxx: In constructor 'Apple::ErrorRef::ErrorRef(CFAllocatorRef, int, CFIndex, CFDictionaryRef)':
../mpd-0.24/src/apple/ErrorRef.hxx:22:47: error: invalid conversion from 'int' to 'CFStringRef' {aka 'const __CFString*'} [-fpermissive]
   22 |                 :ref(CFErrorCreate(allocator, domain, code, userInfo)) {}
      |                                               ^~~~~~
      |                                               |
      |                                               int
In file included from ../mpd-0.24/src/apple/ErrorRef.hxx:7:
/System/Library/Frameworks/CoreFoundation.framework/Headers/CFError.h:82:64: note:   initializing argument 2 of '__CFError* CFErrorCreate(CFAllocatorRef, CFStringRef, CFIndex, CFDictionaryRef)'
   82 | CFErrorRef CFErrorCreate(CFAllocatorRef allocator, CFStringRef domain, CFIndex code, CFDictionaryRef userInfo) AVAILABLE_MAC_OS_X_VERSION_10_5_AND_LATER;
      |                                                    ~~~~~~~~~~~~^~~~~~
../mpd-0.24/src/apple/Throw.cxx: In function 'void Apple::ThrowOSStatus(OSStatus)':
../mpd-0.24/src/apple/Throw.cxx:16:46: error: invalid conversion from 'CFStringRef' {aka 'const __CFString*'} to 'int' [-fpermissive]
   16 |         const Apple::ErrorRef cferr(nullptr, kCFErrorDomainOSStatus,
      |                                              ^~~~~~~~~~~~~~~~~~~~~~
      |                                              |
      |                                              CFStringRef {aka const __CFString*}
../mpd-0.24/src/apple/ErrorRef.hxx:20:58: note:   initializing argument 2 of 'Apple::ErrorRef::ErrorRef(CFAllocatorRef, int, CFIndex, CFDictionaryRef)'
   20 |         ErrorRef(CFAllocatorRef allocator, CFErrorDomain domain,
      |                                            ~~~~~~~~~~~~~~^~~~~~
../mpd-0.24/src/apple/Throw.cxx: In function 'void Apple::ThrowOSStatus(OSStatus, const char*)':
../mpd-0.24/src/apple/Throw.cxx:30:46: error: invalid conversion from 'CFStringRef' {aka 'const __CFString*'} to 'int' [-fpermissive]
   30 |         const Apple::ErrorRef cferr(nullptr, kCFErrorDomainOSStatus,
      |                                              ^~~~~~~~~~~~~~~~~~~~~~
      |                                              |
      |                                              CFStringRef {aka const __CFString*}
../mpd-0.24/src/apple/ErrorRef.hxx:20:58: note:   initializing argument 2 of 'Apple::ErrorRef::ErrorRef(CFAllocatorRef, int, CFIndex, CFDictionaryRef)'
   20 |         ErrorRef(CFAllocatorRef allocator, CFErrorDomain domain,
      |                                            ~~~~~~~~~~~~~~^~~~~~
```