### PR TITLE
macOS: small cleanups in apple/, OSXOutput and Bonjour

### DIFF
--- a/src/apple/Throw.cxx
+++ b/src/apple/Throw.cxx
@@ -5,8 +5,8 @@
 #include "ErrorRef.hxx"
 #include "StringRef.hxx"
 
-#include <cstring>
 #include <stdexcept>
+#include <string>
 
 namespace Apple {
 
@@ -25,18 +25,17 @@ ThrowOSStatus(OSStatus status)
 }
 
 void
-ThrowOSStatus(OSStatus status, const char *_msg)
+ThrowOSStatus(OSStatus status, const char *prefix)
 {
 	const Apple::ErrorRef cferr(nullptr, kCFErrorDomainOSStatus,
 				    status, nullptr);
 	const Apple::StringRef cfstr(cferr.CopyDescription());
 
-	char msg[1024];
-	std::strcpy(msg, _msg);
-	size_t length = std::strlen(msg);
+	char description[1024];
+	if (cfstr.GetCString(description, sizeof(description)))
+		throw std::runtime_error(std::string{prefix} + description);
 
-	cfstr.GetCString(msg + length, sizeof(msg) - length);
-	throw std::runtime_error(msg);
+	throw std::runtime_error(prefix);
 }
 
 } // namespace Apple

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -141,7 +141,6 @@ OSXOutput::OSXOutput(const ConfigBlock &block)
 	}
 	else {
 		component_subtype = kAudioUnitSubType_HALOutput;
-		/* XXX am I supposed to strdup() this? */
 		device_name = device;
 	}
 }
@@ -683,7 +682,7 @@ OSXOutput::Open(AudioFormat &audio_format)
 	bool dop = dop_setting;
 #endif
 
-	memset(&asbd, 0, sizeof(asbd));
+	asbd = {};
 	asbd.mFormatID = kAudioFormatLinearPCM;
 	if (audio_format.format == SampleFormat::FLOAT) {
 		asbd.mFormatFlags = kLinearPCMFormatFlagIsFloat;

--- a/src/zeroconf/Bonjour.cxx
+++ b/src/zeroconf/Bonjour.cxx
@@ -2,12 +2,11 @@
 // Copyright The Music Player Daemon Project
 
 #include "Bonjour.hxx"
+#include "lib/fmt/RuntimeError.hxx"
 #include "util/Domain.hxx"
 #include "Log.hxx"
 
 #include <dns_sd.h>
-
-#include <stdexcept>
 
 #include <arpa/inet.h>
 
@@ -30,7 +29,8 @@ RegisterBonjour(const char *name, const char *type, unsigned port,
 						       callback, ctx);
 
 	if (error != kDNSServiceErr_NoError)
-		throw std::runtime_error("DNSServiceRegister() failed");
+		throw FmtRuntimeError("DNSServiceRegister() failed: {}",
+				      static_cast<int>(error));
 
 	return ref;
 }
@@ -54,7 +54,7 @@ BonjourHelper::Callback([[maybe_unused]] DNSServiceRef sdRef,
 			[[maybe_unused]] const char *domain,
 			[[maybe_unused]] void *context) noexcept
 {
-	auto &helper = *(BonjourHelper *)context;
+	auto &helper = *static_cast<BonjourHelper *>(context);
 
 	if (errorCode != kDNSServiceErr_NoError) {
 		LogError(bonjour_domain,


### PR DESCRIPTION
A handful of low-risk macOS-side cleanups while looking over the code.  No functional changes intended.  Three independent commits, easy to review or drop individually.

## 1. `apple/Throw`: avoid unsafe `strcpy` in `ThrowOSStatus`

`ThrowOSStatus(status, prefix)` formatted its message into a 1024-byte stack buffer with `strcpy(msg, prefix)` — unbounded, so a long prefix would overflow.  All current callers pass short literals, so this has not been triggered, but it is brittle.

Switched to `std::string` concatenation (bounded by available memory, clearer to read).  When the `CFErrorRef` description cannot be retrieved, the prefix is thrown alone — matching the previous behaviour rather than appending undefined buffer contents.

## 2. `output/osx`: small cleanups

- Dropped the obsolete `XXX am I supposed to strdup() this?` comment.  The other output plugins (Alsa, OpenAL, Wasapi, Sndio, Solaris) all store the result of `ConfigBlock::GetBlockValue()` as a bare `const char*` whose lifetime is tied to the `ConfigBlock`, which lives for the duration of the process.
- Replaced the C-style `memset(&asbd, 0, sizeof(asbd))` with the equivalent C++ aggregate-init `asbd = {}`.

## 3. `zeroconf/bonjour`: report `DNSServiceErrorType` in failure message

When `DNSServiceRegister()` fails, the bare `"DNSServiceRegister() failed"` message is not very informative — include the numeric `DNSServiceErrorType` so the user can look it up in `dns_sd.h`.

Also replaced a C-style cast of the callback context pointer with `static_cast` for consistency with the rest of the codebase.

## Test plan

- [x] Builds cleanly on macOS (Apple Clang 21).
- [x] No behaviour change in the success paths; the changes only affect the formatting of error messages and zero-initialisation style.