### PR TITLE
Fix crash in TwoFilters::Reset due to missing null check

### DIFF
--- a/src/filter/plugins/TwoFilters.cxx
+++ b/src/filter/plugins/TwoFilters.cxx
@@ -10,6 +10,9 @@
 std::span<const std::byte>
 TwoFilters::FilterPCM(std::span<const std::byte> src)
 {
+	if (!first)
+		throw std::runtime_error("First filter is null.");
+
 	if (const auto dest = first->FilterPCM(src); dest.empty()) [[unlikely]]
 		/* no output from the first filter; pass the empty
                    buffer on, do not call the second filter */

--- a/src/filter/plugins/TwoFilters.hxx
+++ b/src/filter/plugins/TwoFilters.hxx
@@ -24,7 +24,8 @@ public:
 		 second(std::forward<S>(_second)) {}
 
 	void Reset() noexcept override {
-		first->Reset();
+		if (first)
+			first->Reset();
 		second->Reset();
 	}
 


### PR DESCRIPTION
When there is only one song in the playlist, consume mode is enabled and the song ends, MPD crashes. This fixes it.