### PR TITLE
system/Error: manually prepare localized error code messages through error category method on windows

### DIFF
--- a/src/lib/fmt/SystemError.cxx
+++ b/src/lib/fmt/SystemError.cxx
@@ -16,26 +16,17 @@ VFmtSystemError(std::error_code code,
 
 #include <array>
 
-#include <windef.h> // for HWND (needed by winbase.h)
-#include <winbase.h> // for FormatMessageA()
-
 std::system_error
 VFmtLastError(DWORD code,
 	      fmt::string_view format_str, fmt::format_args args) noexcept
 {
 	std::array<char, 512> buffer;
-	const auto end = buffer.data() + buffer.size();
 
 	constexpr std::size_t max_prefix = sizeof(buffer) - 128;
 	auto [p, _] = fmt::vformat_to_n(buffer.data(),
 					buffer.size() - max_prefix,
 					format_str, args);
-	*p++ = ':';
-	*p++ = ' ';
-
-	FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
-		       FORMAT_MESSAGE_IGNORE_INSERTS,
-		       nullptr, code, 0, p, end - p, nullptr);
+	*p = '\0';
 
 	return MakeLastError(code, buffer.data());
 }


### PR DESCRIPTION
`FormatMessageA` in `VFmtLastError` and `std::system_category::message`
produce non-utf8 multi-byte string, which causes
`std::runtime_error("invalid utf8")` thrown in
`fmt::detail::utf8_to_utf16::utf8_to_utf16`.

Use `FormatMessageW` with a custom category to override `message` method
for utf-8 error message.

Remove `FormatMessageA` in `VFmtLastError` to remove duplicated error message from error code.

fix #2302