### PR TITLE
systemd: add DNS-SD configuration file

### DIFF
--- a/systemd/dnssd/mpd.dnssd
+++ b/systemd/dnssd/mpd.dnssd
@@ -1,0 +1,4 @@
+[Service]
+Name=%H
+Type=_mpd._tcp
+Port=6600


### PR DESCRIPTION
If mDNS is enabled, this allows the user to announce the presence of MPD on the local network. Remote control apps could then find the MPD service automatically, without the need to enter an local IP address:
```
$ resolvectl query -t PTR _mpd._tcp.local
_mpd._tcp.local IN PTR myhostname._mpd._tcp.local         -- link: enp3s0

$ resolvectl service myhostname._mpd._tcp.local
myhostname._mpd._tcp.local: myhostname.local:6600 [priority=0, weight=0]
                              192.168.1.101                 -- link: enp3s0
                              fe80::9ec7:2bb0:ecfa:41c8%2   -- link: enp3s0
                              (myhostname/_mpd._tcp/local)

-- Information acquired via protocol mDNS/IPv4 in 528us.
```

### References:
* [man systemd.dnssd](https://man.archlinux.org/man/systemd.dnssd.5.en)
* [DNS-Based Service Discovery](https://www.rfc-editor.org/rfc/rfc6763)