### PR TITLE
HugeArray: simplify the initialization of the buffer field

### DIFF
--- a/src/util/HugeAllocator.hxx
+++ b/src/util/HugeAllocator.hxx
@@ -128,7 +128,7 @@ HugeDiscard(void *, size_t) noexcept
 template<typename T>
 class HugeArray {
 	using Buffer = std::span<T>;
-	Buffer buffer{nullptr};
+	Buffer buffer;
 
 public:
 	typedef typename Buffer::size_type size_type;


### PR DESCRIPTION
This also fixes compilation with EDG-based C++ compilers:

error 289: no instance of constructor
          "std::span<_Type, _Extent>::span [with _Type=std::byte, _Extent=18446744073709551615UL]"
          matches the argument list