### PR TITLE
Fix running with one or more options on macOS leads to exception in command parsing

### DIFF
--- a/src/apple/AppleMain.cxx
+++ b/src/apple/AppleMain.cxx
@@ -3,9 +3,18 @@
 
 #include "Main.hxx"
 #include "Instance.hxx"
-#include "CommandLine.hxx"
 #include "net/Init.hxx"
 #include "config/Data.hxx"
+
+#ifdef ENABLE_DAEMON
+#include "CommandLine.hxx"
+#include "cmdline/OptionDef.hxx"
+#include "cmdline/OptionParser.hxx"
+
+static constexpr OptionDef option_defs[] = {
+	{"no-daemon", "don't detach from console"},
+};
+#endif
 
 static int service_argc;
 static char **service_argv;
@@ -16,12 +25,9 @@ int apple_main(int argc, char *argv[])
 	service_argv = argv;
 
 #ifdef ENABLE_DAEMON
-	CommandLineOptions options;
-	ConfigData raw_config;
+	OptionParser parser(option_defs, argc, argv);
 
-	ParseCommandLine(argc, argv, options, raw_config);
-
-	if (options.daemon) {
+	if (parser.PeekOptionValue("no-daemon") == nullptr) {
 		// Fork before any Objective-C runtime initializations
 		pid_t pid = fork();
 		if (pid < 0)

--- a/src/cmdline/OptionParser.hxx
+++ b/src/cmdline/OptionParser.hxx
@@ -7,6 +7,7 @@
 #include "OptionDef.hxx"
 
 #include <span>
+#include <string_view>
 
 /**
  * Command line option parser.
@@ -53,6 +54,16 @@ public:
 	std::span<const char *const> GetRemaining() const noexcept {
 		return {remaining_head, remaining_tail};
 	}
+
+	/**
+	 * Peeks the value of a specified long option without advancing the parser state.
+	 *
+	 * @param longOption The long name of the option (without the leading "--").
+	 * @return The value attached to the option, an empty string if the option is a flag,
+	 *         or nullptr if the option is not present.
+	 * @throws FmtRuntimeError if a value is expected but not provided.
+	 */
+	const char *PeekOptionValue(std::string_view s);
 
 private:
 	const char *CheckShiftValue(const char *s, const OptionDef &option);


### PR DESCRIPTION
* Add `PeekOptionValue` to `OptionParser` for non-destructive option lookup

Introduce a new method, `PeekOptionValue`, that scans the remaining command line arguments for a specified long option without advancing the parser state.

* Use `PeekOptionValue` in `apple_main` to handle `--no-daemon` flag

This fixes #2235: Running with one or more options on macOS leads to exception in command parsing. The issue there being that `ParseCommandLine` was being run twice (once in `apple_main`, and once at later stage) which would result in the `argv` being altered.
