### PR TITLE
config: Add ERANGE checks to ParseLong and ParseSize

### DIFF
--- a/src/config/Parser.cxx
+++ b/src/config/Parser.cxx
@@ -7,6 +7,7 @@
 #include "util/StringUtil.hxx"
 
 #include <cstdlib>
+#include <cerrno>
 
 bool
 ParseBool(const char *value)
@@ -27,9 +28,13 @@ long
 ParseLong(const char *s)
 {
 	char *endptr;
+	errno = 0;
 	long value = strtol(s, &endptr, 10);
 	if (endptr == s || *endptr != 0)
 		throw std::runtime_error("Failed to parse number");
+
+	if (errno == ERANGE)
+		throw std::runtime_error("Number out of range");
 
 	return value;
 }
@@ -80,9 +85,13 @@ std::size_t
 ParseSize(const char *s, std::size_t default_factor)
 {
 	char *endptr;
+	errno = 0;
 	std::size_t value = strtoul(s, &endptr, 10);
 	if (endptr == s)
 		throw std::runtime_error("Failed to parse integer");
+
+	if (errno == ERANGE)
+		throw std::runtime_error("Integer out of range");
 
 	static constexpr std::size_t KILO = 1024;
 	static constexpr std::size_t MEGA = 1024 * KILO;


### PR DESCRIPTION
## Issue

The ParseLong() function calls strtol() but does not check errno for ERANGE. When strtol() encounters a value outside the representable range of long, it returns LONG_MAX or LONG_MIN and sets errno = ERANGE. The current code only validates that strtol consumed all characters but ignores the overflow condition.

This means:
- Input "99999999999999999999999" silently returns LONG_MAX
- Input "-99999999999999999999999" silently returns LONG_MIN

The same issue exists in ParseSize() which calls strtoul() without checking for ERANGE.

This affects all config parsing that uses ParseLong() or ParseSize().

In practice, this is unlikely to cause exploitable conditions because even LONG_MAX is not large enough to cause a meaningful wraparound in the downstream allocation logic. The main risk is denial of service (e.g., very large audio_buffer_size causing OOM), and incorrect behavior due to silent truncation.

In ParseSize(), strtoul() returns ULONG_MAX on overflow, which would cause Multiply<> to wrap around SIZE_MAX leading to incorrect size computation.

## Solution

The patch adds ERANGE checks after both strtol() and strtoul() calls:

1. Clear errno = 0 before each conversion to avoid false positives from stale errno values.

2. After strtol() in ParseLong(), check errno == ERANGE and throw.

3. After strtoul() in ParseSize(), check errno == ERANGE and throw.