### PR TITLE
Add cover.jxl to cover art filenames

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ ver 0.25 (not yet released)
   - implement "window" parameter for command "list"
   - new command "stringnormalization"
   - show detailed seek errors
+  - support filename "cover.jxl" for "albumart" command
 * decoder
   - faad: implement seeking
   - faad: output 32 bit floating point samples instead of 16 bit integer

--- a/doc/protocol.rst
+++ b/doc/protocol.rst
@@ -1113,7 +1113,7 @@ The music database
 
     This is currently implemented by searching the directory the file
     resides in for a file called :file:`cover.png`, :file:`cover.jpg`,
-    or :file:`cover.webp`.
+    :file:`cover.jxl`, or :file:`cover.webp`.
 
     Returns the file size and actual number
     of bytes read at the requested offset, followed

--- a/src/command/FileCommands.cxx
+++ b/src/command/FileCommands.cxx
@@ -141,6 +141,7 @@ find_stream_art(std::string_view directory, Mutex &mutex)
 	static constexpr auto art_names = std::array {
 		"cover.png",
 		"cover.jpg",
+		"cover.jxl",
 		"cover.webp",
 	};
 


### PR DESCRIPTION
Since JPEG is widely used for cover art files, JPEG XL's support for lossless JPEG transcodes could be helpful for reducing cover art file sizes across an entire collection of music. It’d be nice if MPD looked for these files.