### PR TITLE
Amend includes to fix build of mpd 0.24.x on FreeBSD with clang

### DIFF
--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -5,6 +5,8 @@
  * CD-Audio handling (requires libcdio_paranoia)
  */
 
+#include <cstddef>
+
 #include "CdioParanoiaInputPlugin.hxx"
 #include "lib/cdio/Paranoia.hxx"
 #include "lib/fmt/RuntimeError.hxx"

--- a/src/lib/yajl/Callbacks.hxx
+++ b/src/lib/yajl/Callbacks.hxx
@@ -7,7 +7,7 @@
 
 #include <string_view>
 
-#include <yajl_parse.h>
+#include <yajl/yajl_parse.h>
 
 namespace Yajl {
 

--- a/src/lib/yajl/Gen.hxx
+++ b/src/lib/yajl/Gen.hxx
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <yajl_gen.h>
+#include <yajl/yajl_gen.h>
 
 #include <algorithm>
 #include <span>

--- a/src/lib/yajl/Handle.hxx
+++ b/src/lib/yajl/Handle.hxx
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <yajl_parse.h>
+#include <yajl/yajl_parse.h>
 
 #include <utility>
 

--- a/src/net/DscpParser.cxx
+++ b/src/net/DscpParser.cxx
@@ -9,7 +9,10 @@
 #ifdef _WIN32
 #include <ws2tcpip.h>
 #else
-#include <netinet/ip.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #endif
 
 #ifndef IPTOS_DSCP_AF11


### PR DESCRIPTION
We have to apply this change to make mpd 0.24.x compile. It would be great to incorporate them upstream.