### PR TITLE
(wip) song/DirectorySongFilter: new filter

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ ver 0.25 (not yet released)
   - implement "window" parameter for command "list"
   - new command "stringnormalization"
   - show detailed seek errors
+  - new filter "directory": non-recursive version of "base"
 * decoder
   - faad: implement seeking
   - faad: output 32 bit floating point samples instead of 16 bit integer

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -213,6 +213,8 @@ of:
   songs in the given directory (relative to the music
   directory).
 
+- ``(directory 'VALUE')``: non-recursive version of ``(base 'VALUE')``.
+
 - ``(modified-since 'VALUE')``: compares the
   file's time stamp with the given value (ISO 8601 or UNIX
   time stamp).

--- a/src/db/Selection.cxx
+++ b/src/db/Selection.cxx
@@ -3,6 +3,7 @@
 
 #include "Selection.hxx"
 #include "song/Filter.hxx"
+#include "song/BaseSongFilter.hxx"
 
 DatabaseSelection::DatabaseSelection(const char *_uri, bool _recursive,
 				     const SongFilter *_filter) noexcept
@@ -10,10 +11,11 @@ DatabaseSelection::DatabaseSelection(const char *_uri, bool _recursive,
 {
 	/* optimization: if the caller didn't specify a base URI, pick
 	   the one from SongFilter */
-	if (uri.empty() && filter != nullptr) {
-		auto base = filter->GetBase();
-		if (base != nullptr)
-			uri = base;
+	if (filter != nullptr) {
+		Base base = filter->GetBase();
+		if (uri.empty() && base.uri != nullptr)
+			uri = base.uri;
+		recursive = base.recursive;
 	}
 }
 

--- a/src/song/BaseSongFilter.hxx
+++ b/src/song/BaseSongFilter.hxx
@@ -8,17 +8,22 @@
 
 class BaseSongFilter final : public ISongFilter {
 	std::string value;
+  bool recursive;
 
 public:
 	BaseSongFilter(const BaseSongFilter &) = default;
 
 	template<typename V>
-	explicit BaseSongFilter(V &&_value)
-		:value(std::forward<V>(_value)) {}
+	explicit BaseSongFilter(V &&_value, bool _recursive)
+		:value(std::forward<V>(_value)), recursive(_recursive) {}
 
 	const char *GetValue() const noexcept {
 		return value.c_str();
 	}
+
+  bool IsRecursive() const noexcept {
+    return recursive;
+  }
 
 	ISongFilterPtr Clone() const noexcept override {
 		return std::make_unique<BaseSongFilter>(*this);

--- a/src/song/Filter.hxx
+++ b/src/song/Filter.hxx
@@ -29,6 +29,11 @@
 enum TagType : uint8_t;
 struct LightSong;
 
+/**
+ * Base URI and recursive flag.
+ */
+struct Base { const char *uri; bool recursive; };
+
 class SongFilter {
 	AndSongFilter and_filter;
 
@@ -80,11 +85,11 @@ public:
 	bool HasFoldCase() const noexcept;
 
 	/**
-	 * Returns the "base" specification (if there is one) or
-	 * nullptr.
+	 * Returns the "base" specification, containing URI (if any) and
+	 * recursive flag (default to true).
 	 */
 	[[gnu::pure]]
-	const char *GetBase() const noexcept;
+	const Base GetBase() const noexcept;
 
 	/**
 	 * Create a copy of the filter with the given prefix stripped


### PR DESCRIPTION
Adds a new filter `directory` similar to `base` but non-recursive.

See https://github.com/MusicPlayerDaemon/MPD/issues/2418

~~(The commit adds a `GetDirectory` method on `LightSong` struct, similar to `GetURI`. It could be done from within the filter functions, but I think that other (future) features could use this, e.g. `group directory` or `list directory`.)~~

In its current state (a  partial and unoptimized copy of BasSongFilter), it's still very slow!