### PR TITLE
config: Prevent infinite recursion in include directives

### DIFF
--- a/src/config/File.cxx
+++ b/src/config/File.cxx
@@ -159,10 +159,17 @@ ReadConfigParam(ConfigData &config_data, BufferedReader &reader,
 
 /**
  * @param directory the directory used to resolve relative paths
+ * @param depth the current include recursion depth (to detect cycles)
  */
 static void
-ReadConfigFile(ConfigData &config_data, BufferedReader &reader, Path directory)
+ReadConfigFile(ConfigData &config_data, BufferedReader &reader, Path directory,
+	       unsigned depth = 0)
 {
+	static constexpr unsigned MAX_INCLUDE_DEPTH = 16;
+
+	if (depth > MAX_INCLUDE_DEPTH)
+		throw std::runtime_error("Include recursion too deep");
+
 	while (true) {
 		char *line = reader.ReadLine();
 		if (line == nullptr)
@@ -180,12 +187,10 @@ ReadConfigFile(ConfigData &config_data, BufferedReader &reader, Path directory)
 		assert(name != nullptr);
 
 		if (StringIsEqual(name, "include")) {
-			// TODO: detect recursion
-			// TODO: Config{Block,Param} have only line number but no file name
 			const auto pattern = AllocatedPath::Apply(directory,
 								  AllocatedPath::FromUTF8Throw(ExpectValueAndEnd(tokenizer, false)));
 			for (const auto &path : ListWildcard(pattern))
-				ReadConfigFile(config_data, path);
+				ReadConfigFile(config_data, path, depth + 1);
 			continue;
 		}
 
@@ -204,7 +209,7 @@ ReadConfigFile(ConfigData &config_data, BufferedReader &reader, Path directory)
 
 			for (const auto &path : l)
 				if (PathExists(path))
-					ReadConfigFile(config_data, path);
+					ReadConfigFile(config_data, path, depth + 1);
 			continue;
 		}
 
@@ -227,7 +232,7 @@ ReadConfigFile(ConfigData &config_data, BufferedReader &reader, Path directory)
 }
 
 void
-ReadConfigFile(ConfigData &config_data, Path path)
+ReadConfigFile(ConfigData &config_data, Path path, unsigned depth)
 {
 	assert(!path.IsNull());
 
@@ -238,7 +243,7 @@ ReadConfigFile(ConfigData &config_data, Path path)
 	BufferedReader reader(file);
 
 	try {
-		ReadConfigFile(config_data, reader, path.GetDirectoryName());
+		ReadConfigFile(config_data, reader, path.GetDirectoryName(), depth);
 	} catch (...) {
 		std::throw_with_nested(FmtRuntimeError("Error in {:?} line {}",
 						       path,

--- a/src/config/File.hxx
+++ b/src/config/File.hxx
@@ -8,6 +8,6 @@ class Path;
 struct ConfigData;
 
 void
-ReadConfigFile(ConfigData &data, Path path);
+ReadConfigFile(ConfigData &data, Path path, unsigned depth = 0);
 
 #endif


### PR DESCRIPTION
## Issue

The MPD config file parser supports an "include" directive to load additional config files. The ReadConfigFile() function calls itself recursively for each included file, but has no mechanism to detect recursive includes. A config file that includes itself (directly or transitively through other files) will cause infinite recursion, eventually overflowing the stack and crashing MPD with a segfault.

## Solution

The patch adds a "depth" parameter to the internal ReadConfigFile() function. Depth is incremented on each recursive include call. If depth exceeds 16 (MAX_INCLUDE_DEPTH), a std::runtime_error is thrown with the message "Include recursion too deep".

The header src/config/File.hxx is also modified to add the depth parameter to the public ReadConfigFile() signature, defaulting to 0 for backward compatibility with existing callers.

Both "include" and "include_optional" paths pass depth + 1 to recursive calls, ensuring cycles are detected at any depth.