### PR TITLE
Cache suffix computation in FfmpegDecoderPlugin

### DIFF
--- a/src/decoder/plugins/FfmpegDecoderPlugin.cxx
+++ b/src/decoder/plugins/FfmpegDecoderPlugin.cxx
@@ -694,9 +694,21 @@ ffmpeg_protocols() noexcept
 	return protocols;
 }
 
+/* The list of supported suffixes is computed at most once because
+   it is assumed to remain unchanged during the execution. The suffixes
+   are saved in this set. An empty set encodes that the suffixes
+   have not been computed yet.
+   So in the rare cornercase where ffmpeg supports nothing, the caching
+   does not help (but also does not harm).
+*/
+static std::set<std::string, std::less<>> ffmpeg_suffixes_cache = {};
+
 static std::set<std::string, std::less<>>
 ffmpeg_suffixes() noexcept
 {
+	if (!ffmpeg_suffixes_cache.empty()) {
+		return ffmpeg_suffixes_cache;
+	}
 	std::set<std::string, std::less<>> suffixes;
 
 	void *demuxer_opaque = nullptr;
@@ -730,6 +742,7 @@ ffmpeg_suffixes() noexcept
 		}
 	}
 
+	ffmpeg_suffixes_cache = suffixes;
 	return suffixes;
 }
 


### PR DESCRIPTION

Issue: I've noticed this issue during the database update: whenever mpd checks if a file is supported by the ffmpeg decoder plugin, the set of all suffixes supported by ffmpeg is re-computed from scratch.

Solution: I've added a static `std::set` variable in `FfmpegDecoderPlugin.cxx` where the supported suffixes are saved after computation. Whenever this set is non-empty, then `ffmpeg_suffixes` just the pre-computed set.

Evaluation: My music directory holds 10k songs and ffmpeg supports 467 suffixes:

* Before the present change, the DB update takes ≥3.5 seconds
* With the caching ffmpeg_suffixes(), the DB update takes ≤0.8 seconds

Implmentation Decisions:
Since `DecoderPlugin::SupportsSuffix()` is `const`, I can't implement the cache as a member variable of `struct DecoderPlugin`. Also this would add a member variable to also those `DecoderPlugin` instances that do not use `DecoderPlugin::suffixes_function` at all. Since ffmpeg seems to be the only decoder plugin that makes use of the callback, I've added the cache specifically there. Thus, this single additional variable shouldn't affect those users who do not use the ffmpeg decoder at all.