### PR TITLE
fmt 12.2.0 compatibilty

### DIFF
--- a/src/Mapper.cxx
+++ b/src/Mapper.cxx
@@ -17,7 +17,7 @@
 #include "Main.hxx"
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 

--- a/src/input/plugins/AlsaInputPlugin.cxx
+++ b/src/input/plugins/AlsaInputPlugin.cxx
@@ -27,7 +27,7 @@
 
 #include <alsa/asoundlib.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 

--- a/src/input/plugins/QobuzClient.cxx
+++ b/src/input/plugins/QobuzClient.cxx
@@ -5,7 +5,7 @@
 #include "lib/crypto/MD5.hxx"
 #include "thread/ScopeUnlock.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 #include <stdexcept>

--- a/src/input/plugins/QobuzLoginRequest.cxx
+++ b/src/input/plugins/QobuzLoginRequest.cxx
@@ -6,7 +6,7 @@
 #include "QobuzSession.hxx"
 #include "lib/curl/Form.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
 #include <cassert>

--- a/src/input/plugins/QobuzTrackRequest.cxx
+++ b/src/input/plugins/QobuzTrackRequest.cxx
@@ -5,7 +5,7 @@
 #include "QobuzErrorParser.hxx"
 #include "QobuzClient.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
 using std::string_view_literals::operator""sv;

--- a/src/lib/avahi/Publisher.cxx
+++ b/src/lib/avahi/Publisher.cxx
@@ -13,7 +13,7 @@
 #include <avahi-common/malloc.h>
 #include <avahi-common/alternative.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 

--- a/src/net/ToString.cxx
+++ b/src/net/ToString.cxx
@@ -6,7 +6,7 @@
 #include "IPv4Address.hxx"
 #include "net/Features.hxx" // for HAVE_TCP, HAVE_IPV6, HAVE_UN
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cassert>

--- a/src/output/plugins/httpd/HttpdClient.cxx
+++ b/src/output/plugins/httpd/HttpdClient.cxx
@@ -13,7 +13,7 @@
 #include "util/StringSplit.hxx"
 #include "Log.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 

--- a/src/output/plugins/httpd/IcyMetaDataServer.cxx
+++ b/src/output/plugins/httpd/IcyMetaDataServer.cxx
@@ -5,7 +5,7 @@
 #include "tag/Tag.hxx"
 #include "util/TruncateString.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <iterator>
 

--- a/src/song/AddedSinceSongFilter.cxx
+++ b/src/song/AddedSinceSongFilter.cxx
@@ -6,7 +6,7 @@
 #include "time/ISO8601.hxx"
 #include "util/StringBuffer.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
 

--- a/src/song/AudioFormatSongFilter.cxx
+++ b/src/song/AudioFormatSongFilter.cxx
@@ -5,7 +5,7 @@
 #include "LightSong.hxx"
 #include "util/StringBuffer.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
 

--- a/src/song/LightSong.cxx
+++ b/src/song/LightSong.cxx
@@ -4,7 +4,7 @@
 #include "LightSong.hxx"
 #include "tag/Tag.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
 

--- a/src/song/ModifiedSinceSongFilter.cxx
+++ b/src/song/ModifiedSinceSongFilter.cxx
@@ -6,7 +6,7 @@
 #include "time/ISO8601.hxx"
 #include "util/StringBuffer.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
 

--- a/src/song/TagSongFilter.cxx
+++ b/src/song/TagSongFilter.cxx
@@ -8,7 +8,7 @@
 #include "tag/Tag.hxx"
 #include "tag/Fallback.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
 

--- a/src/song/UriSongFilter.cxx
+++ b/src/song/UriSongFilter.cxx
@@ -5,7 +5,7 @@
 #include "Escape.hxx"
 #include "LightSong.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
 


### PR DESCRIPTION
The [api](https://fmt.dev/12.0/api/) for fmt 12.2.0 changed