### PR TITLE
lib/ffmpeg/Filter: add missing <cstddef> include

### DIFF
--- a/src/lib/ffmpeg/Filter.hxx
+++ b/src/lib/ffmpeg/Filter.hxx
@@ -13,6 +13,7 @@ extern "C" {
 #include <libavfilter/avfilter.h>
 }
 
+#include <cstddef>
 #include <new>
 #include <utility>
 


### PR DESCRIPTION
## Summary

`src/lib/ffmpeg/Filter.hxx` uses `std::nullptr_t` (in the `FilterGraph(std::nullptr_t)` constructor) but only includes `<new>` and `<utility>`. On newer libc++ (e.g. Apple Clang 21 on macOS 26), neither header transitively pulls in `<cstddef>`, so the build fails with:

```
src/lib/ffmpeg/Filter.hxx:101:19: error: non-friend class member 'nullptr_t' cannot have a qualified name
  101 |         FilterGraph(std::nullptr_t) noexcept {}
      |                     ~~~~~^
```

Include `<cstddef>` explicitly so the type is always available.

## Test plan

- [x] `meson setup output/release --buildtype=debugoptimized -Db_ndebug=true` and `meson compile -C output/release` complete successfully on macOS with Apple Clang 21