### PR TITLE
curl: Add NULL checks for curl_easy_escape/unescape

### DIFF
--- a/src/lib/curl/Escape.cxx
+++ b/src/lib/curl/Escape.cxx
@@ -13,6 +13,9 @@ CurlEscapeUriPath(CURL *curl, std::string_view src) noexcept
 
 	for (const auto i : IterableSplitString(src, '/')) {
 		CurlString escaped(curl_easy_escape(curl, i.data(), i.size()));
+		if (!escaped)
+			break;
+
 		if (!dest.empty())
 			dest.push_back('/');
 		dest += escaped.c_str();
@@ -33,7 +36,10 @@ CurlUnescape(CURL *curl, std::string_view src) noexcept
 {
 	int outlength;
 	CurlString tmp(curl_easy_unescape(curl, src.data(), src.size(),
-					  &outlength));
+				  &outlength));
+	if (!tmp)
+		return {};
+
 	return {tmp.c_str(), size_t(outlength)};
 }
 


### PR DESCRIPTION
## Issue

The curl_easy_escape() and curl_easy_unescape() functions can return NULL on memory allocation failure. The original code passes the return value directly to the CurlString constructor, which stores the pointer without checking for NULL. When CurlString::c_str() is called on a NULL-holding instance, it returns NULL, which is then passed to std::string::operator+=() or the std::string(const char*) constructor, both of which exhibit undefined behavior on NULL input, typically causing a crash.

Affected functions:
- CurlEscapeUriPath(): line 18: dest += escaped.c_str()
- CurlUnescape(): line 37: return {tmp.c_str(), size_t(outlength)};

If curl's memory allocation fails, MPD crashes. This can be triggered:
- During WebDAV storage operations (CurlStorage)
- During CURL input stream operations
- Under system memory pressure

## Solution

The patch adds NULL checks after calling curl_easy_escape() and curl_easy_unescape() before using the returned pointers:

- In CurlEscapeUriPath: checks `if (!escaped) break;` to skip the segment on allocation failure (uses CurlString::operator bool())
- In CurlUnescape: checks `if (!tmp) return {};` to return an empty string on allocation failure

This preserves the existing CurlString RAII wrapper pattern while adding the necessary safety checks.