### PR TITLE
libfmt 12.2.0 support: use fmt/format.h not fmt/core.h

### DIFF
--- a/src/input/plugins/AlsaInputPlugin.cxx
+++ b/src/input/plugins/AlsaInputPlugin.cxx
@@ -27,7 +27,7 @@
 
 #include <alsa/asoundlib.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 

--- a/src/input/plugins/QobuzClient.cxx
+++ b/src/input/plugins/QobuzClient.cxx
@@ -5,7 +5,7 @@
 #include "lib/crypto/MD5.hxx"
 #include "thread/ScopeUnlock.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 #include <stdexcept>

--- a/src/input/plugins/QobuzLoginRequest.cxx
+++ b/src/input/plugins/QobuzLoginRequest.cxx
@@ -6,7 +6,7 @@
 #include "QobuzSession.hxx"
 #include "lib/curl/Form.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
 #include <cassert>

--- a/src/input/plugins/QobuzTrackRequest.cxx
+++ b/src/input/plugins/QobuzTrackRequest.cxx
@@ -5,7 +5,7 @@
 #include "QobuzErrorParser.hxx"
 #include "QobuzClient.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
 using std::string_view_literals::operator""sv;

--- a/src/lib/avahi/Publisher.cxx
+++ b/src/lib/avahi/Publisher.cxx
@@ -13,7 +13,7 @@
 #include <avahi-common/malloc.h>
 #include <avahi-common/alternative.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 

--- a/src/lib/nfs/FileReader.cxx
+++ b/src/lib/nfs/FileReader.cxx
@@ -10,7 +10,7 @@
 
 #include <nfsc/libnfs.h> // for struct nfs_stat_64
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 #include <cstring>

--- a/src/net/ToString.cxx
+++ b/src/net/ToString.cxx
@@ -6,7 +6,7 @@
 #include "IPv4Address.hxx"
 #include "net/Features.hxx" // for HAVE_TCP, HAVE_IPV6, HAVE_UN
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cassert>

--- a/src/output/plugins/httpd/HttpdClient.cxx
+++ b/src/output/plugins/httpd/HttpdClient.cxx
@@ -13,7 +13,7 @@
 #include "util/StringSplit.hxx"
 #include "Log.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 

--- a/src/output/plugins/httpd/IcyMetaDataServer.cxx
+++ b/src/output/plugins/httpd/IcyMetaDataServer.cxx
@@ -5,7 +5,7 @@
 #include "tag/Tag.hxx"
 #include "util/TruncateString.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <iterator>
 

--- a/src/song/AddedSinceSongFilter.cxx
+++ b/src/song/AddedSinceSongFilter.cxx
@@ -6,7 +6,7 @@
 #include "time/ISO8601.hxx"
 #include "util/StringBuffer.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
 

--- a/src/song/AudioFormatSongFilter.cxx
+++ b/src/song/AudioFormatSongFilter.cxx
@@ -5,7 +5,7 @@
 #include "LightSong.hxx"
 #include "util/StringBuffer.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
 

--- a/src/song/ModifiedSinceSongFilter.cxx
+++ b/src/song/ModifiedSinceSongFilter.cxx
@@ -6,7 +6,7 @@
 #include "time/ISO8601.hxx"
 #include "util/StringBuffer.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
 

--- a/src/storage/plugins/NfsStorage.cxx
+++ b/src/storage/plugins/NfsStorage.cxx
@@ -28,7 +28,7 @@ extern "C" {
 #include <nfsc/libnfs-raw-nfs.h>
 }
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 #include <string>


### PR DESCRIPTION
Since libfmt 12.2.0, fmt/core.h is a shim that only includes fmt/base.h which does not provide fmt::format(). Include fmt/format.h directly in files that call fmt::format().

Fixes build with libfmt-12.2.0

https://github.com/fmtlib/fmt/releases/tag/12.2.0