### PR TITLE
Recommend the more secure https:// instead of git://

### DIFF
--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -91,13 +91,13 @@ Always write your code against the latest git:
 
 .. code-block:: none
 
-    git clone git://github.com/MusicPlayerDaemon/MPD
+    git clone https://github.com/MusicPlayerDaemon/MPD.git
 
 If you already have a clone, update it:
 
 .. code-block:: none
 
-    git pull --rebase git://github.com/MusicPlayerDaemon/MPD master
+    git pull --rebase https://github.com/MusicPlayerDaemon/MPD.git master
 
 You can do without :code:`--rebase`, but we recommend that you rebase
 your repository on the "master" repository all the time.


### PR DESCRIPTION
From https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
> Finally, we have the Git protocol. This is a special daemon that comes
> packaged with Git; it listens on a dedicated port (9418) that provides
> a service similar to the SSH protocol, but with absolutely no
> authentication or cryptography.