### PR TITLE
Fix fail_timer duration multiplication

### DIFF
--- a/src/output/Control.cxx
+++ b/src/output/Control.cxx
@@ -305,7 +305,7 @@ AudioOutputControl::LockUpdate(const AudioFormat audio_format,
 
 	if (enabled && really_enabled) {
 		if (force || !fail_timer.IsDefined() ||
-		    fail_timer.Check(REOPEN_AFTER * 1000)) {
+		    fail_timer.Check(REOPEN_AFTER)) {
 			return Open(std::move(lock), audio_format, mp);
 		}
 	} else if (IsOpen())


### PR DESCRIPTION
Remove incorrect `* 1000` multiplier in fail_timer.Check() call.

When the PeriodClock API was migrated to std::chrono in commit 401189984 , the fail_timer.Check() call was not updated. This caused the timer to check for a duration that was 1000 times longer than intended.

```c
// before
static constexpr unsigned REOPEN_AFTER = 10;
// after
static constexpr PeriodClock::Duration REOPEN_AFTER = std::chrono::seconds(10);

// It actually waits 10000 seconds
fail_timer.Check(REOPEN_AFTER * 1000);
```

