### PR TITLE
Fixed UPnP for full URLs with scheme

### DIFF
--- a/src/TagAny.cxx
+++ b/src/TagAny.cxx
@@ -48,6 +48,9 @@ TagScanFile(const Path path_fs, TagHandler &handler)
 static std::string
 ResolveUri(std::string_view base, const char *relative)
 {
+	if (uri_has_scheme(relative)) {
+		return std::string(relative);
+	}
 	while (true) {
 		const char *rest = StringAfterPrefix(relative, "../");
 		if (rest == nullptr)

--- a/src/db/plugins/upnp/Directory.cxx
+++ b/src/db/plugins/upnp/Directory.cxx
@@ -156,6 +156,8 @@ protected:
 				if (duration != nullptr)
 					tag.SetDuration(ParseDuration(duration));
 
+				object.url.clear();
+
 				state = RES;
 			}
 
@@ -205,7 +207,7 @@ protected:
 			break;
 
 		case RES:
-			object.url.assign(s);
+			object.url.append(s);
 			break;
 
 		case CLASS:

--- a/src/lib/upnp/ContentDirectoryService.cxx
+++ b/src/lib/upnp/ContentDirectoryService.cxx
@@ -13,7 +13,7 @@ using std::string_view_literals::operator""sv;
 
 ContentDirectoryService::ContentDirectoryService(const UPnPDevice &device,
 						 const UPnPService &service) noexcept
-	:m_actionURL(uri_apply_base(service.controlURL, device.URLBase)),
+	:m_actionURL(uri_apply_relative(service.controlURL, device.URLBase)),
 	 m_serviceType(service.serviceType),
 	 m_deviceId(device.UDN),
 	 m_friendlyName(device.friendlyName),


### PR DESCRIPTION
Fixes #2450 

To be frank I have zero confidence in URL fix, I simply patched two URL methods to return relative if it has scheme.

XML parser fix is a better one. Current version breaks on URLs with parameters. Parser sends URL by parts split on each `&`. With this fix all of them will be concatenated together.

Tested on Jellyfin server - works fine (slow, but works).