### PR TITLE
Replace atoi() with strtol/strtoul for safer parsing

### DIFF
--- a/src/SongSave.cxx
+++ b/src/SongSave.cxx
@@ -117,9 +117,15 @@ song_load(LineReader &file, const char *uri,
 		} else if (StringIsEqual(line, "Playlist")) {
 			tag.SetHasPlaylist(StringIsEqual(value, "yes"));
 		} else if (StringIsEqual(line, SONG_MTIME)) {
-			song.SetLastModified(std::chrono::system_clock::from_time_t(atoi(value)));
+			char *endptr;
+			long t = strtol(value, &endptr, 10);
+			if (endptr > value && *endptr == 0)
+				song.SetLastModified(std::chrono::system_clock::from_time_t(t));
 		} else if (StringIsEqual(line, SONG_ADDED)) {
-			song.SetAdded(std::chrono::system_clock::from_time_t(atoi(value)));
+			char *endptr;
+			long t = strtol(value, &endptr, 10);
+			if (endptr > value && *endptr == 0)
+				song.SetAdded(std::chrono::system_clock::from_time_t(t));
 		} else if (StringIsEqual(line, "Range")) {
 			char *endptr;
 

--- a/src/db/plugins/simple/DatabaseSave.cxx
+++ b/src/db/plugins/simple/DatabaseSave.cxx
@@ -70,7 +70,10 @@ db_load_internal(LineReader &file, Directory &music_root,
 		const char *p;
 
 		if ((p = StringAfterPrefix(line, DB_FORMAT_PREFIX))) {
-			format = atoi(p);
+			char *endptr;
+			format = (unsigned)strtoul(p, &endptr, 10);
+			if (endptr == p || *endptr != 0)
+				format = 0;
 		} else if (StringStartsWith(line, DIRECTORY_MPD_VERSION)) {
 			if (found_version)
 				throw std::runtime_error("Duplicate version line");

--- a/src/queue/PlaylistState.cxx
+++ b/src/queue/PlaylistState.cxx
@@ -151,7 +151,10 @@ playlist_state_restore(const StateFileConfig &config,
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_CONSUME))) {
 			playlist.SetConsume(ConsumeFromString(p));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_CROSSFADE))) {
-			pc.SetCrossFade(FloatDuration(atoi(p)));
+			char *endptr;
+			int cf = (int)strtol(p, &endptr, 10);
+			if (endptr > p && *endptr == 0)
+				pc.SetCrossFade(FloatDuration(cf));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_MIXRAMPDB))) {
 			pc.SetMixRampDb(ParseFloat(p));
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_MIXRAMPDELAY))) {
@@ -164,7 +167,10 @@ playlist_state_restore(const StateFileConfig &config,
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_RANDOM))) {
 			random_mode = StringIsEqual(p, "1");
 		} else if ((p = StringAfterPrefix(line, PLAYLIST_STATE_FILE_CURRENT))) {
-			current = atoi(p);
+			char *endptr;
+			current = (int)strtol(p, &endptr, 10);
+			if (endptr == p || *endptr != 0)
+				current = -1;
 		} else if (StringStartsWith(line,
 					    PLAYLIST_STATE_FILE_PLAYLIST_BEGIN)) {
 			playlist_state_load(file, song_loader, playlist);


### PR DESCRIPTION
## Issue

Five calls to atoi() are used to parse numeric values from data files (database file, state file, song files) that may be controlled by an attacker with filesystem access.

atoi() has three fundamental flaws:

1. It returns 0 on ANY parse failure, making it impossible to distinguish "value is 0" from "parse failed" or "empty input".
2. On integer overflow, atoi() triggers undefined behavior (C standard, section 7.22.1.2).
3. It does not accept an endptr parameter, so there is no way to validate that the entire input was consumed.

Affected code locations:

- SongSave.cxx:120 — mtime timestamp from song files
- SongSave.cxx:122 — added timestamp from song files
- DatabaseSave.cxx:73 — database format version
- PlaylistState.cxx:154 — crossfade duration from state file
- PlaylistState.cxx:167 — current playlist position

An attacker who can write or modify MPD's state files (typically ~/.mpd/state, ~/.mpd/database, or song cache) can provide crafted numeric fields that may:
- Cause atoi() to invoke undefined behavior via overflow
- Silently produce default values (0) when parsing fails, leading to incorrect program behavior

While the practical exploitability is limited (these are local state files readable only by the MPD user), this represents a robustness issue that can cause crashes or incorrect behavior if state files become corrupted.

## Solution

Each atoi() call is replaced with the corresponding strtol() or strtoul() call with proper endptr validation:

**src/SongSave.cxx:**
- mtime: strtol + endptr check; skip SetLastModified on parse failure (leaving default/invalid state)
- added: same approach

**src/db/plugins/simple/DatabaseSave.cxx:**
- format: strtoul + endptr check; set to 0 on parse failure (will be rejected by the range check below)

**src/queue/PlaylistState.cxx:**
- crossfade: strtol + endptr check; skip SetCrossFade on parse failure (leaving current value)
- current: strtol + endptr check; set to -1 on parse failure (same as default/unset)