### PR TITLE
Update libopenmpt base name

### DIFF
--- a/python/build/libs.py
+++ b/python/build/libs.py
@@ -49,7 +49,7 @@ libopenmpt = AutotoolsProject(
         '--without-portaudio', '--without-portaudiocpp', '--without-sndfile',
         '--without-flac',
     ],
-    base='libopenmpt-0.8.3+release.autotools',
+    base='libopenmpt-0.8.4+release.autotools',
 )
 
 wildmidi = CmakeProject(


### PR DESCRIPTION
Whilst trying to build (on Windows), the incorrect `base` prevented it from building.