### PR TITLE
Add: test program to fetch and parse audio CD info from Musicbrainz.

### DIFF
--- a/test/MusicbrainzCDID.cxx
+++ b/test/MusicbrainzCDID.cxx
@@ -1,0 +1,234 @@
+#include "fs/AllocatedPath.hxx"
+#include "lib/cdio/Paranoia.hxx"
+#include "util/StringCompare.hxx"
+#include "util/StringSplit.hxx"
+#include "util/NumberParser.hxx"
+#include "util/ScopeExit.hxx"
+#include "util/PrintException.hxx"
+#include <cdio/cd_types.h>
+#include <cstdint>
+#include <vector>
+
+extern "C" {
+#include <libavutil/sha.h>
+#include <libavutil/base64.h>
+#include <libavutil/mem.h>
+}
+
+#include <stdio.h>
+
+using std::string_view_literals::operator""sv;
+
+struct TrackOffsets
+{
+	int firstTrackNumber = 1;
+	int lastTrackNumber = -1;
+	int leadIn = -1;
+	std::vector<int> frameOffsets;
+
+	bool isValid () const
+	{
+		return lastTrackNumber >= firstTrackNumber
+			&& leadIn > 0
+			&& frameOffsets.size() > 0;
+	}
+};
+
+static const std::string
+makeMusicBrainzIdWithOffsets (const TrackOffsets& trackOffsets)
+{
+	const size_t numBitsSha1 = 160;
+	const size_t digestSize = numBitsSha1 / 8;
+	uint8_t digest[digestSize];
+	const size_t tempSize = 32;
+	char temp[tempSize];
+	struct AVSHA* sha1 = av_sha_alloc();
+
+	AtScopeExit(sha1) { av_free(sha1); };
+
+	av_sha_init(sha1, numBitsSha1);
+
+	snprintf(temp, tempSize, "%02X", trackOffsets.firstTrackNumber);
+	av_sha_update(sha1, (const uint8_t*)temp, strlen(temp));
+
+	snprintf(temp, tempSize, "%02X", trackOffsets.lastTrackNumber);
+	av_sha_update(sha1, (const uint8_t*)temp, strlen(temp));
+
+	const size_t numTracksNeeded = 100; 
+
+	if (trackOffsets.frameOffsets.size() > numTracksNeeded)
+	{
+		throw std::runtime_error("Too many tracks found");
+	}
+
+	for (size_t i = 0; i < trackOffsets.frameOffsets.size(); ++i)
+	{
+		int offset = trackOffsets.frameOffsets[i] + trackOffsets.leadIn;
+
+		snprintf(temp, tempSize, "%08X", offset);
+		av_sha_update(sha1, (const uint8_t*)temp, strlen(temp));
+	}
+
+	for (size_t i = trackOffsets.frameOffsets.size(); i < numTracksNeeded; ++i)
+	{
+		int offset = 0;
+
+		snprintf(temp, tempSize, "%08X", offset);
+		av_sha_update(sha1, (const uint8_t*)temp, strlen(temp));
+	}
+
+	av_sha_final(sha1, digest);
+
+	const size_t outputSize = 128;
+	char output[outputSize] = { 0 };
+
+	av_base64_encode(output, outputSize, digest, digestSize);
+
+	std::string outputString(output);
+
+	std::replace(outputString.begin(), outputString.end(), '=', '-');
+	std::replace(outputString.begin(), outputString.end(), '/', '_');
+	std::replace(outputString.begin(), outputString.end(), '+', '.');
+
+	return outputString;
+}
+
+static const TrackOffsets
+getTrackOffsetsFromDevice_cdio (const AllocatedPath& device)
+{
+	const auto cdio = cdio_open(device.c_str(), DRIVER_UNKNOWN);
+	if (cdio == nullptr)
+		throw std::runtime_error("Failed to open CD drive");
+
+	const auto drv = cdio_cddap_identify_cdio(cdio, 1, nullptr);
+	if (drv == nullptr)
+	{
+		cdio_destroy(cdio);
+		throw std::runtime_error("Unable to identify audio CD disc.");
+	}
+
+	AtScopeExit(cdio, drv)
+	{
+		cdio_cddap_close_no_free_cdio(drv);
+		cdio_destroy(cdio);
+	};
+
+	cdio_cddap_verbose_set(drv, CDDA_MESSAGE_FORGETIT, CDDA_MESSAGE_FORGETIT);
+
+	if (0 != cdio_cddap_open(drv))
+		throw std::runtime_error("Unable to open disc.");
+
+	auto lastSector = cdio_cddap_disc_lastsector(drv);
+	TrackOffsets trackOffsets;
+
+	int leadOut = (int)lastSector + 1;
+
+	trackOffsets.frameOffsets.push_back(leadOut);
+
+	int numTracks = (int)cdio_cddap_tracks(drv);
+
+	if (numTracks <= 0)
+		throw std::runtime_error("Invalid number of tracks found");
+
+	trackOffsets.firstTrackNumber = cdio_get_first_track_num(drv->p_cdio);
+
+	for (int i = 0; i < numTracks; ++i)
+	{
+		auto frameOffset = cdio_cddap_track_firstsector(drv, i + trackOffsets.firstTrackNumber);
+
+		trackOffsets.frameOffsets.push_back((int)frameOffset);
+	}
+
+	trackOffsets.leadIn = CDIO_PREGAP_SECTORS;
+	trackOffsets.lastTrackNumber = numTracks + trackOffsets.firstTrackNumber - 1;
+
+	return trackOffsets;
+}
+
+static AllocatedPath
+cdio_detect_device()
+{
+	char **devices = cdio_get_devices_with_cap(nullptr, CDIO_FS_AUDIO, false);
+
+	if (devices == nullptr)
+		return nullptr;
+
+	AtScopeExit(devices) { cdio_free_device_list(devices); };
+
+	if (devices[0] == nullptr)
+		return nullptr;
+
+	return AllocatedPath::FromFS(devices[0]);
+}
+
+struct CdioUri
+{
+	char device[64];
+	int track;
+};
+
+static CdioUri
+parse_cdio_uri (std::string_view src)
+{
+	CdioUri dest;
+
+	src = StringAfterPrefixIgnoreCase(src, "cdda://"sv);
+
+	const auto [device, track] = Split(src, '/');
+	if (device.size() >= sizeof(dest.device))
+		throw std::invalid_argument{"Device name is too long"};
+
+	*std::copy(device.begin(), device.end(), dest.device) = '\0';
+
+	if (!track.empty())
+	{
+		auto value = ParseInteger<uint_least16_t>(track);
+		if (!value)
+			throw std::invalid_argument{"Bad track number"};
+
+		dest.track = *value;
+	}
+	else
+		dest.track = -1;
+
+	return dest;
+}
+
+int
+main(int argc, char **argv) noexcept
+try {
+	if (argc != 2) {
+		fprintf(stderr, "Usage: MusicbrainzCDID track-uri\n"
+				"Where track-uri is a valid audio cd uri (starting with 'cdda://')\n"
+				"(first track of default drive is 'cdda:///1')\n");
+		return EXIT_FAILURE;
+	}
+
+	const std::string uri(argv[1]);
+	const auto parsed_uri = parse_cdio_uri(uri);
+	const AllocatedPath device = parsed_uri.device[0] != 0
+		? AllocatedPath::FromFS(parsed_uri.device)
+		: cdio_detect_device();
+
+	if (device.IsNull())
+		throw std::runtime_error("Unable find or access a CD-ROM drive with an audio CD in it.");
+
+	auto trackOffsets = getTrackOffsetsFromDevice_cdio(device);
+
+	if (!trackOffsets.isValid())
+		throw std::runtime_error("Disc track offsets found are invalid.");
+
+	auto musicbrainzId = makeMusicBrainzIdWithOffsets(trackOffsets);
+
+	if (musicbrainzId == std::string())
+		throw std::runtime_error("CDID creation failed");
+
+	fprintf(stderr, "CDID found\n");
+	fprintf(stdout, "%s\n", musicbrainzId.c_str());
+
+	return EXIT_SUCCESS;
+
+} catch (...) {
+	PrintException(std::current_exception());
+	return EXIT_FAILURE;
+}

--- a/test/MusicbrainzCache.hxx
+++ b/test/MusicbrainzCache.hxx
@@ -1,0 +1,310 @@
+#include "lib/expat/ExpatParser.hxx"
+#include <map>
+#include <string>
+
+extern "C" {
+#include <string.h>
+}
+
+#include <stdio.h>
+
+struct CDAlbumInfo
+{
+	struct TrackInfo
+	{
+		int trackNum = -99;
+		std::string title;
+		std::string artist;
+		std::string originalDate;
+		int duration = 0;
+	};
+
+	std::map<int, TrackInfo> tracks;
+
+	std::string albumTitle;
+	std::string albumDate;
+	std::string albumArtist;
+	std::string albumGenre;
+
+	void fixAlbumDateIfNeeded ()
+	{
+		if (albumDate == std::string() && tracks.size() > 0)
+		{
+			fprintf(stderr, "No album date found, using first track's date\n");
+			albumDate = tracks.begin()->second.originalDate;
+		}
+	}
+
+	void printResults ()
+	{
+		if (tracks.size() == 0)
+		{
+			fprintf(stderr, "No tracks found.\n");
+			return ;
+		}
+		fprintf(stderr, "album artist:'%s' album title:'%s' (date:'%s', genres:'%s')\n",
+				albumArtist.c_str(),
+				albumTitle.c_str(),
+				albumDate.c_str(),
+				albumGenre.c_str());
+		for (auto it : tracks)
+		{
+			fprintf(stderr, "track:%02d - artist:'%s' title:'%s' (original date:'%s')\n",
+					it.second.trackNum,
+					it.second.artist.c_str(),
+					it.second.title.c_str(),
+					it.second.originalDate.c_str());
+		}
+	}
+};
+
+struct MBZParser
+{
+	enum
+	{
+		ROOT,
+		RELEASE,
+		RELEASE_TITLE,
+		RELEASE_ARTIST_BLOCK,
+		RELEASE_ARTIST_NAME,
+		RELEASE_ARTIST_GENRE,
+		RELEASE_ARTIST_GENRE_NAME,
+		RELEASE_DATE,
+		TRACK_LIST,
+		TRACK,
+		RECORDING_TRACKNUM,
+		RECORDING_TITLE,
+		RECORDING_DURATION,
+		RECORDING_ARTIST_BLOCK,
+		RECORDING_ARTIST_NAME,
+		RECORDING_ARTIST_GENRE,
+		RECORDING_FIRST_RELEASE_DATE,
+	} state = ROOT;
+
+	std::string value;
+
+	CDAlbumInfo::TrackInfo currentTrack;
+	CDAlbumInfo cdAlbumInfo;
+
+	void finishCurrenTrack ()
+	{
+		cdAlbumInfo.tracks[currentTrack.trackNum] = currentTrack;
+		currentTrack = {};
+	}
+};
+
+static void XMLCALL
+mbz_start_element (void *user_data, const XML_Char *element_name,
+		[[maybe_unused]] const XML_Char **atts)
+{
+	auto *parser = (MBZParser *)user_data;
+
+	parser->value.clear();
+
+	switch (parser->state)
+	{
+	case MBZParser::ROOT:
+		if (strcmp(element_name, "release") == 0)
+			parser->state = MBZParser::RELEASE;
+		break;
+	case MBZParser::RELEASE:
+		if (strcmp(element_name, "artist") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_BLOCK;
+		else if (strcmp(element_name, "title") == 0)
+			parser->state = MBZParser::RELEASE_TITLE;
+		else if (strcmp(element_name, "date") == 0)
+			parser->state = MBZParser::RELEASE_DATE;
+		else if (strcmp(element_name, "track-list") == 0)
+			parser->state = MBZParser::TRACK_LIST;
+		break;
+	case MBZParser::RELEASE_ARTIST_BLOCK:
+		if (strcmp(element_name, "name") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_NAME;
+		else if (strcmp(element_name, "genre-list") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_GENRE;
+		break;
+	case MBZParser::RELEASE_ARTIST_GENRE:
+		if (strcmp(element_name, "name") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_GENRE_NAME;
+		break;
+	case MBZParser::TRACK_LIST:
+		if (strcmp(element_name, "track") == 0)
+			parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::TRACK:
+		if (strcmp(element_name, "artist") == 0)
+			parser->state = MBZParser::RECORDING_ARTIST_BLOCK;
+		else if (strcmp(element_name, "title") == 0)
+			parser->state = MBZParser::RECORDING_TITLE;
+		else if (strcmp(element_name, "length") == 0)
+			parser->state = MBZParser::RECORDING_DURATION;
+		else if (strcmp(element_name, "number") == 0)
+			parser->state = MBZParser::RECORDING_TRACKNUM;
+		else if (strcmp(element_name, "first-release-date") == 0)
+			parser->state = MBZParser::RECORDING_FIRST_RELEASE_DATE;
+		break;
+	case MBZParser::RECORDING_ARTIST_BLOCK:
+		if (strcmp(element_name, "name") == 0)
+			parser->state = MBZParser::RECORDING_ARTIST_NAME;
+		else if (strcmp(element_name, "genre-list") == 0)
+			parser->state = MBZParser::RECORDING_ARTIST_GENRE;
+		break;
+	case MBZParser::RECORDING_ARTIST_GENRE:
+	case MBZParser::RELEASE_TITLE:
+	case MBZParser::RELEASE_ARTIST_NAME:
+	case MBZParser::RELEASE_ARTIST_GENRE_NAME:
+	case MBZParser::RELEASE_DATE:
+	case MBZParser::RECORDING_TRACKNUM:
+	case MBZParser::RECORDING_TITLE:
+	case MBZParser::RECORDING_DURATION:
+	case MBZParser::RECORDING_ARTIST_NAME:
+	case MBZParser::RECORDING_FIRST_RELEASE_DATE:
+		break;
+	}
+}
+
+static void XMLCALL
+mbz_end_element (void *user_data, const XML_Char *element_name)
+{
+	auto *parser = (MBZParser *)user_data;
+
+	switch (parser->state)
+	{
+	case MBZParser::ROOT:
+		break;
+	case MBZParser::RELEASE:
+		if (strcmp(element_name, "release") == 0)
+			parser->state = MBZParser::ROOT;
+		break;
+	case MBZParser::RELEASE_TITLE:
+		parser->state = MBZParser::RELEASE;
+		parser->cdAlbumInfo.albumTitle = parser->value;
+		break;
+	case MBZParser::RELEASE_ARTIST_BLOCK:
+		if (strcmp(element_name, "artist") == 0)
+			parser->state = MBZParser::RELEASE;
+		break;
+	case MBZParser::RELEASE_ARTIST_NAME:
+		parser->cdAlbumInfo.albumArtist = parser->value;
+		parser->state = MBZParser::RELEASE_ARTIST_BLOCK;
+		break;
+	case MBZParser::RELEASE_ARTIST_GENRE:
+		if (strcmp(element_name, "genre-list") == 0)
+			parser->state = MBZParser::RELEASE_ARTIST_BLOCK;
+		break;
+	case MBZParser::RELEASE_ARTIST_GENRE_NAME:
+		if (parser->cdAlbumInfo.albumGenre.length() > 0)
+			parser->cdAlbumInfo.albumGenre += ",";
+		parser->cdAlbumInfo.albumGenre += parser->value;
+		parser->state = MBZParser::RELEASE_ARTIST_GENRE;
+		break;
+	case MBZParser::RELEASE_DATE:
+		parser->cdAlbumInfo.albumDate = parser->value;
+		parser->state = MBZParser::RELEASE;
+		break;
+	case MBZParser::TRACK_LIST:
+		if (strcmp(element_name, "track-list") == 0)
+			parser->state = MBZParser::RELEASE;
+		break;
+	case MBZParser::TRACK:
+		if (strcmp(element_name, "track") == 0)
+		{
+			parser->finishCurrenTrack();
+			parser->state = MBZParser::TRACK_LIST;
+		}
+		break;
+	case MBZParser::RECORDING_TRACKNUM:
+		parser->currentTrack.trackNum = std::stoi(parser->value);
+		parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::RECORDING_TITLE:
+		parser->currentTrack.title = parser->value;
+		parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::RECORDING_DURATION:
+		parser->currentTrack.duration = (std::stoi(parser->value) + 500) / 1000;
+		parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::RECORDING_ARTIST_BLOCK:
+		if (strcmp(element_name, "artist") == 0)
+			parser->state = MBZParser::TRACK;
+		break;
+	case MBZParser::RECORDING_ARTIST_GENRE:
+		if (strcmp(element_name, "genre-list") == 0)
+			parser->state = MBZParser::RECORDING_ARTIST_BLOCK;
+		break;
+	case MBZParser::RECORDING_ARTIST_NAME:
+		parser->currentTrack.artist = parser->value;
+		parser->state = MBZParser::RECORDING_ARTIST_BLOCK;
+		break;
+	case MBZParser::RECORDING_FIRST_RELEASE_DATE:
+		parser->currentTrack.originalDate = parser->value;
+		parser->state = MBZParser::TRACK;
+		break;
+	}
+}
+
+static void XMLCALL
+mbz_char_data (void *user_data, const XML_Char *s, int len)
+{
+	auto *parser = (MBZParser *)user_data;
+
+	switch (parser->state)
+	{
+	case MBZParser::ROOT:
+	case MBZParser::RELEASE:
+	case MBZParser::RELEASE_ARTIST_BLOCK:
+	case MBZParser::TRACK_LIST:
+	case MBZParser::TRACK:
+	case MBZParser::RECORDING_ARTIST_BLOCK:
+	case MBZParser::RECORDING_ARTIST_GENRE:
+	case MBZParser::RELEASE_ARTIST_GENRE:
+		break;
+	case MBZParser::RELEASE_TITLE:
+	case MBZParser::RELEASE_ARTIST_NAME:
+	case MBZParser::RECORDING_ARTIST_NAME:
+	case MBZParser::RECORDING_TITLE:
+	case MBZParser::RECORDING_DURATION:
+	case MBZParser::RELEASE_DATE:
+	case MBZParser::RECORDING_FIRST_RELEASE_DATE:
+	case MBZParser::RECORDING_TRACKNUM:
+		parser->value.append(s, len);
+		break;
+	case MBZParser::RELEASE_ARTIST_GENRE_NAME:
+		if (parser->value.length() > 0)
+			parser->value += ",";
+		parser->value.append(s, len);
+		break;
+	}
+}
+
+class MusicbrainzCache
+{
+	CDAlbumInfo cdAlbumInfo;
+
+public:
+	void musicBrainzXMLParser (std::string& body)
+	{
+		MBZParser mbzParser;
+		{
+			ExpatParser expat(&mbzParser);
+
+			expat.SetElementHandler(mbz_start_element, mbz_end_element);
+			expat.SetCharacterDataHandler(mbz_char_data);
+			expat.Parse(body, true);
+		}
+		cdAlbumInfo = std::move(mbzParser.cdAlbumInfo);
+		cdAlbumInfo.fixAlbumDateIfNeeded();
+	}
+
+	bool makeTrackInfoFromXml (std::string& body)
+	{
+		musicBrainzXMLParser(body);
+		return cdAlbumInfo.tracks.size() > 0;
+	}
+
+	void printResults ()
+	{
+		cdAlbumInfo.printResults();
+	}
+};

--- a/test/MusicbrainzFetch.cxx
+++ b/test/MusicbrainzFetch.cxx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The Music Player Daemon Project
+
+#include "ShutdownHandler.hxx"
+#include "lib/curl/Global.hxx"
+#include "lib/curl/Request.hxx"
+#include "lib/curl/StringHandler.hxx"
+#include "event/Loop.hxx"
+#include "util/PrintException.hxx"
+#include "MusicbrainzCache.hxx"
+#include <string>
+#include <stdio.h>
+
+class ResponseHandler final : public StringCurlResponseHandler {
+	EventLoop &event_loop;
+	MusicbrainzCache &musicbrainzCache;
+	std::exception_ptr error;
+
+public:
+	explicit ResponseHandler(EventLoop &_event_loop, MusicbrainzCache &_cache) noexcept
+		:event_loop(_event_loop), musicbrainzCache(_cache) {}
+
+	void Finish() {
+		if (error)
+			std::rethrow_exception(error);
+	}
+
+	void OnEnd() override {
+		auto resp = StringCurlResponseHandler::GetResponse();
+
+		if (musicbrainzCache.makeTrackInfoFromXml(resp.body))
+			musicbrainzCache.printResults();
+		else
+			throw std::runtime_error("Failed to parse");
+		event_loop.Break();
+	}
+
+	void OnError(std::exception_ptr e) noexcept override {
+		error = std::move(e);
+		event_loop.Break();
+	}
+};
+
+
+int
+main(int argc, char **argv) noexcept
+try {
+	if (argc != 2) {
+		fprintf(stderr, "Usage: FetchMusicbrainz cd-id\n");
+		return EXIT_FAILURE;
+	}
+
+	std::string cdid(argv[1]);
+	std::string urlPrefix("https://musicbrainz.org/ws/2/discid/");
+	std::string urlArgs("?inc=artist-credits+recordings+genres");
+	std::string url = urlPrefix + cdid + urlArgs;
+	EventLoop event_loop;
+	const ShutdownHandler shutdown_handler(event_loop);
+	CurlGlobal curl_global(event_loop);
+	MusicbrainzCache musicbrainzCache;
+
+	ResponseHandler handler(event_loop, musicbrainzCache);
+	CurlRequest request(curl_global, url.c_str(), handler);
+	request.Start();
+
+	event_loop.Run();
+
+	handler.Finish();
+
+	return EXIT_SUCCESS;
+} catch (...) {
+	PrintException(std::current_exception());
+	return EXIT_FAILURE;
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -642,4 +642,22 @@ if alsa_dep.found()
   )
 endif
 
+#
+# Musicbrainz
+#
+
+if curl_dep.found() and expat_dep.found()
+  executable(
+    'MusicbrainzFetch',
+    'MusicbrainzFetch.cxx',
+    'ShutdownHandler.cxx',
+    include_directories: inc,
+    dependencies: [
+      curl_dep,
+      event_dep,
+      expat_dep,
+    ],
+  )
+endif
+
 subdir('fs')

--- a/test/meson.build
+++ b/test/meson.build
@@ -660,4 +660,17 @@ if curl_dep.found() and expat_dep.found()
   )
 endif
 
+if libcdio_paranoia_dep.found() and ffmpeg_dep.found()
+  executable(
+    'MusicbrainzCDID',
+    'MusicbrainzCDID.cxx',
+    include_directories: inc,
+    dependencies: [
+      libcdio_paranoia_dep,
+      ffmpeg_dep,
+      config_dep,
+    ],
+  )
+endif
+
 subdir('fs')

--- a/test/test_musicbrainz.sh
+++ b/test/test_musicbrainz.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+echo "Fetching for id 'iDvvaSuc6SAP8p_2FuI7V3dabAg'..."
+./test/MusicbrainzFetch iDvvaSuc6SAP8p_2FuI7V3dabAg-
+echo
+echo "Fetching for id '.hw8qyOjKencjxtAAsiE2l7geu4-'..."
+./test/MusicbrainzFetch .hw8qyOjKencjxtAAsiE2l7geu4-


### PR DESCRIPTION
Generates a Curl request to Musicbrainz from an audio CD id given as parameter.

CD id must be calculated as decribed here: [https://musicbrainz.org/doc/Disc_ID_Calculation](https://musicbrainz.org/doc/Disc_ID_Calculation)

2 ids are given in test script.
The XML received is parsed and a digest of the tags is printed out to stderr.

(another test program to output id from a loaded CD will come next)