### PR TITLE
Fix hang when activating shout output

### DIFF
--- a/src/output/plugins/ShoutOutputPlugin.cxx
+++ b/src/output/plugins/ShoutOutputPlugin.cxx
@@ -311,7 +311,7 @@ EncoderToShout(shout_t *shout_conn, Encoder &encoder)
 	while (true) {
 		std::byte buffer[32768];
 		const auto e = encoder.Read(std::span{buffer});
-		if (e.empty() == 0)
+		if (e.empty())
 			return;
 
 		int err = shout_send(shout_conn,


### PR DESCRIPTION
std::span.empty() returns true or 1 on empty span.
In this case, the function should return and not the other way around.