### PR TITLE
chore: add pcre to build of win32.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ project(
     'opus:default_library=static',
     'sqlite3:default_library=static',
     'vorbis:default_library=static',
+    'pcre2:default_library=static',
 
     # Not interested in compiler warnings from subprojects.
     'curl:werror=false',
@@ -159,6 +160,9 @@ test_common_flags = [
 
   # libfmt causes this warning due to -ffast-math
   '-Wno-nan-infinity-disabled',
+
+  # PCRE2 overlength-strings warning
+  '-Wno-overlength-strings'
 ]
 
 test_global_cxxflags = test_global_common_flags + [

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -19,3 +19,5 @@
 /openssl-*/
 /opus-*/
 /sqlite-*/
+/pcre2-*/
+

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = pcre2-10.47
+source_url = https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.bz2
+source_filename = pcre2-10.47.tar.bz2
+source_hash = 47fe8c99461250d42f89e6e8fdaeba9da057855d06eb7fc08d9ca03fd08d7bc7
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/pcre2_10.47-3/pcre2-10.47.tar.bz2
+patch_filename = pcre2_10.47-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.47-3/get_patch
+patch_hash = 42df135f63e216141ffcc30e3e7c8ae6bdea21f7638828cbab5f7ad484fa9044
+wrapdb_version = 10.47-3
+
+[provide]
+dependency_names = libpcre2-8, libpcre2-16, libpcre2-32, libpcre2-posix

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -11,3 +11,6 @@ wrapdb_version = 10.47-3
 
 [provide]
 dependency_names = libpcre2-8, libpcre2-16, libpcre2-32, libpcre2-posix
+
+[options]
+c_args = -Wno-overlength-strings

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -11,6 +11,3 @@ wrapdb_version = 10.47-3
 
 [provide]
 dependency_names = libpcre2-8, libpcre2-16, libpcre2-32, libpcre2-posix
-
-[options]
-c_args = -Wno-overlength-strings


### PR DESCRIPTION
As title.

To use regex matching feature as described in [Filters - Protocol — Music Player Daemon 0.25~git documentation](https://mpd.readthedocs.io/en/latest/protocol.html#filters) , need to add `pcre` support in win32 build.

