### PR TITLE
Fix https://github.com/MusicPlayerDaemon/MPD/issues/2488

### DIFF
--- a/src/LocateUri.cxx
+++ b/src/LocateUri.cxx
@@ -117,7 +117,7 @@ LocateUri(UriPluginKind kind,
 #endif
 					 );
 	else {
-		if (!uri_safe_local(uri))
+		if (!uri.empty() && !uri_safe_local(uri))
 			throw std::invalid_argument{"Bad relative path"};
 
 		return LocatedUri(LocatedUri::Type::RELATIVE, uri);


### PR DESCRIPTION
Fix https://github.com/MusicPlayerDaemon/MPD/issues/2488

Function "uri_safe_local(uri)" when called with an empty string reports a bad relative path and breaks some mpd clients. This commit adds a check if "uri" is an empty string, allowing empty strings to pass the check.