### PR TITLE
Adds audio CD tags, fetched from Musicbrainz server.

### DIFF
--- a/src/input/RemoteTagScanner.hxx
+++ b/src/input/RemoteTagScanner.hxx
@@ -41,6 +41,11 @@ class RemoteTagScanner {
 public:
 	virtual ~RemoteTagScanner() noexcept = default;
 	virtual void Start() = 0;
+
+	virtual bool DisableTagCaching ()
+	{
+		return false;
+	}
 };
 
 #endif

--- a/src/input/plugins/CdioParanoiaCDID.cxx
+++ b/src/input/plugins/CdioParanoiaCDID.cxx
@@ -1,0 +1,357 @@
+#include "CdioParanoiaCDID.hxx"
+#include "lib/cdio/Paranoia.hxx"
+
+#include <vector>
+
+extern "C" {
+#include <libavutil/sha.h>
+#include <libavutil/base64.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h> /* close() */
+#include <string.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#if defined(__linux__)
+#include <linux/cdrom.h>
+#define cdte_track_address      cdte_addr.lba
+#define DEVICE_NAME             "/dev/cdrom"
+
+#elif defined(__GNU__)
+/* According to Samuel Thibault <sthibault@debian.org>, cd-discid needs this
+ * to compile on Debian GNU/Hurd (i386) */
+#include <sys/cdrom.h>
+#define cdte_track_address      cdte_addr.lba
+#define DEVICE_NAME             "/dev/cd0"
+
+#elif defined(sun) && defined(unix) && defined(__SVR4)
+#include <sys/cdio.h>
+#define CD_MSF_OFFSET   150
+#define CD_FRAMES       75
+/* According to David Schweikert <dws@ee.ethz.ch>, cd-discid needs this
+ * to compile on Solaris */
+#define cdte_track_address      cdte_addr.lba
+#define DEVICE_NAME             "/dev/vol/aliases/cdrom0"
+
+/* __FreeBSD_kernel__ is needed for properly compiling on Debian GNU/kFreeBSD
+   Look at http://glibc-bsd.alioth.debian.org/porting/PORTING for more info */
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+#include <sys/cdio.h>
+#define CDROM_LBA               CD_LBA_FORMAT    /* first frame is 0 */
+#define CD_MSF_OFFSET           150              /* MSF offset of first frame */
+#define CD_FRAMES               75               /* per second */
+#define CDROM_LEADOUT           0xAA             /* leadout track */
+#define CDROMREADTOCHDR         CDIOREADTOCHEADER
+#define CDROMREADTOCENTRY       CDIOREADTOCENTRY
+#define cdrom_tochdr            ioc_toc_header
+#define cdth_trk0               starting_track
+#define cdth_trk1               ending_track
+#define cdrom_tocentry          ioc_read_toc_single_entry
+#define cdte_track              track
+#define cdte_format             address_format
+#define cdte_track_address      entry.addr.lba
+#define DEVICE_NAME             "/dev/cdrom"
+
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
+#include <sys/cdio.h>
+#define CDROM_LBA               CD_LBA_FORMAT    /* first frame is 0 */
+#define CD_MSF_OFFSET           150              /* MSF offset of first frame */
+#define CD_FRAMES               75               /* per second */
+#define CDROM_LEADOUT           0xAA             /* leadout track */
+#define CDROMREADTOCHDR         CDIOREADTOCHEADER
+#define cdrom_tochdr            ioc_toc_header
+#define cdth_trk0               starting_track
+#define cdth_trk1               ending_track
+#define cdrom_tocentry          cd_toc_entry
+#define cdte_track              track
+#define cdte_track_address      addr.lba
+#define DEVICE_NAME             "/dev/cd0a"
+
+#elif defined(__APPLE__)
+#include <sys/types.h>
+#include <IOKit/storage/IOCDTypes.h>
+#include <IOKit/storage/IOCDMediaBSDClient.h>
+#define CD_FRAMES               75               /* per second */
+#define CD_MSF_OFFSET           150              /* MSF offset of first frame */
+#define cdrom_tochdr            CDDiscInfo
+#define cdth_trk0               numberOfFirstTrack
+/* NOTE: Judging by the name here, we might have to do this:
+ * hdr.lastTrackNumberInLastSessionMSB << 8 *
+ * sizeof(hdr.lastTrackNumberInLastSessionLSB)
+ * | hdr.lastTrackNumberInLastSessionLSB; */
+#define cdth_trk1               lastTrackNumberInLastSessionLSB
+#define cdrom_tocentry          CDTrackInfo
+#define cdte_track_address      trackStartAddress
+#define DEVICE_NAME             "/dev/rdisk1"
+
+#elif defined(__sgi)
+#include <dmedia/cdaudio.h>
+#define CD_FRAMES               75               /* per second */
+#define CD_MSF_OFFSET           150              /* MSF offset of first frame */
+#define cdrom_tochdr            CDSTATUS
+#define cdth_trk0               first
+#define cdth_trk1               last
+#define close                   CDclose
+struct cdrom_tocentry
+{
+	int cdte_track_address;
+};
+#define DEVICE_NAME             "/dev/scsi/sc0d4l0"
+#else
+#error "Your OS isn't supported yet."
+#endif  /* os selection */
+}
+
+static char*
+makeMusicBrainzIdWith(int firstTrack, int lastTrack, int leadIn, std::vector<int> frameOffsets)
+{
+	struct AVSHA* sha1 = av_sha_alloc();
+	const int numBitsSha1 = 160;
+	const int digestSize = numBitsSha1 / 8;
+	uint8_t digest[digestSize];
+	const int tempSize = 32;
+	char temp[tempSize];
+
+	av_sha_init(sha1, numBitsSha1);
+
+	snprintf(temp, tempSize, "%02X", firstTrack);
+	av_sha_update(sha1, (const uint8_t*)temp, strlen(temp));
+
+	snprintf(temp, tempSize, "%02X", lastTrack);
+	av_sha_update(sha1, (const uint8_t*)temp, strlen(temp));
+
+	for (size_t i = 0; i < 100; ++i)
+	{
+		int offset = 0;
+
+		if (i < frameOffsets.size())
+			offset = frameOffsets[i] + leadIn;
+		snprintf(temp, tempSize, "%08X", offset);
+		av_sha_update(sha1, (const uint8_t*)temp, strlen(temp));
+	}
+	av_sha_final(sha1, digest);
+	free(sha1);
+
+	const int outputSize = 128;
+	char *output = new char[outputSize];
+
+	av_base64_encode(output, outputSize, digest, digestSize);
+
+	for (size_t i = 0; i < strlen(output); ++i)
+	{
+		switch (output[i])
+		{
+		case '=':
+			output[i] = '-';
+			break;
+		case '/':
+			output[i] = '_';
+			break;
+		case '+':
+			output[i] = '.';
+			break;
+		default:
+			break;
+		}
+	}
+
+	return output;
+}
+
+// getCurrentCDId is ported from https://github.com/taem/cd-discid
+
+std::string
+CDIODiscID::getCurrentCDId (std::string device)
+{
+	int len;
+	int i;
+	long int cksum = 0;
+	//int musicbrainz = 0;
+	unsigned char last = 1;
+	const char *devicename = device.c_str();
+	struct cdrom_tocentry *TocEntry;
+#ifndef __sgi
+	int drive;
+	struct cdrom_tochdr hdr;
+#else
+	CDPLAYER *drive;
+	CDTRACKINFO info;
+	cdrom_tochdr hdr;
+#endif
+	//char *command = argv[0];
+
+#if defined(__OpenBSD__) || defined(__NetBSD__)
+	struct ioc_read_toc_entry t;
+#elif defined(__APPLE__)
+	dk_cd_read_disc_info_t discInfoParams;
+#endif
+
+#if defined(__sgi)
+	drive = CDopen(devicename, "r");
+	if (drive == 0) {
+		return {};
+	}
+#else
+	drive = open(devicename, O_RDONLY | O_NONBLOCK);
+	if (drive < 0) {
+		return {};
+	}
+#endif
+
+#if defined(__APPLE__)
+	memset(&discInfoParams, 0, sizeof(discInfoParams));
+	discInfoParams.buffer = &hdr;
+	discInfoParams.bufferLength = sizeof(hdr);
+	if (ioctl(drive, DKIOCCDREADDISCINFO, &discInfoParams) < 0
+			|| discInfoParams.bufferLength != sizeof(hdr)) {
+		return {};
+	}
+#elif defined(__sgi)
+	if (CDgetstatus(drive, &hdr) == 0) {
+		return {}
+	}
+#else
+	if (ioctl(drive, CDROMREADTOCHDR, &hdr) < 0) {
+		return {};
+	}
+#endif
+
+	last = hdr.cdth_trk1;
+
+	len = (last + 1) * sizeof(struct cdrom_tocentry);
+
+	TocEntry = (cdrom_tocentry*)malloc(len);
+	if (!TocEntry) {
+		return {};
+	}
+
+#if defined(__OpenBSD__)
+	t.starting_track = 0;
+#elif defined(__NetBSD__)
+	t.starting_track = 1;
+#endif
+
+#if defined(__OpenBSD__) || defined(__NetBSD__)
+	t.address_format = CDROM_LBA;
+	t.data_len = len;
+	t.data = TocEntry;
+	memset(TocEntry, 0, len);
+
+	if (ioctl(drive, CDIOREADTOCENTRYS, (char*)&t) < 0) {
+		return {};
+	}
+#elif defined(__APPLE__)
+	dk_cd_read_track_info_t trackInfoParams;
+	memset(&trackInfoParams, 0, sizeof(trackInfoParams));
+	trackInfoParams.addressType = kCDTrackInfoAddressTypeTrackNumber;
+	trackInfoParams.bufferLength = sizeof(*TocEntry);
+
+	for (i = 0; i < last; i++) {
+		trackInfoParams.address = i + 1;
+		trackInfoParams.buffer = &TocEntry[i];
+
+		if (ioctl(drive, DKIOCCDREADTRACKINFO, &trackInfoParams) < 0) {
+			return {};
+		}
+	}
+
+	/* MacOS X on G5-based systems does not report valid info for
+	 * TocEntry[last-1].lastRecordedAddress + 1, so we compute the start
+	 * of leadout from the start+length of the last track instead
+	 */
+	TocEntry[last].cdte_track_address = htonl(ntohl(TocEntry[last-1].trackSize) + ntohl(TocEntry[last-1].trackStartAddress));
+#elif defined(__sgi)
+	for (i = 0; i < last; i++) {
+		if (CDgettrackinfo(drive, i + 1, &info) == 0) {
+			return {};
+		}
+		TocEntry[i].cdte_track_address = info.start_min*60*CD_FRAMES + info.start_sec*CD_FRAMES + info.start_frame;
+	}
+	TocEntry[last].cdte_track_address = TocEntry[last - 1].cdte_track_address + info.total_min*60*CD_FRAMES + info.total_sec*CD_FRAMES + info.total_frame;
+#else   /* FreeBSD, Linux, Solaris */
+	for (i = 0; i < last; i++) {
+		/* tracks start with 1, but I must start with 0 on OpenBSD */
+		TocEntry[i].cdte_track = i + 1;
+		TocEntry[i].cdte_format = CDROM_LBA;
+		if (ioctl(drive, CDROMREADTOCENTRY, &TocEntry[i]) < 0) {
+			return {};
+		}
+	}
+
+	TocEntry[last].cdte_track = CDROM_LEADOUT;
+	TocEntry[last].cdte_format = CDROM_LBA;
+	if (ioctl(drive, CDROMREADTOCENTRY, &TocEntry[i]) < 0) {
+		return {};
+	}
+#endif
+
+	/* release file handle */
+	close(drive);
+
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+	TocEntry[i].cdte_track_address = ntohl(TocEntry[i].cdte_track_address);
+#endif
+
+	for (i = 0; i < last; i++) {
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+		TocEntry[i].cdte_track_address = ntohl(TocEntry[i].cdte_track_address);
+#endif
+		cksum += cddb_sum((TocEntry[i].cdte_track_address + CD_MSF_OFFSET) / CD_FRAMES);
+	}
+
+	/*
+	 *totaltime = ((TocEntry[last].cdte_track_address + CD_MSF_OFFSET) / CD_FRAMES) -
+	 *    ((TocEntry[0].cdte_track_address + CD_MSF_OFFSET) / CD_FRAMES);
+	 */
+
+	/*
+	 *[> print discid <]
+	 *if (!musicbrainz)
+	 *    printf("%08lx ", (cksum % 0xff) << 24 | totaltime << 8 | last);
+	 */
+
+	/* print number of tracks */
+	//printf("%d", last);
+	int numTracks = last;
+	int firstTrackNumber = 1;
+
+	std::vector<int> frameOffsets;
+
+	if (last > 0)
+		frameOffsets.push_back(TocEntry[last].cdte_track_address);
+
+	/* print frame offsets of all tracks */
+	for (i = 0; i < last; i++)
+	{
+		//printf(" %d", TocEntry[i].cdte_track_address + CD_MSF_OFFSET);
+		frameOffsets.push_back(TocEntry[i].cdte_track_address);
+	}
+
+	free(TocEntry);
+
+	int leadIn = CDIO_PREGAP_SECTORS;
+	int lastTrack = numTracks + firstTrackNumber - 1;
+
+	auto musicId = makeMusicBrainzIdWith(firstTrackNumber, lastTrack, leadIn, frameOffsets);
+
+	std::string musicIdString(musicId);
+
+	delete [] musicId;
+
+	return musicIdString;
+}
+
+int
+CDIODiscID::cddb_sum(int n)
+{
+	/* a number like 2344 becomes 2+3+4+4 (13) */
+	int ret = 0;
+
+	while (n > 0) {
+		ret = ret + (n % 10);
+		n = n / 10;
+	}
+
+	return ret;
+}

--- a/src/input/plugins/CdioParanoiaCDID.hxx
+++ b/src/input/plugins/CdioParanoiaCDID.hxx
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+struct CdioUri {
+	char device[64];
+	int track;
+};
+
+class CDIODiscID
+{
+public:
+	static std::string getCurrentCDId (std::string device);
+
+private:
+	static int cddb_sum(int n);
+};
+
+

--- a/src/input/plugins/CdioParanoiaInputPlugin.cxx
+++ b/src/input/plugins/CdioParanoiaInputPlugin.cxx
@@ -29,7 +29,7 @@
 
 using std::string_view_literals::operator""sv;
 
-static constexpr Domain cdio_domain("cdio");
+constexpr Domain cdio_domain("cdio");
 
 static bool default_reverse_endian;
 static unsigned speed = 0;

--- a/src/input/plugins/CdioParanoiaMusicBrainzTags.cxx
+++ b/src/input/plugins/CdioParanoiaMusicBrainzTags.cxx
@@ -57,7 +57,18 @@ MusicBrainzCDTagCache::cancelRequest (Listener* listener)
 bool
 MusicBrainzCDTagCache::insertedCdChanged ()
 {
-	auto cdId = CDIODiscID::getCurrentCDId(device);
+	std::string cdId;
+
+	try {
+		cdId = CDIODiscID::getCurrentCDId(device);
+	} catch (...) {
+		if (lastCdId.length() > 0)
+		{
+			lastCdId = {};
+			return true;
+		}
+		return false;
+	}
 
 	if (cdId.length() == 0)
 	{
@@ -108,9 +119,11 @@ MusicBrainzCDTagCache::requestMusicBrainzTags()
 bool
 MusicBrainzCDTagCache::makeTrackInfoFromXml (std::string& body)
 {
-	MusicBrainzXMLParser parser;
-
-	tracks = parser.parse(body);
+	try {
+		tracks = musicBrainzXMLParser(body);
+	} catch (...) {
+		tracks.clear();
+	}
 
 	return tracks.size() > 0;
 }

--- a/src/input/plugins/CdioParanoiaMusicBrainzTags.cxx
+++ b/src/input/plugins/CdioParanoiaMusicBrainzTags.cxx
@@ -1,0 +1,140 @@
+#include "CdioParanoiaMusicBrainzTags.hxx"
+#include "CdioParanoiaCDID.hxx"
+#include "CdioParanoiaMusicBrainzXMLParser.hxx"
+
+MusicBrainzCDTagCache* MusicBrainzCDTagCache::instance = nullptr;
+
+void 
+MusicBrainzCDTagCache::requestTags (std::string_view& uri, std::string device_, Listener *listener)
+{
+	bool callListener = false;
+	int trackNum;
+
+	device = device_;
+
+	{
+		const std::scoped_lock lock{mutex};
+		const char* uriPrefix = "cdda:///";
+
+		if (strlen(uri.data()) <= strlen(uriPrefix))
+			return ;
+
+		trackNum = atoi(uri.data() + strlen(uriPrefix));
+
+		if (insertedCdChanged())
+		{
+			clearTracks();
+			requestMusicBrainzTags();
+		}
+		callListener = dataReady;
+		if (!dataReady)
+			listeners[trackNum].insert(listener);
+	}
+
+	if (callListener)
+	{
+		auto it = tracks.find(trackNum);
+
+		if (it != tracks.end())
+			listener->setTags(it->second);
+	}
+}
+
+void
+MusicBrainzCDTagCache::cancelRequest (Listener* listener)
+{
+	const std::scoped_lock lock{mutex};
+
+	for (auto it : listeners)
+	{
+		auto lit = it.second.find(listener);
+
+		if (lit != it.second.end())
+			it.second.erase(lit);
+	}
+}
+
+bool
+MusicBrainzCDTagCache::insertedCdChanged ()
+{
+	auto cdId = CDIODiscID::getCurrentCDId(device);
+
+	if (cdId.length() == 0)
+	{
+		if (lastCdId.length() > 0)
+		{
+			lastCdId = {};
+			return true;
+		}
+		return false;
+	}
+
+	if (cdId == lastCdId)
+		return false;
+
+	lastCdId = cdId;
+	return true;
+}
+
+void
+MusicBrainzCDTagCache::clearTracks ()
+{
+	dataReady = false;
+	tracks.clear();
+	if (request.get() != nullptr)
+		request->StopIndirect();
+	responseHandler.reset(nullptr);
+}
+
+void
+MusicBrainzCDTagCache::requestMusicBrainzTags()
+{
+	if (lastCdId.length() == 0)
+		return ;
+
+	// create url
+	std::string urlPrefix("https://musicbrainz.org/ws/2/discid/");
+	std::string urlArgs("?inc=artist-credits+recordings+genres");
+	std::string url = urlPrefix + lastCdId + urlArgs;
+
+	// launch curl request
+	responseHandler.reset(new ResponseHandler());
+	request.reset(new CurlRequest(*curl, url.c_str(),
+				*(StringCurlResponseHandler*)responseHandler.get()));
+
+	request->StartIndirect();
+}
+
+bool
+MusicBrainzCDTagCache::makeTrackInfoFromXml (std::string& body)
+{
+	MusicBrainzXMLParser parser;
+
+	tracks = parser.parse(body);
+
+	return tracks.size() > 0;
+}
+
+void
+MusicBrainzCDTagCache::callListeners ()
+{
+	const std::scoped_lock lock{mutex};
+
+	dataReady = true;
+	for (auto it : listeners)
+	{
+		int trackNum = it.first;
+		auto trackInfoIt = tracks.find(trackNum);
+
+		if (trackInfoIt == tracks.end())
+		{
+			continue;
+		}
+
+		for (auto listener : it.second)
+		{
+			listener->setTags(trackInfoIt->second);
+		}
+	}
+	listeners.clear();
+}

--- a/src/input/plugins/CdioParanoiaMusicBrainzTags.hxx
+++ b/src/input/plugins/CdioParanoiaMusicBrainzTags.hxx
@@ -7,9 +7,13 @@
 #include "input/RemoteTagScanner.hxx"
 #include "tag/Builder.hxx"
 #include "tag/Tag.hxx"
+#include "util/Domain.hxx"
+#include "Log.hxx"
 
 #include <map>
 #include <set>
+
+extern const Domain cdio_domain;
 
 class MusicBrainzCDTagCache
 {
@@ -78,7 +82,7 @@ private:
 
 	static MusicBrainzCDTagCache *instance;
 
-	std::map<int, std::set<Listener*> > listeners;
+	std::map<int, std::set<Listener*>> listeners;
 	Mutex mutex;
 	CurlInit curl;
 	std::unique_ptr<CurlRequest> request;
@@ -86,7 +90,7 @@ private:
 	std::string device;
 
 	class ResponseHandler
-	: public StringCurlResponseHandler
+		: public StringCurlResponseHandler
 	{
 	public: // CurlResponseHandler
 		/* virtual methods from CurlResponseHandler */
@@ -100,6 +104,7 @@ private:
 
 		void OnError(std::exception_ptr ) noexcept override
 		{
+			FmtError(cdio_domain, "Couldn't fetch tags from MusicBrainz");
 		}
 
 	};
@@ -108,8 +113,8 @@ private:
 };
 
 class MusicBrainzTagScanner final
-: public RemoteTagScanner
-, public MusicBrainzCDTagCache::Listener
+	: public RemoteTagScanner
+	, public MusicBrainzCDTagCache::Listener
 {
 	RemoteTagHandler &handler;
 	std::string_view uri;

--- a/src/input/plugins/CdioParanoiaMusicBrainzTags.hxx
+++ b/src/input/plugins/CdioParanoiaMusicBrainzTags.hxx
@@ -1,0 +1,170 @@
+#pragma once
+
+#include "lib/curl/Init.hxx"
+#include "lib/curl/Headers.hxx"
+#include "lib/curl/Request.hxx"
+#include "lib/curl/StringHandler.hxx"
+#include "input/RemoteTagScanner.hxx"
+#include "tag/Builder.hxx"
+#include "tag/Tag.hxx"
+
+#include <map>
+#include <set>
+
+class MusicBrainzCDTagCache
+{
+public:
+	MusicBrainzCDTagCache (EventLoop &event_loop)
+	: curl(event_loop)
+	{
+	}
+
+	virtual ~MusicBrainzCDTagCache ()
+	{
+		clearTracks();
+	}
+
+public:
+	struct TrackInfo
+	{
+		int trackNum = -99;
+		std::string title;
+		std::string artist;
+		std::string firstReleaseDate;
+		std::string albumTitle;
+		std::string albumDate;
+		std::string albumArtist;
+		std::string albumGenre;
+		int duration = 0;
+	};
+
+public:
+	class Listener
+	{
+	public: // MusicBrainzCDTagCache::Listener
+		virtual void setTags (MusicBrainzCDTagCache::TrackInfo& trackInfo) = 0;
+	};
+
+public:
+	void requestTags (std::string_view& uri, std::string device_, Listener *listener);
+	void cancelRequest (Listener* listener);
+	bool insertedCdChanged ();
+	void clearTracks ();
+	void requestMusicBrainzTags();
+	bool makeTrackInfoFromXml (std::string& body);
+	void callListeners ();
+
+public:
+	static void deleteInstance ()
+	{
+		if (instance != nullptr)
+			delete instance;
+		instance = nullptr;
+	}
+
+	static void createInstance (EventLoop &event_loop)
+	{
+		instance = new MusicBrainzCDTagCache(event_loop);
+	}
+
+	static MusicBrainzCDTagCache* getInstance ()
+	{
+		return instance;
+	}
+
+private:
+	std::string lastCdId;
+	std::map<int, TrackInfo> tracks;
+
+	static MusicBrainzCDTagCache *instance;
+
+	std::map<int, std::set<Listener*> > listeners;
+	Mutex mutex;
+	CurlInit curl;
+	std::unique_ptr<CurlRequest> request;
+	bool dataReady = false;
+	std::string device;
+
+	class ResponseHandler
+	: public StringCurlResponseHandler
+	{
+	public: // CurlResponseHandler
+		/* virtual methods from CurlResponseHandler */
+		void OnEnd() override
+		{
+			auto resp = StringCurlResponseHandler::GetResponse();
+
+			if (MusicBrainzCDTagCache::getInstance()->makeTrackInfoFromXml(resp.body))
+				MusicBrainzCDTagCache::getInstance()->callListeners();
+		}
+
+		void OnError(std::exception_ptr ) noexcept override
+		{
+		}
+
+	};
+
+	std::unique_ptr<ResponseHandler> responseHandler;
+};
+
+class MusicBrainzTagScanner final
+: public RemoteTagScanner
+, public MusicBrainzCDTagCache::Listener
+{
+	RemoteTagHandler &handler;
+	std::string_view uri;
+	std::string device;
+	bool tagsset = false;
+
+public:
+	MusicBrainzTagScanner(std::string_view _uri,
+			RemoteTagHandler &_handler,
+			std::string device_
+			)
+	: handler(_handler)
+	, uri(_uri)  
+	, device(device_)
+	{
+	}
+
+	~MusicBrainzTagScanner() noexcept override
+	{
+		if (!tagsset)
+			MusicBrainzCDTagCache::getInstance()->cancelRequest(this);
+	}
+
+public: // MusicBrainzCDTagCache::Listener
+	virtual void setTags (MusicBrainzCDTagCache::TrackInfo& trackInfo) override
+	{
+		TagBuilder b;
+		Tag tag;
+
+		b.AddItem(TAG_TITLE, trackInfo.title);
+		b.AddItem(TAG_ARTIST, trackInfo.artist);
+		b.AddItem(TAG_ORIGINAL_DATE, trackInfo.firstReleaseDate);
+		b.AddItem(TAG_ALBUM, trackInfo.albumTitle);
+		if (trackInfo.albumDate == std::string())
+			b.AddItem(TAG_DATE, trackInfo.firstReleaseDate);
+		else
+			b.AddItem(TAG_DATE, trackInfo.albumDate);
+		b.AddItem(TAG_ALBUM_ARTIST, trackInfo.albumArtist);
+		b.AddItem(TAG_GENRE, trackInfo.albumGenre);
+		b.AddItem(TAG_TRACK, std::to_string(trackInfo.trackNum));
+		b.SetDuration(SignedSongTime::FromS(trackInfo.duration));
+		b.Commit(tag);
+
+		tagsset = true;
+		handler.OnRemoteTag(std::move(tag));
+	}
+
+public:
+	void Start() noexcept override
+	{
+		MusicBrainzCDTagCache::getInstance()->requestTags(uri, device, this);
+	}
+
+	bool DisableTagCaching () override
+	{
+		return true;
+	}
+};

--- a/src/input/plugins/CdioParanoiaMusicBrainzXMLParser.cxx
+++ b/src/input/plugins/CdioParanoiaMusicBrainzXMLParser.cxx
@@ -231,7 +231,7 @@ mbz_char_data (void *user_data, const XML_Char *s, int len)
 }
 
 std::map<int, MusicBrainzCDTagCache::TrackInfo>
-MusicBrainzXMLParser::parse(std::string& body)
+musicBrainzXMLParser(std::string& body)
 {
 	MBZParser mbzParser;
 	{

--- a/src/input/plugins/CdioParanoiaMusicBrainzXMLParser.cxx
+++ b/src/input/plugins/CdioParanoiaMusicBrainzXMLParser.cxx
@@ -1,0 +1,245 @@
+#include "CdioParanoiaMusicBrainzXMLParser.hxx"
+#include "lib/expat/ExpatParser.hxx"
+
+struct MBZParser
+{
+	enum
+	{
+		ROOT,
+		RELEASE,
+		RELEASE_TITLE,
+		RELEASE_ARTIST_BLOCK,
+		RELEASE_ARTIST_NAME,
+		RELEASE_ARTIST_GENRE,
+		RELEASE_ARTIST_GENRE_NAME,
+		RELEASE_DATE,
+		TRACK_LIST,
+		TRACK,
+		RECORDING_TRACKNUM,
+		RECORDING_TITLE,
+		RECORDING_DURATION,
+		RECORDING_ARTIST_BLOCK,
+		RECORDING_ARTIST_NAME,
+		RECORDING_ARTIST_GENRE,
+		RECORDING_FIRST_RELEASE_DATE,
+	} state = ROOT;
+
+	std::string value;
+
+	MusicBrainzCDTagCache::TrackInfo currentTrack;
+	std::map<int, MusicBrainzCDTagCache::TrackInfo> tracks;
+
+	std::string albumTitle;
+	std::string albumDate;
+	std::string albumArtist;
+	std::string albumGenre;
+
+	void finishCurrenTrack ()
+	{
+		currentTrack.albumTitle = albumTitle;
+		currentTrack.albumDate = albumDate;
+		currentTrack.albumArtist = albumArtist;
+		currentTrack.albumGenre = albumGenre;
+		tracks[currentTrack.trackNum] = currentTrack;
+		currentTrack = {};
+	}
+};
+
+static void XMLCALL
+mbz_start_element (void *user_data, const XML_Char *element_name,
+		[[maybe_unused]] const XML_Char **atts)
+{
+	auto *parser = (MBZParser *)user_data;
+
+	parser->value.clear();
+
+	switch (parser->state)
+	{
+	case MBZParser::ROOT:
+		if (strcmp(element_name, "release") == 0)
+			parser->state = MBZParser::RELEASE;
+		break;
+	case MBZParser::RELEASE:
+		if (strcmp(element_name, "artist") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_BLOCK;
+		else if (strcmp(element_name, "title") == 0)
+			parser->state = MBZParser::RELEASE_TITLE;
+		else if (strcmp(element_name, "date") == 0)
+			parser->state = MBZParser::RELEASE_DATE;
+		else if (strcmp(element_name, "track-list") == 0)
+			parser->state = MBZParser::TRACK_LIST;
+		break;
+	case MBZParser::RELEASE_ARTIST_BLOCK:
+		if (strcmp(element_name, "name") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_NAME;
+		else if (strcmp(element_name, "genre-list") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_GENRE;
+		break;
+	case MBZParser::RELEASE_ARTIST_GENRE:
+		if (strcmp(element_name, "name") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_GENRE_NAME;
+		break;
+	case MBZParser::TRACK_LIST:
+		if (strcmp(element_name, "track") == 0)
+			parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::TRACK:
+		if (strcmp(element_name, "artist") == 0)
+			parser->state = MBZParser::RECORDING_ARTIST_BLOCK;
+		else if (strcmp(element_name, "title") == 0)
+			parser->state = MBZParser::RECORDING_TITLE;
+		else if (strcmp(element_name, "length") == 0)
+			parser->state = MBZParser::RECORDING_DURATION;
+		else if (strcmp(element_name, "number") == 0)
+			parser->state = MBZParser::RECORDING_TRACKNUM;
+		else if (strcmp(element_name, "first-release-date") == 0)
+			parser->state = MBZParser::RECORDING_FIRST_RELEASE_DATE;
+		break;
+	case MBZParser::RECORDING_ARTIST_BLOCK:
+		if (strcmp(element_name, "name") == 0)
+			parser->state = MBZParser::RECORDING_ARTIST_NAME;
+		else if (strcmp(element_name, "genre-list") == 0)
+			parser->state = MBZParser::RECORDING_ARTIST_GENRE;
+		break;
+	case MBZParser::RECORDING_ARTIST_GENRE:
+	case MBZParser::RELEASE_TITLE:
+	case MBZParser::RELEASE_ARTIST_NAME:
+	case MBZParser::RELEASE_ARTIST_GENRE_NAME:
+	case MBZParser::RELEASE_DATE:
+	case MBZParser::RECORDING_TRACKNUM:
+	case MBZParser::RECORDING_TITLE:
+	case MBZParser::RECORDING_DURATION:
+	case MBZParser::RECORDING_ARTIST_NAME:
+	case MBZParser::RECORDING_FIRST_RELEASE_DATE:
+		break;
+	}
+}
+
+static void XMLCALL
+mbz_end_element (void *user_data, const XML_Char *element_name)
+{
+	auto *parser = (MBZParser *)user_data;
+
+	switch (parser->state)
+	{
+	case MBZParser::ROOT:
+		break;
+	case MBZParser::RELEASE:
+		if (strcmp(element_name, "release") == 0)
+			parser->state = MBZParser::ROOT;
+		break;
+	case MBZParser::RELEASE_TITLE:
+		parser->state = MBZParser::RELEASE;
+		parser->albumTitle = parser->value;
+		break;
+	case MBZParser::RELEASE_ARTIST_BLOCK:
+		if (strcmp(element_name, "artist") == 0)
+			parser->state = MBZParser::RELEASE;
+		break;
+	case MBZParser::RELEASE_ARTIST_NAME:
+		parser->albumArtist = parser->value;
+		parser->state = MBZParser::RELEASE_ARTIST_BLOCK;
+		break;
+	case MBZParser::RELEASE_ARTIST_GENRE:
+		if (strcmp(element_name, "genre-list") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_BLOCK;
+		break;
+	case MBZParser::RELEASE_ARTIST_GENRE_NAME:
+		if (parser->albumGenre.length() > 0)
+			parser->albumGenre += ",";
+		parser->albumGenre += parser->value;
+		parser->state = MBZParser::RELEASE_ARTIST_GENRE;
+		break;
+	case MBZParser::RELEASE_DATE:
+		parser->albumDate = parser->value;
+		parser->state = MBZParser::RELEASE;
+		break;
+	case MBZParser::TRACK_LIST:
+		if (strcmp(element_name, "track-list") == 0)
+			parser->state = MBZParser::RELEASE;
+		break;
+	case MBZParser::TRACK:
+		if (strcmp(element_name, "track") == 0)
+		{
+			parser->finishCurrenTrack();
+			parser->state = MBZParser::TRACK_LIST;
+		}
+		break;
+	case MBZParser::RECORDING_TRACKNUM:
+		parser->currentTrack.trackNum = std::stoi(parser->value);
+		parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::RECORDING_TITLE:
+		parser->currentTrack.title = parser->value;
+		parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::RECORDING_DURATION:
+		parser->currentTrack.duration = (std::stoi(parser->value) + 500) / 1000;
+		parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::RECORDING_ARTIST_BLOCK:
+		if (strcmp(element_name, "artist") == 0)
+			parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::RECORDING_ARTIST_GENRE:
+		if (strcmp(element_name, "genre-list") == 0)
+			parser->state = MBZParser::RECORDING_ARTIST_BLOCK;
+		break;
+	case MBZParser::RECORDING_ARTIST_NAME:
+		parser->currentTrack.artist = parser->value;
+		parser->state = MBZParser::RECORDING_ARTIST_BLOCK;
+		break;
+	case MBZParser::RECORDING_FIRST_RELEASE_DATE:
+		parser->currentTrack.firstReleaseDate = parser->value;
+		parser->state = MBZParser::TRACK;
+		break;
+	}
+}
+
+static void XMLCALL
+mbz_char_data (void *user_data, const XML_Char *s, int len)
+{
+	auto *parser = (MBZParser *)user_data;
+
+	switch (parser->state)
+	{
+	case MBZParser::ROOT:
+	case MBZParser::RELEASE:
+	case MBZParser::RELEASE_ARTIST_BLOCK:
+	case MBZParser::TRACK_LIST:
+	case MBZParser::TRACK:
+	case MBZParser::RECORDING_ARTIST_BLOCK:
+	case MBZParser::RECORDING_ARTIST_GENRE:
+	case MBZParser::RELEASE_ARTIST_GENRE:
+		break;
+	case MBZParser::RELEASE_TITLE:
+	case MBZParser::RELEASE_ARTIST_NAME:
+	case MBZParser::RECORDING_ARTIST_NAME:
+	case MBZParser::RECORDING_TITLE:
+	case MBZParser::RECORDING_DURATION:
+	case MBZParser::RELEASE_DATE:
+	case MBZParser::RECORDING_FIRST_RELEASE_DATE:
+	case MBZParser::RECORDING_TRACKNUM:
+		parser->value.append(s, len);
+		break;
+	case MBZParser::RELEASE_ARTIST_GENRE_NAME:
+		if (parser->value.length() > 0)
+			parser->value += ",";
+		parser->value.append(s, len);
+		break;
+	}
+}
+
+std::map<int, MusicBrainzCDTagCache::TrackInfo>
+MusicBrainzXMLParser::parse(std::string& body)
+{
+	MBZParser mbzParser;
+	{
+		ExpatParser expat(&mbzParser);
+	
+		expat.SetElementHandler(mbz_start_element, mbz_end_element);
+		expat.SetCharacterDataHandler(mbz_char_data);
+		expat.Parse(body, true);
+	}
+	return mbzParser.tracks;
+}

--- a/src/input/plugins/CdioParanoiaMusicBrainzXMLParser.hxx
+++ b/src/input/plugins/CdioParanoiaMusicBrainzXMLParser.hxx
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "CdioParanoiaMusicBrainzTags.hxx"
+
+class MusicBrainzXMLParser
+{
+public:
+	std::map<int, MusicBrainzCDTagCache::TrackInfo> parse(std::string& body);
+};

--- a/src/input/plugins/CdioParanoiaMusicBrainzXMLParser.hxx
+++ b/src/input/plugins/CdioParanoiaMusicBrainzXMLParser.hxx
@@ -1,9 +1,6 @@
 #pragma once
 
 #include "CdioParanoiaMusicBrainzTags.hxx"
+#include <map>
 
-class MusicBrainzXMLParser
-{
-public:
-	std::map<int, MusicBrainzCDTagCache::TrackInfo> parse(std::string& body);
-};
+std::map<int, MusicBrainzCDTagCache::TrackInfo> musicBrainzXMLParser (std::string& body);

--- a/src/input/plugins/meson.build
+++ b/src/input/plugins/meson.build
@@ -13,7 +13,12 @@ endif
 libcdio_paranoia_dep = dependency('libcdio_paranoia', version: '>= 10.2+0.93+1', required: get_option('cdio_paranoia'))
 input_features.set('ENABLE_CDIO_PARANOIA', libcdio_paranoia_dep.found())
 if libcdio_paranoia_dep.found()
-  input_plugins_sources += 'CdioParanoiaInputPlugin.cxx'
+  input_plugins_sources += [
+    'CdioParanoiaCDID.cxx',
+    'CdioParanoiaInputPlugin.cxx',
+    'CdioParanoiaMusicBrainzTags.cxx',
+    'CdioParanoiaMusicBrainzXMLParser.cxx',
+    ]
 endif
 
 if curl_dep.found()


### PR DESCRIPTION
Enabled by default (musicbrainz_tags_enabled), can be disabled with "musicbrainz_tags" bool option (cdio_paranoia plugin).

RemoteTagCache is disabled for this: changing the CD would fail to re-fetch the same looking "cdda:///x" tracks.
Tags are fetched only once per CD change.

For reference, a Musicbrainz URL used here can look like this:
[https://musicbrainz.org/ws/2/discid/iDvvaSuc6SAP8p_2FuI7V3dabAg-?inc=artist-credits+recordings+genres](https://musicbrainz.org/ws/2/discid/iDvvaSuc6SAP8p_2FuI7V3dabAg-?inc=artist-credits+recordings+genres)