### PR TITLE
tag/Id3Load: Fix handling zero-length tags in RIFF/AIFF

### DIFF
--- a/src/tag/Id3Load.cxx
+++ b/src/tag/Id3Load.cxx
@@ -182,6 +182,8 @@ try {
 		size = aiff_seek_id3(is, lock);
 	}
 
+	if (size == 0)
+		return nullptr;
 	if (size > 4 * 1024 * 1024)
 		/* too large, don't allocate so much memory */
 		return nullptr;


### PR DESCRIPTION
Fixes https://github.com/MusicPlayerDaemon/MPD/issues/2299.