### PR TITLE
Use snd_pcm_pause if available

### DIFF
--- a/src/lib/alsa/HwSetup.cxx
+++ b/src/lib/alsa/HwSetup.cxx
@@ -281,6 +281,8 @@ SetupHw(snd_pcm_t *pcm,
 	if (err < 0)
 		throw Alsa::MakeError(err, "snd_pcm_hw_params_get_period_size() failed");
 
+	result.can_pause = snd_pcm_hw_params_can_pause(hwparams);
+
 	return result;
 }
 

--- a/src/lib/alsa/HwSetup.hxx
+++ b/src/lib/alsa/HwSetup.hxx
@@ -15,6 +15,7 @@ namespace Alsa {
 struct HwResult {
 	snd_pcm_format_t format;
 	snd_pcm_uframes_t buffer_size, period_size;
+	bool can_pause;
 };
 
 /**

--- a/src/output/Filtered.cxx
+++ b/src/output/Filtered.cxx
@@ -192,7 +192,7 @@ FilteredAudioOutput::Cancel() noexcept
 void
 FilteredAudioOutput::BeginPause() noexcept
 {
-	if (!output->SupportsPauseWithoutCancel())
+	if (!output->SupportsHardwarePause())
 		Cancel();
 }
 

--- a/src/output/Filtered.cxx
+++ b/src/output/Filtered.cxx
@@ -192,7 +192,8 @@ FilteredAudioOutput::Cancel() noexcept
 void
 FilteredAudioOutput::BeginPause() noexcept
 {
-	Cancel();
+	if (!output->SupportsPauseWithoutCancel())
+		Cancel();
 }
 
 bool

--- a/src/output/Interface.hxx
+++ b/src/output/Interface.hxx
@@ -40,12 +40,22 @@ public:
 		return flags & FLAG_PAUSE;
 	}
 
-	virtual bool SupportsPauseWithoutCancel() const noexcept {
-		return false;
-	}
-
 	bool GetNeedFullyDefinedAudioFormat() const noexcept {
 		return flags & FLAG_NEED_FULLY_DEFINED_AUDIO_FORMAT;
+	}
+
+	/**
+	 * Returns true if this plugin can pause playback without first
+	 * discarding buffered audio via Cancel().  When this returns true,
+	 * #FilteredAudioOutput::BeginPause() will skip the Cancel() call,
+	 * allowing the plugin to preserve its hardware buffer across a pause
+	 * and resume it intact when Play() is next called.
+	 *
+	 * Plugins that return true must handle buffer cleanup if
+	 * Cancel() is called while paused (e.g. on stop or seek).
+	 */
+	virtual bool SupportsHardwarePause() const noexcept {
+		return false;
 	}
 
 	/**

--- a/src/output/Interface.hxx
+++ b/src/output/Interface.hxx
@@ -40,6 +40,10 @@ public:
 		return flags & FLAG_PAUSE;
 	}
 
+	virtual bool SupportsPauseWithoutCancel() const noexcept {
+		return false;
+	}
+
 	bool GetNeedFullyDefinedAudioFormat() const noexcept {
 		return flags & FLAG_NEED_FULLY_DEFINED_AUDIO_FORMAT;
 	}

--- a/src/output/Thread.cxx
+++ b/src/output/Thread.cxx
@@ -519,6 +519,10 @@ AudioOutputControl::Task() noexcept
 				   the actual playback */
 				if (source_state == SourceState::OPEN)
 					source.Cancel();
+				{
+					const ScopeUnlock unlock(mutex);
+					output->Cancel();
+				}
 				InternalPause(lock);
 			} else {
 				InternalClose(false);

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -232,6 +232,7 @@ class AlsaOutput final
 	const bool close_on_pause;
 
 	std::atomic_bool paused;
+	bool hw_can_pause = false;
 
 public:
 	AlsaOutput(EventLoop &loop, const ConfigBlock &block);
@@ -398,6 +399,11 @@ private:
 	/* virtual methods from class MultiSocketMonitor */
 	Event::Duration PrepareSockets() noexcept override;
 	void DispatchSockets() noexcept override;
+
+	bool SupportsPauseWithoutCancel() const noexcept override {
+		return !close_on_pause && hw_can_pause;
+	}
+
 };
 
 static constexpr Domain alsa_output_domain("alsa_output");
@@ -562,6 +568,8 @@ AlsaOutput::Setup(AudioFormat &audio_format,
 
 	AlsaSetupSw(pcm, hw_result.buffer_size - hw_result.period_size,
 		    hw_result.period_size);
+
+	hw_can_pause = hw_result.can_pause;
 
 	auto alsa_period_size = hw_result.period_size;
 	if (alsa_period_size == 0)
@@ -1095,6 +1103,7 @@ AlsaOutput::CancelInternal() noexcept
 	ring_buffer.Clear();
 
 	active = false;
+	paused = false;
 	waiting = false;
 
 	UnregisterSockets();
@@ -1139,13 +1148,46 @@ AlsaOutput::Cancel() noexcept
 bool
 AlsaOutput::Pause() noexcept
 {
-	std::lock_guard lock{mutex};
-	interrupted = false;
+	{
+		std::lock_guard lock{mutex};
+		interrupted = false;
 
-	if (close_on_pause)
-		return false;
+		if (close_on_pause)
+			return false;
 
-	// TODO use snd_pcm_pause()?
+		if (!hw_can_pause) {
+			paused = true;
+			return true;
+		}
+	}
+
+	if (LockIsActive()) {
+		BlockingCall(GetEventLoop(), [this](){
+			/* only pause if actually running; if the PCM is
+			   still in PREPARED state, there is nothing in
+			   the hardware buffer worth preserving */
+			if (snd_pcm_state(pcm) == SND_PCM_STATE_RUNNING) {
+				int err = snd_pcm_pause(pcm, /* enable */ 1);
+				if (err < 0) {
+					LogError(alsa_output_domain,
+							 "snd_pcm_pause() failed");
+					hw_can_pause = false;
+					return;
+				}
+			}
+
+			UnregisterSockets();
+			silence_timer.Cancel();
+
+			/* set waiting=true so that Activate() inside
+			   Play() will re-schedule the event loop on
+			   resume; without this, Activate() sees
+			   active=true/waiting=false and returns early */
+			waiting = true;
+		});
+	}
+	if (!hw_can_pause)
+		return Pause(); // try again without hw pause
 
 	paused = true;
 	return true;
@@ -1215,7 +1257,12 @@ AlsaOutput::Play(std::span<const std::byte> src)
 	assert(!src.empty());
 	assert(src.size() % in_frame_size == 0);
 
-	paused = false;
+	const bool was_paused = paused.exchange(false);
+
+	if (was_paused) {
+		std::lock_guard lock{mutex};
+		Activate();
+	}
 
 	const size_t max_frames = LockWaitWriteAvailable();
 	const size_t max_size = max_frames * in_frame_size;
@@ -1242,6 +1289,15 @@ AlsaOutput::PrepareSockets() noexcept
 	}
 
 	try {
+		/* if the PCM was paused via snd_pcm_pause() (i.e. Pause()
+		   was called with hw_can_pause), resume it now that Play()
+		   has delivered new data and re-activated the I/O thread */
+		if (snd_pcm_state(pcm) == SND_PCM_STATE_PAUSED) {
+			int err = snd_pcm_pause(pcm, /* disable */ 0);
+			if (err < 0)
+				throw Alsa::MakeError(err, "snd_pcm_pause() failed");
+		}
+
 		return non_block.PrepareSockets(*this, pcm);
 	} catch (...) {
 		ClearSocketList();

--- a/src/output/plugins/AlsaOutputPlugin.cxx
+++ b/src/output/plugins/AlsaOutputPlugin.cxx
@@ -400,7 +400,7 @@ private:
 	Event::Duration PrepareSockets() noexcept override;
 	void DispatchSockets() noexcept override;
 
-	bool SupportsPauseWithoutCancel() const noexcept override {
+	bool SupportsHardwarePause() const noexcept override {
 		return !close_on_pause && hw_can_pause;
 	}
 
@@ -1103,7 +1103,6 @@ AlsaOutput::CancelInternal() noexcept
 	ring_buffer.Clear();
 
 	active = false;
-	paused = false;
 	waiting = false;
 
 	UnregisterSockets();


### PR DESCRIPTION
This should fix #1136 but note I have only tried this on hardware that does support pause (quite old pci soundblaster live). It is also quite possible I do silly things in the patch, I'm not very familiar with the codebase, but pausing/unpausing works, stopping/playing while paused or not paused works, with and without the always_on and/or close_on_pause options (the latter should fully disable hardware pausing and revert to the old behaviour, and it's on by default). It didn't seem worth adding another option explicitly to disable hardware pause since this option already exists, but I don't have whatever DSD is, so maybe I do break that usecase if that needs silence streamed actively?