### PR TITLE
Use redundant call to io_uring_queue_init()

### DIFF
--- a/src/io/uring/Ring.cxx
+++ b/src/io/uring/Ring.cxx
@@ -10,8 +10,16 @@ namespace Uring {
 Ring::Ring(unsigned entries, unsigned flags)
 {
 	if (int error = io_uring_queue_init(entries, &ring, flags);
-	    error < 0)
-		throw MakeErrno(-error, "io_uring_queue_init() failed");
+	    error < 0) {
+		if (error == -EINVAL && (flags & ~iouring_setup_mask)) {
+		    flags &= iouring_setup_mask;
+			if (error = io_uring_queue_init(entries, &ring, flags);
+			    error < 0)
+				throw MakeErrno(-error, "io_uring_queue_init() failed (fallback)");
+			}
+		else
+			throw MakeErrno(-error, "io_uring_queue_init() failed");
+		}
 }
 
 Ring::Ring(unsigned entries, struct io_uring_params &params)

--- a/src/io/uring/Ring.hxx
+++ b/src/io/uring/Ring.hxx
@@ -18,6 +18,16 @@ namespace Uring {
 class Ring {
 	struct io_uring ring;
 
+// io_uring_setup() flags supported by Linux kernel 5.6
+unsigned iouring_setup_mask = (
+	IORING_SETUP_IOPOLL |
+	IORING_SETUP_SQPOLL |
+	IORING_SETUP_SQ_AFF |
+	IORING_SETUP_CQSIZE |
+	IORING_SETUP_CLAMP |
+	IORING_SETUP_ATTACH_WQ
+	);
+
 public:
 	/**
 	 * Construct the io_uring using io_uring_queue_init().


### PR DESCRIPTION
Commit e309941 [1] introduced IORING_SETUP_SINGLE_ISSUER in the call to io_uring_setup(). This flag is available since kernel version 6.0 [2]. Within the system call, the kernel checks supplied against defined flags, and returns -EINVAL if extra flags were supplied.

The initialization in io/uring/Ring.cxx fails with a low priority warning, that is not even printed in the log file (using default settings) and continues without io_uring support.

The Linux kernel supports io_uring since version 5.1, MPD currently has a minimum kernel requirement of 5.6. Ideally this feature should work with all supported kernels.

Introduce a bit mask for setup flags, initialized to the values known to the minimum supported Linux kernel [3]. If the first attempt to setup a uring queue fails with -EINVAL and extra flags were specified, repeat the setup with flags masked to the minimum values.

[1] https://github.com/MusicPlayerDaemon/MPD/commit/e309941
[2] https://www.man7.org/linux/man-pages/man2/io_uring_setup.2.html
[3] https://elixir.bootlin.com/linux/v5.6/source/include/uapi/linux/io_uring.h#L78-L83