### PR TITLE
Support UTF-8 BOM stripping in `TextInputStream`

### DIFF
--- a/src/input/TextInputStream.hxx
+++ b/src/input/TextInputStream.hxx
@@ -10,6 +10,7 @@
 class TextInputStream {
 	InputStreamPtr is;
 	StaticFifoBuffer<char, 4096> buffer;
+	bool bom_checked = false;
 
 public:
 	/**


### PR DESCRIPTION
Currently, `TextInputStream` treats all text as raw bytes and does not strip UTF-8 BOM (`EF BB BF`). Cue sheets saved with UTF-8 BOM can fail to parse the first line because the first token is prefixed with BOM bytes.

This PR Strips UTF-8 BOM in `TextInputStream` constructor. It tries to read the first 3 bytes into buffer, and consume those bytes if a BOM is present.
