### PR TITLE
decoder/ffmpeg: free AVIO buffer

### DIFF
--- a/src/decoder/plugins/FfmpegIo.cxx
+++ b/src/decoder/plugins/FfmpegIo.cxx
@@ -97,9 +97,10 @@ AvioStream::Open()
 				false, this,
 				_Read, nullptr,
 				input.IsSeekable() ? _Seek : nullptr);
-	/* If avio_alloc_context() fails, who frees the buffer?  The
-	   libavformat API documentation does not specify this, it
-	   only says that AVIOContext.buffer must be freed in the end,
-	   however no AVIOContext exists in that failure code path. */
-	return io != nullptr;
+	if (io == nullptr) {
+		av_free(buffer);
+		return false;
+	}
+
+	return true;
 }


### PR DESCRIPTION
Free the buffer allocated for avio_alloc_context() if creating the AVIOContext fails.

Without this cleanup, that failure path leaks the 8192-byte buffer.