### PR TITLE
Implement diacritics stripping and string normalization command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 ver 0.25 (not yet released)
 * protocol
   - implement "window" parameter for command "list"
+  - new command "stringnormalization"
 * decoder
   - vgmstream: new plugin
 * output

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1751,6 +1751,44 @@ Connection settings
 :command:`protocol available`
     Lists all available protocol features.
 
+.. _command_stringnormalization:
+
+:command:`stringnormalization`
+    Shows a list of enabled string normalization options when searching
+    using :ref:`search <command_search>`.
+
+    Available options:
+
+    - ``strip_diacritics``: strip diacritics from searched strings
+
+    The following ``stringnormalization`` sub commands configure the
+    options.
+
+.. _command_stringnormalization_disable:
+
+:command:`stringnormalization disable {FEATURE...}`
+    Disables one or more string normalization options.
+
+.. _command_stringnormalization_enable:
+
+:command:`stringnormalization enable {FEATURE...}`
+    Enables one or more string normalization options.
+
+.. _command_stringnormalization_clear:
+
+:command:`stringnormalization clear`
+    Disables all string normalization options.
+
+.. _command_stringnormalization_all:
+
+:command:`stringnormalization all`
+    Enables all string normalization options.
+
+.. _command_stringnormalization_available:
+
+:command:`stringnormalization available`
+    Lists all available string normalization options.
+
 .. _partition_commands:
 
 Partition commands

--- a/meson.build
+++ b/meson.build
@@ -381,6 +381,7 @@ sources = [
   'src/client/Response.cxx',
   'src/client/ThreadBackgroundCommand.cxx',
   'src/client/ProtocolFeature.cxx',
+  'src/client/StringNormalization.cxx',
   'src/Listen.cxx',
   'src/LogInit.cxx',
   'src/ls.cxx',

--- a/src/client/Client.hxx
+++ b/src/client/Client.hxx
@@ -6,6 +6,7 @@
 #include "IClient.hxx"
 #include "Message.hxx"
 #include "ProtocolFeature.hxx"
+#include "client/StringNormalization.hxx"
 #include "command/CommandResult.hxx"
 #include "command/CommandListBuilder.hxx"
 #include "db/Features.hxx" // for ENABLE_DATABASE
@@ -119,6 +120,11 @@ private:
 	 */
 	ProtocolFeature protocol_feature = ProtocolFeature::None();
 
+	/**
+	 * Bitmask of string normalizations
+	 */
+	StringNormalization string_normalization = StringNormalization::None();
+
 public:
 	Client(EventLoop &loop, Partition &partition,
 	       UniqueSocketDescriptor fd, int uid,
@@ -196,6 +202,29 @@ public:
 
 	bool ProtocolFeatureEnabled(enum ProtocolFeatureType value) noexcept {
 		return protocol_feature.Test(value);
+	}
+
+	StringNormalization GetStringNormalizations() const noexcept {
+		return string_normalization;
+	}
+
+	void SetStringNormalizations(StringNormalization features, bool enable) noexcept {
+		if (enable)
+			string_normalization.Set(features);
+		else
+			string_normalization.Unset(features);
+	}
+
+	void AllStringNormalizations() noexcept {
+		string_normalization.SetAll();
+	}
+
+	void ClearStringNormalizations() noexcept {
+		string_normalization.Clear();
+	}
+
+	bool StringNormalizationEnabled(enum StringNormalizationType value) noexcept {
+		return string_normalization.Test(value);
 	}
 
 	/**

--- a/src/client/StringNormalization.cxx
+++ b/src/client/StringNormalization.cxx
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The Music Player Daemon Project
+
+#include "StringNormalization.hxx"
+#include "Client.hxx"
+#include "Response.hxx"
+#include "util/StringAPI.hxx"
+
+#include <cassert>
+#include <fmt/format.h>
+
+struct string_normalization_type_table {
+	const char *name;
+
+	StringNormalizationType type;
+};
+
+static constexpr struct string_normalization_type_table string_normalization_names_init[] = {
+	{"strip_diacritics", SN_STRIP_DIACRITICS},
+};
+
+static constexpr auto
+MakeStringNormalizationNames() noexcept
+{
+	std::array<const char *, PF_NUM_OF_ITEM_TYPES> result{};
+
+	static_assert(std::size(string_normalization_names_init) == result.size());
+
+	for (const auto &i : string_normalization_names_init) {
+		assert(result[i.type] == nullptr);
+
+		result[i.type] = i.name;
+	}
+
+	return result;
+}
+
+constinit const std::array<const char *, SN_NUM_OF_ITEM_TYPES> string_normalization_names = MakeStringNormalizationNames();
+
+void
+string_normalizations_print(Client &client, Response &r) noexcept
+{
+	const auto string_normalization = client.GetStringNormalizations();
+	for (unsigned i = 0; i < PF_NUM_OF_ITEM_TYPES; i++)
+		if (string_normalization.Test(StringNormalizationType(i)))
+			r.Fmt("stringnormalization: {}\n", string_normalization_names[i]);
+}
+
+void
+string_normalizations_print_all(Response &r) noexcept
+{
+	for (unsigned i = 0; i < SN_NUM_OF_ITEM_TYPES; i++)
+		r.Fmt("stringnormalization: {}\n", string_normalization_names[i]);
+}
+
+StringNormalizationType
+string_normalization_parse_i(const char *name) noexcept
+{
+	for (unsigned i = 0; i < SN_NUM_OF_ITEM_TYPES; ++i) {
+		assert(string_normalization_names[i] != nullptr);
+
+		if (StringIsEqualIgnoreCase(name, string_normalization_names[i]))
+			return (StringNormalizationType)i;
+	}
+
+	return SN_NUM_OF_ITEM_TYPES;
+}

--- a/src/client/StringNormalization.hxx
+++ b/src/client/StringNormalization.hxx
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The Music Player Daemon Project
+
+#pragma once
+
+#include <string_view>
+#include <cstdint>
+
+class Client;
+class Response;
+
+/**
+ * Codes for the string normalization options.
+ */
+enum StringNormalizationType : uint8_t {
+	SN_STRIP_DIACRITICS,
+
+	SN_NUM_OF_ITEM_TYPES
+};
+
+class StringNormalization {
+	using string_normalization_t = uint_least8_t;
+
+	/* must have enough bits to represent all string normalization options
+	   supported by MPD */
+	static_assert(SN_NUM_OF_ITEM_TYPES <= sizeof(string_normalization_t) * 8);
+
+	string_normalization_t value;
+
+	explicit constexpr StringNormalization(string_normalization_t  _value) noexcept
+		:value(_value) {}
+
+public:
+	constexpr StringNormalization() noexcept = default;
+
+	constexpr StringNormalization(StringNormalizationType _value) noexcept
+		:value(string_normalization_t(1) << string_normalization_t(_value)) {}
+
+	static constexpr StringNormalization None() noexcept {
+		return StringNormalization(string_normalization_t(0));
+	}
+
+	static constexpr StringNormalization All() noexcept {
+		return ~None();
+	}
+
+	constexpr StringNormalization operator~() const noexcept {
+		return StringNormalization(~value);
+	}
+
+	constexpr StringNormalization operator&(StringNormalization other) const noexcept {
+		return StringNormalization(value & other.value);
+	}
+
+	constexpr StringNormalization operator|(StringNormalization other) const noexcept {
+		return StringNormalization(value | other.value);
+	}
+
+	constexpr StringNormalization operator^(StringNormalization other) const noexcept {
+		return StringNormalization(value ^ other.value);
+	}
+
+	constexpr StringNormalization &operator&=(StringNormalization other) noexcept {
+		value &= other.value;
+		return *this;
+	}
+
+	constexpr StringNormalization &operator|=(StringNormalization other) noexcept {
+		value |= other.value;
+		return *this;
+	}
+
+	constexpr StringNormalization &operator^=(StringNormalization other) noexcept {
+		value ^= other.value;
+		return *this;
+	}
+
+	constexpr bool TestAny() const noexcept {
+		return value != 0;
+	}
+
+	constexpr bool Test(StringNormalization feature) const noexcept {
+		return (*this & feature).TestAny();
+	}
+
+	constexpr void Set(StringNormalization features) noexcept {
+		*this |= features;
+	}
+
+	constexpr void Unset(StringNormalization features) noexcept {
+		*this &= ~StringNormalization(features);
+	}
+
+	constexpr void SetAll() noexcept {
+		*this = StringNormalization::All();
+	}
+
+	constexpr void Clear() noexcept {
+		*this = StringNormalization::None();
+	}
+};
+
+void
+string_normalizations_print(Client &client, Response &r) noexcept;
+
+void
+string_normalizations_print_all(Response &r) noexcept;
+
+StringNormalizationType
+string_normalization_parse_i(const char *name) noexcept;

--- a/src/command/AllCommands.cxx
+++ b/src/command/AllCommands.cxx
@@ -195,6 +195,7 @@ static constexpr struct command commands[] = {
 	{ "stickertypes", PERMISSION_ADMIN, 0, 0, handle_sticker_types },
 #endif
 	{ "stop", PERMISSION_PLAYER, 0, 0, handle_stop },
+	{ "stringnormalization", PERMISSION_NONE, 0, -1, handle_string_normalization },
 	{ "subscribe", PERMISSION_READ, 1, 1, handle_subscribe },
 	{ "swap", PERMISSION_PLAYER, 2, 2, handle_swap },
 	{ "swapid", PERMISSION_PLAYER, 2, 2, handle_swapid },

--- a/src/command/ClientCommands.hxx
+++ b/src/command/ClientCommands.hxx
@@ -28,4 +28,7 @@ handle_tagtypes(Client &client, Request request, Response &response);
 CommandResult
 handle_protocol(Client &client, Request request, Response &response);
 
+CommandResult
+handle_string_normalization(Client &client, Request request, Response &response);
+
 #endif

--- a/src/command/QueueCommands.cxx
+++ b/src/command/QueueCommands.cxx
@@ -291,7 +291,7 @@ ParseSortTag(const char *s)
 
 static CommandResult
 handle_playlist_match(Client &client, Request args, Response &r,
-		      bool fold_case)
+		      bool fold_case, bool strip_diacritics)
 {
 	RangeArg window = RangeArg::All();
 	if (args.size() >= 2 && StringIsEqual(args[args.size() - 2], "window")) {
@@ -318,7 +318,7 @@ handle_playlist_match(Client &client, Request args, Response &r,
 
 	SongFilter filter;
 	try {
-		filter.Parse(args, fold_case);
+		filter.Parse(args, fold_case, strip_diacritics);
 	} catch (...) {
 		r.Error(ACK_ERROR_ARG,
 			GetFullMessage(std::current_exception()).c_str());
@@ -339,13 +339,14 @@ handle_playlist_match(Client &client, Request args, Response &r,
 CommandResult
 handle_playlistfind(Client &client, Request args, Response &r)
 {
-	return handle_playlist_match(client, args, r, false);
+	return handle_playlist_match(client, args, r, false, false);
 }
 
 CommandResult
 handle_playlistsearch(Client &client, Request args, Response &r)
 {
-	return handle_playlist_match(client, args, r, true);
+	auto strip_diacritics = client.StringNormalizationEnabled(SN_STRIP_DIACRITICS);
+	return handle_playlist_match(client, args, r, true, strip_diacritics);
 }
 
 CommandResult

--- a/src/lib/icu/Canonicalize.hxx
+++ b/src/lib/icu/Canonicalize.hxx
@@ -27,8 +27,9 @@ IcuCanonicalizeFinish() noexcept;
  * used):
  *
  * - case folding (optional)
+ * - diacritics stripping (optional)
  */
 AllocatedString
-IcuCanonicalize(std::string_view src, bool fold_case) noexcept;
+IcuCanonicalize(std::string_view src, bool fold_case, bool strip_diacritics) noexcept;
 
 #endif

--- a/src/lib/icu/Compare.cxx
+++ b/src/lib/icu/Compare.cxx
@@ -13,13 +13,17 @@
 
 #ifdef HAVE_ICU_CANONICALIZE
 
-IcuCompare::IcuCompare(std::string_view _needle) noexcept
-	:needle(IcuCanonicalize(_needle, true)) {}
+IcuCompare::IcuCompare(std::string_view _needle, bool _fold_case, bool _strip_diacritics) noexcept
+	:needle(IcuCanonicalize(_needle, _fold_case, _strip_diacritics)),
+	 fold_case(_fold_case),
+	 strip_diacritics(_strip_diacritics) {}
 
 #elif defined(_WIN32)
 
-IcuCompare::IcuCompare(std::string_view _needle) noexcept
-	:needle(nullptr)
+IcuCompare::IcuCompare(std::string_view _needle, bool _fold_case, bool _strip_diacritics) noexcept
+	:needle(nullptr),
+	 fold_case(_fold_case),
+	 strip_diacritics(_strip_diacritics)
 {
 	try {
 		needle = MultiByteToWideChar(CP_UTF8, _needle);
@@ -29,8 +33,12 @@ IcuCompare::IcuCompare(std::string_view _needle) noexcept
 
 #else
 
-IcuCompare::IcuCompare(std::string_view _needle) noexcept
-	:needle(_needle) {}
+IcuCompare::IcuCompare(std::string_view _needle,
+		       [[maybe_unused]] bool _fold_case,
+		       [[maybe_unused]] bool _strip_diacritics) noexcept
+	:needle(_needle),
+	 fold_case(false),
+	 strip_diacritics(false) {}
 
 #endif
 
@@ -38,7 +46,7 @@ bool
 IcuCompare::operator==(const char *haystack) const noexcept
 {
 #ifdef HAVE_ICU_CANONICALIZE
-	return StringIsEqual(IcuCanonicalize(haystack, true).c_str(), needle.c_str());
+	return StringIsEqual(IcuCanonicalize(haystack, fold_case, strip_diacritics).c_str(), needle.c_str());
 #elif defined(_WIN32)
 	if (needle == nullptr)
 		/* the MultiByteToWideChar() call in the constructor
@@ -64,7 +72,7 @@ bool
 IcuCompare::IsIn(const char *haystack) const noexcept
 {
 #ifdef HAVE_ICU_CANONICALIZE
-	return StringFind(IcuCanonicalize(haystack, true).c_str(),
+	return StringFind(IcuCanonicalize(haystack, fold_case, strip_diacritics).c_str(),
 			  needle.c_str()) != nullptr;
 #elif defined(_WIN32)
 	if (needle == nullptr)
@@ -101,7 +109,7 @@ bool
 IcuCompare::StartsWith(const char *haystack) const noexcept
 {
 #ifdef HAVE_ICU_CANONICALIZE
-	return StringStartsWith(IcuCanonicalize(haystack, true).c_str(),
+	return StringStartsWith(IcuCanonicalize(haystack, fold_case, strip_diacritics).c_str(),
 				needle);
 #elif defined(_WIN32)
 	if (needle == nullptr)

--- a/src/lib/icu/Compare.hxx
+++ b/src/lib/icu/Compare.hxx
@@ -25,21 +25,27 @@ class IcuCompare {
 #endif
 
 	AllocatedString needle;
+	bool fold_case;
+	bool strip_diacritics;
 
 public:
 	IcuCompare():needle(nullptr) {}
 
-	explicit IcuCompare(std::string_view needle) noexcept;
+	explicit IcuCompare(std::string_view needle, bool fold_case, bool strip_diacritics) noexcept;
 
 	IcuCompare(const IcuCompare &src) noexcept
 		:needle(src
 			? AllocatedString(src.needle)
-			: nullptr) {}
+			: nullptr),
+		 fold_case(src.fold_case),
+		 strip_diacritics(src.strip_diacritics) {}
 
 	IcuCompare &operator=(const IcuCompare &src) noexcept {
 		needle = src
 			? AllocatedString(src.needle)
 			: nullptr;
+		fold_case = src.fold_case;
+		strip_diacritics = src.strip_diacritics;
 		return *this;
 	}
 
@@ -59,6 +65,10 @@ public:
 
 	[[gnu::pure]]
 	bool StartsWith(const char *haystack) const noexcept;
+
+	bool GetFoldCase() const noexcept {
+		return needle != nullptr && fold_case;
+	}
 };
 
 #endif

--- a/src/song/Filter.hxx
+++ b/src/song/Filter.hxx
@@ -35,7 +35,7 @@ class SongFilter {
 public:
 	SongFilter() = default;
 
-	SongFilter(TagType tag, const char *value, bool fold_case=false);
+	SongFilter(TagType tag, const char *value, bool fold_case=false, bool strip_diacritics=false);
 
 	~SongFilter();
 
@@ -49,15 +49,15 @@ public:
 	std::string ToExpression() const noexcept;
 
 private:
-	static ISongFilterPtr ParseExpression(const char *&s, bool fold_case=false);
+	static ISongFilterPtr ParseExpression(const char *&s, bool fold_case=false, bool strip_diacritics=false);
 
-	void Parse(const char *tag, const char *value, bool fold_case=false);
+	void Parse(const char *tag, const char *value, bool fold_case=false, bool strip_diacritics=false);
 
 public:
 	/**
 	 * Throws on error.
 	 */
-	void Parse(std::span<const char *const> args, bool fold_case=false);
+	void Parse(std::span<const char *const> args, bool fold_case=false, bool strip_diacritics=false);
 
 	void Optimize() noexcept;
 

--- a/src/song/StringFilter.cxx
+++ b/src/song/StringFilter.cxx
@@ -16,19 +16,19 @@ StringFilter::MatchWithoutNegation(const char *s) const noexcept
 		return regex->Match(s);
 #endif
 
-	if (fold_case) {
+	if (icu_compare) {
 		switch (position) {
 		case Position::FULL:
 			break;
 
 		case Position::ANYWHERE:
-			return fold_case.IsIn(s);
+			return icu_compare.IsIn(s);
 
 		case Position::PREFIX:
-			return fold_case.StartsWith(s);
+			return icu_compare.StartsWith(s);
 		}
 
-		return fold_case == s;
+		return icu_compare == s;
 	} else {
 		switch (position) {
 		case Position::FULL:

--- a/src/song/StringFilter.hxx
+++ b/src/song/StringFilter.hxx
@@ -32,9 +32,9 @@ private:
 	std::string value;
 
 	/**
-	 * This value is only set if case folding is enabled.
+	 * This value is only set if case folding or diacritics stripping is enabled.
 	 */
-	IcuCompare fold_case;
+	IcuCompare icu_compare;
 
 #ifdef HAVE_PCRE
 	std::shared_ptr<UniqueRegex> regex;
@@ -46,10 +46,10 @@ private:
 
 public:
 	template<typename V>
-	StringFilter(V &&_value, bool _fold_case, Position _position, bool _negated)
+	StringFilter(V &&_value, bool _fold_case, bool _strip_diacritics, Position _position, bool _negated)
 		:value(std::forward<V>(_value)),
-		 fold_case(_fold_case
-			   ? IcuCompare(value)
+		 icu_compare(_fold_case || _strip_diacritics
+			   ? IcuCompare(value, _fold_case, _strip_diacritics)
 			   : IcuCompare()),
 		 position(_position),
 		 negated(_negated) {}
@@ -78,7 +78,7 @@ public:
 	}
 
 	bool GetFoldCase() const noexcept {
-		return fold_case;
+		return icu_compare.GetFoldCase();
 	}
 
 	bool IsNegated() const noexcept {

--- a/test/TestStringFilter.cxx
+++ b/test/TestStringFilter.cxx
@@ -20,7 +20,7 @@ protected:
 
 TEST_F(StringFilterTest, ASCII)
 {
-	const StringFilter f{"needle", false, StringFilter::Position::FULL, false};
+	const StringFilter f{"needle", false, false, StringFilter::Position::FULL, false};
 
 	EXPECT_TRUE(f.Match("needle"));
 	EXPECT_FALSE(f.Match("nëedle"));
@@ -37,7 +37,7 @@ TEST_F(StringFilterTest, ASCII)
 
 TEST_F(StringFilterTest, Negated)
 {
-	const StringFilter f{"needle", false, StringFilter::Position::FULL, true};
+	const StringFilter f{"needle", false, false, StringFilter::Position::FULL, true};
 
 	EXPECT_FALSE(f.Match("needle"));
 	EXPECT_TRUE(f.Match("Needle"));
@@ -50,7 +50,7 @@ TEST_F(StringFilterTest, Negated)
 
 TEST_F(StringFilterTest, StartsWith)
 {
-	const StringFilter f{"needle", false, StringFilter::Position::PREFIX, false};
+	const StringFilter f{"needle", false, false, StringFilter::Position::PREFIX, false};
 
 	EXPECT_TRUE(f.Match("needle"));
 	EXPECT_FALSE(f.Match("Needle"));
@@ -64,7 +64,7 @@ TEST_F(StringFilterTest, StartsWith)
 
 TEST_F(StringFilterTest, IsIn)
 {
-	const StringFilter f{"needle", false, StringFilter::Position::ANYWHERE, false};
+	const StringFilter f{"needle", false, false, StringFilter::Position::ANYWHERE, false};
 
 	EXPECT_TRUE(f.Match("needle"));
 	EXPECT_FALSE(f.Match("Needle"));
@@ -78,7 +78,7 @@ TEST_F(StringFilterTest, IsIn)
 
 TEST_F(StringFilterTest, Latin)
 {
-	const StringFilter f{"nëedlé", false, StringFilter::Position::FULL, false};
+	const StringFilter f{"nëedlé", false, false, StringFilter::Position::FULL, false};
 
 	EXPECT_TRUE(f.Match("nëedlé"));
 #if defined(HAVE_ICU) || defined(_WIN32)
@@ -101,7 +101,7 @@ TEST_F(StringFilterTest, Latin)
 
 TEST_F(StringFilterTest, Normalize)
 {
-	const StringFilter f{"1①H", true, StringFilter::Position::FULL, false};
+	const StringFilter f{"1①H", true, false, StringFilter::Position::FULL, false};
 
 	EXPECT_TRUE(f.Match("1①H"));
 
@@ -114,14 +114,14 @@ TEST_F(StringFilterTest, Normalize)
 
 	EXPECT_FALSE(f.Match("21H"));
 
-	EXPECT_TRUE(StringFilter("ǆ", true, StringFilter::Position::FULL, false).Match("dž"));
+	EXPECT_TRUE(StringFilter("ǆ", true, false, StringFilter::Position::FULL, false).Match("dž"));
 
-	EXPECT_TRUE(StringFilter("\u212b", true, StringFilter::Position::FULL, false).Match("\u0041\u030a"));
-	EXPECT_TRUE(StringFilter("\u212b", true, StringFilter::Position::FULL, false).Match("\u00c5"));
+	EXPECT_TRUE(StringFilter("\u212b", true, false, StringFilter::Position::FULL, false).Match("\u0041\u030a"));
+	EXPECT_TRUE(StringFilter("\u212b", true, false, StringFilter::Position::FULL, false).Match("\u00c5"));
 
-	EXPECT_TRUE(StringFilter("\u1e69", true, StringFilter::Position::FULL, false).Match("\u0073\u0323\u0307"));
+	EXPECT_TRUE(StringFilter("\u1e69", true, false, StringFilter::Position::FULL, false).Match("\u0073\u0323\u0307"));
 
-	EXPECT_TRUE(StringFilter("\u1e69", true, StringFilter::Position::FULL, false).Match("\u0073\u0307\u0323"));
+	EXPECT_TRUE(StringFilter("\u1e69", true, false, StringFilter::Position::FULL, false).Match("\u0073\u0307\u0323"));
 }
 
 #endif
@@ -130,17 +130,23 @@ TEST_F(StringFilterTest, Normalize)
 
 TEST_F(StringFilterTest, Transliterate)
 {
-	const StringFilter f{"'", true, StringFilter::Position::FULL, false};
+	const StringFilter f{"'", true, false, StringFilter::Position::FULL, false};
 
 	EXPECT_TRUE(f.Match("’"));
 	EXPECT_FALSE(f.Match("\""));
+	EXPECT_TRUE(StringFilter("áéíóúýčďěňřšťžůåäöüàãâçêõîşûğăôơư", true, true, StringFilter::Position::FULL, false)
+		.Match("aeiouycdenrstzuaaouaaaceoisugaoou"));
+	EXPECT_TRUE(StringFilter("ÁÉÍÓÚÝČĎĚŇŘŠŤŽŮÅÄÖÜÀÃÂÇÊÕÎŞÛĞĂÔƠƯ", true, true, StringFilter::Position::FULL, false)
+		.Match("áéíóúýčďěňřšťžůåäöüàãâçêõîşûğăôơư"));
+	EXPECT_FALSE(StringFilter("ÁÉÍÓÚÝČĎĚŇŘŠŤŽŮÅÄÖÜÀÃÂÇÊÕÎŞÛĞĂÔƠƯ", false, true, StringFilter::Position::FULL, false)
+		.Match("áéíóúýčďěňřšťžůåäöüàãâçêõîşûğăôơư"));
 }
 
 #endif
 
 TEST_F(StringFilterTest, FoldCase)
 {
-	const StringFilter f{"nëedlé", true, StringFilter::Position::FULL, false};
+	const StringFilter f{"nëedlé", true, false, StringFilter::Position::FULL, false};
 
 	EXPECT_TRUE(f.Match("nëedlé"));
 #if defined(HAVE_ICU) || defined(_WIN32)

--- a/test/TestTagSongFilter.cxx
+++ b/test/TestTagSongFilter.cxx
@@ -30,7 +30,7 @@ TEST_F(TagSongFilterTest, Basic)
 {
 	const TagSongFilter f{
 		TAG_TITLE,
-		{"needle", false, StringFilter::Position::FULL, false},
+		{"needle", false, false, StringFilter::Position::FULL, false},
 	};
 
 	EXPECT_TRUE(InvokeFilter(f, MakeTag(TAG_TITLE, "needle")));
@@ -53,7 +53,7 @@ TEST_F(TagSongFilterTest, Empty)
 {
 	const TagSongFilter f{
 		TAG_TITLE,
-		{"", false, StringFilter::Position::FULL, false},
+		{"", false, false, StringFilter::Position::FULL, false},
 	};
 
 	EXPECT_TRUE(InvokeFilter(f, MakeTag()));
@@ -66,7 +66,7 @@ TEST_F(TagSongFilterTest, Substring)
 {
 	const TagSongFilter f{
 		TAG_TITLE,
-		{"needle", false, StringFilter::Position::ANYWHERE, false},
+		{"needle", false, false, StringFilter::Position::ANYWHERE, false},
 	};
 
 	EXPECT_TRUE(InvokeFilter(f, MakeTag(TAG_TITLE, "needle")));
@@ -82,7 +82,7 @@ TEST_F(TagSongFilterTest, Startswith)
 {
 	const TagSongFilter f{
 		TAG_TITLE,
-		{"needle", false, StringFilter::Position::PREFIX, false},
+		{"needle", false, false, StringFilter::Position::PREFIX, false},
 	};
 
 	EXPECT_TRUE(InvokeFilter(f, MakeTag(TAG_TITLE, "needle")));
@@ -98,7 +98,7 @@ TEST_F(TagSongFilterTest, Negated)
 {
 	const TagSongFilter f{
 		TAG_TITLE,
-		{"needle", false, StringFilter::Position::FULL, true},
+		{"needle", false, false, StringFilter::Position::FULL, true},
 	};
 
 	EXPECT_TRUE(InvokeFilter(f, MakeTag()));
@@ -113,7 +113,7 @@ TEST_F(TagSongFilterTest, EmptyNegated)
 {
 	const TagSongFilter f{
 		TAG_TITLE,
-		{"", false, StringFilter::Position::FULL, true},
+		{"", false, false, StringFilter::Position::FULL, true},
 	};
 
 	EXPECT_FALSE(InvokeFilter(f, MakeTag()));
@@ -127,7 +127,7 @@ TEST_F(TagSongFilterTest, MultiNegated)
 {
 	const TagSongFilter f{
 		TAG_TITLE,
-		{"needle", false, StringFilter::Position::FULL, true},
+		{"needle", false, false, StringFilter::Position::FULL, true},
 	};
 
 	EXPECT_TRUE(InvokeFilter(f, MakeTag(TAG_TITLE, "foo", TAG_TITLE, "bar")));
@@ -143,7 +143,7 @@ TEST_F(TagSongFilterTest, Fallback)
 {
 	const TagSongFilter f{
 		TAG_ALBUM_ARTIST,
-		{"needle", false, StringFilter::Position::FULL, false},
+		{"needle", false, false, StringFilter::Position::FULL, false},
 	};
 
 	EXPECT_TRUE(InvokeFilter(f, MakeTag(TAG_ALBUM_ARTIST, "needle")));
@@ -165,7 +165,7 @@ TEST_F(TagSongFilterTest, EmptyFallback)
 {
 	const TagSongFilter f{
 		TAG_ALBUM_ARTIST,
-		{"", false, StringFilter::Position::FULL, false},
+		{"", false, false, StringFilter::Position::FULL, false},
 	};
 
 	EXPECT_TRUE(InvokeFilter(f, MakeTag()));
@@ -181,7 +181,7 @@ TEST_F(TagSongFilterTest, NegatedFallback)
 {
 	const TagSongFilter f{
 		TAG_ALBUM_ARTIST,
-		{"needle", false, StringFilter::Position::FULL, true},
+		{"needle", false, false, StringFilter::Position::FULL, true},
 	};
 
 	EXPECT_TRUE(InvokeFilter(f, MakeTag()));


### PR DESCRIPTION
Attempt to implement https://github.com/MusicPlayerDaemon/MPD/issues/2327

* Introduces new `stringnormalization` protocol command
* Implements first string normalization to strip diacritics when using `search` and the related commands

The implementation works, but I am unsure whether I took the right approach (and its my first go at CPP). The threading through of booleans is also getting pretty gnarly in there. So I am mostly looking for feedback at this point. We can also workshop the `stringnormalization` name.