### PR TITLE
Fix typos in messages

### DIFF
--- a/src/client/Process.cxx
+++ b/src/client/Process.cxx
@@ -60,7 +60,7 @@ Client::ProcessLine(char *line) noexcept
 
 	if (cmd_list.IsActive() && IsAsyncCommmand(line)) {
 		FmtWarning(client_domain,
-			   "[{}] not possible in comand list: {:?}",
+			   "[{}] not possible in command list: {:?}",
 			   name, line);
 		return CommandResult::CLOSE;
 	}

--- a/src/command/ClientCommands.cxx
+++ b/src/command/ClientCommands.cxx
@@ -128,7 +128,7 @@ ParseProtocolFeature(Request request)
 	for (const char *name : request) {
 		auto type = protocol_feature_parse_i(name);
 		if (type == PF_NUM_OF_ITEM_TYPES)
-			throw ProtocolError(ACK_ERROR_ARG, "Unknown protcol feature");
+			throw ProtocolError(ACK_ERROR_ARG, "Unknown protocol feature");
 
 		result |= type;
 	}


### PR DESCRIPTION
protcol -> protocol

comand -> command

Found by Debian's lintian spellchecker