### PR TITLE
upnp: Fix infinite loop DoS in ContentDirectoryService

### DIFF
--- a/src/db/plugins/upnp/ContentDirectoryService.cxx
+++ b/src/db/plugins/upnp/ContentDirectoryService.cxx
@@ -8,6 +8,8 @@
 
 #include <fmt/format.h>
 
+#include <cstdint>
+
 static void
 ReadResultTag(UPnPDirContent &dirbuf, const UpnpActionResponse &response)
 {
@@ -54,13 +56,18 @@ ContentDirectoryService::readDir(UpnpClient_Handle handle,
 				 const char *objectId) const
 {
 	UPnPDirContent dirbuf;
-	unsigned offset = 0, total = -1, count;
+	unsigned offset = 0, total = 0, count;
+	unsigned iterations = 0;
+	static constexpr unsigned MAX_ITERATIONS = 100000;
 
 	do {
 		readDirSlice(handle, objectId, offset, m_rdreqcnt, dirbuf,
 			     count, total);
 
 		offset += count;
+
+		if (++iterations > MAX_ITERATIONS)
+			break;
 	} while (count > 0 && offset < total);
 
 	return dirbuf;
@@ -72,7 +79,9 @@ ContentDirectoryService::search(UpnpClient_Handle hdl,
 				const char *ss) const
 {
 	UPnPDirContent dirbuf;
-	unsigned offset = 0, total = -1, count;
+	unsigned offset = 0, total = 0, count;
+	unsigned iterations = 0;
+	static constexpr unsigned MAX_ITERATIONS = 100000;
 
 	do {
 		const auto response = UpnpSendAction(hdl, m_actionURL.c_str(),
@@ -98,6 +107,9 @@ ContentDirectoryService::search(UpnpClient_Handle hdl,
 			total = ParseUnsigned(value);
 
 		ReadResultTag(dirbuf, response);
+
+		if (++iterations > MAX_ITERATIONS)
+			break;
 	} while (count > 0 && offset < total);
 
 	return dirbuf;


### PR DESCRIPTION
## Issue

Both the readDir() and search() methods in ContentDirectoryService initialize the loop bound variable "total" to (unsigned)-1 (i.e. UINT_MAX). A malicious or buggy UPnP Media Server that returns NumberReturned=0 while leaving TotalMatches at a large value will cause the loop to spin for an excessive number of iterations, consuming CPU and hanging the MPD process.

Specifically, in readDir() (line 57):
```
unsigned offset = 0, total = -1, count;
do {
    readDirSlice(..., count, total);
    offset += count;   // count=0 → offset never advances
} while (count > 0 && offset < total);
```

Note: when count=0, the "count > 0" condition in the while() is false, so the loop does exit. However, the more serious variant is when count=1 and total=UINT_MAX: the loop runs ~UINT_MAX times (billions of iterations), which is effectively infinite for practical purposes, hanging MPD for hours. Even with count=0 and total=UINT_MAX, a partially honest server returning small but non-zero counts will cause far more iterations than needed.

## Solution

The patch makes two changes:

1. Initialises total = 0 instead of total = -1. This is the primary fix: with total=0, the initial loop condition "offset < total" is "0 < 0 = false", so the loop exits on the first iteration if the server fails to update total. This ensures the first server response correctly establishes the total bound.

2. Adds a MAX_ITERATIONS (100000) limit with an iteration counter, breaking out of the loop if exceeded. This provides a hard upper bound on loop execution regardless of server responses, serving as defense-in-depth.

Both readDir() and search() are patched identically.