### PR TITLE
systemd: allow AF_NETLINK when upnp is enabled

### DIFF
--- a/systemd/meson.build
+++ b/systemd/meson.build
@@ -2,7 +2,7 @@ systemd_unit_conf = configuration_data()
 systemd_unit_conf.set('prefix', get_option('prefix'))
 
 address_families = ['AF_INET', 'AF_INET6', 'AF_UNIX']
-if get_option('smbclient').enabled()
+if get_option('smbclient').enabled() or conf.get('ENABLE_UPNP')
   # AF_NETLINK is required by libsmbclient, or it will exit() .. *sigh*
   address_families += 'AF_NETLINK'
 endif


### PR DESCRIPTION
`AF_NETLINK` is also needed for the upnp database plugin: https://bbs.archlinux.org/viewtopic.php?id=310134