### PR TITLE
net/DscpParser: fix building dscp parser code on FreeBSD / OpenBSD.

### DIFF
--- a/src/net/DscpParser.cxx
+++ b/src/net/DscpParser.cxx
@@ -9,6 +9,7 @@
 #ifdef _WIN32
 #include <ws2tcpip.h>
 #else
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #endif
 


### PR DESCRIPTION
```
/usr/include/netinet/ip.h:67:19: error: field has incomplete type 'struct in_addr'
        struct    in_addr ip_src, ip_dst; /* source and dest address */
                          ^
```