### PR TITLE
Fix clipping with Opus files without ReplayGain tags when there's less than 5 dB headroom

### DIFF
--- a/src/decoder/plugins/OpusDecoderPlugin.cxx
+++ b/src/decoder/plugins/OpusDecoderPlugin.cxx
@@ -47,17 +47,6 @@ IsOpusTags(const ogg_packet &packet) noexcept
 	return packet.bytes >= 8 && memcmp(packet.packet, "OpusTags", 8) == 0;
 }
 
-/**
- * Convert an EBU R128 value to ReplayGain.
- */
-static constexpr float
-EbuR128ToReplayGain(float ebu_r128) noexcept
-{
-	/* add 5dB to compensate for the different reference levels
-	   between ReplayGain (89dB) and EBU R128 (-23 LUFS) */
-	return ebu_r128 + 5;
-}
-
 static bool
 mpd_opus_init([[maybe_unused]] const ConfigBlock &block)
 {
@@ -282,11 +271,12 @@ MPDOpusDecoder::HandleTags(const ogg_packet &packet)
 
 	if (rgi.IsDefined()) {
 		/* submit all valid EBU R128 values with output_gain
-		   applied */
+		   applied. conversion from EBU R128 -> ReplayGain
+		   happened in ScanOpusTags already. */
 		if (rgi.track.IsDefined())
-			rgi.track.gain += EbuR128ToReplayGain(output_gain);
+			rgi.track.gain += output_gain;
 		if (rgi.album.IsDefined())
-			rgi.album.gain += EbuR128ToReplayGain(output_gain);
+			rgi.album.gain += output_gain;
 		client.SubmitReplayGain(&rgi);
 		submitted_replay_gain = true;
 	}

--- a/src/decoder/plugins/OpusDecoderPlugin.cxx
+++ b/src/decoder/plugins/OpusDecoderPlugin.cxx
@@ -312,7 +312,7 @@ MPDOpusDecoder::HandleAudio(const ogg_packet &packet)
 		   gain" value */
 		ReplayGainInfo rgi;
 		rgi.Clear();
-		rgi.track.gain = EbuR128ToReplayGain(output_gain);
+		rgi.track.gain = output_gain;
 		client.SubmitReplayGain(&rgi);
 		submitted_replay_gain = true;
 	}

--- a/src/decoder/plugins/OpusTags.cxx
+++ b/src/decoder/plugins/OpusTags.cxx
@@ -17,6 +17,17 @@
 
 using std::string_view_literals::operator""sv;
 
+/**
+ * Convert an EBU R128 value to ReplayGain.
+ */
+static constexpr float
+EbuR128ToReplayGain(float ebu_r128) noexcept
+{
+	/* add 5dB to compensate for the different reference levels
+	   between ReplayGain (89dB) and EBU R128 (-23 LUFS) */
+	return ebu_r128 + 5;
+}
+
 [[gnu::pure]]
 static TagType
 ParseOpusTagName(std::string_view name) noexcept
@@ -47,14 +58,14 @@ ScanOneOpusTag(std::string_view name, std::string_view value,
 		   dB */
 
 		if (const auto i = ParseInteger<int_least32_t>(value))
-			rgi->track.gain = float(*i) / 256.0f;
+			rgi->track.gain = EbuR128ToReplayGain(float(*i) / 256.0f);
 	} else if (rgi != nullptr &&
 		   StringIsEqualIgnoreCase(name, "R128_ALBUM_GAIN"sv)) {
 		/* R128_ALBUM_GAIN is a Q7.8 fixed point number in
 		   dB */
 
 		if (const auto i = ParseInteger<int_least32_t>(value))
-			rgi->album.gain = float(*i) / 256.0f;
+			rgi->album.gain = EbuR128ToReplayGain(float(*i) / 256.0f);
 	}
 
 	handler.OnPair(name, value);


### PR DESCRIPTION
Kindly see commit messages for what & why.

Here's some reproducer info:

### Reproducer file

1. Open audacity and make sure the project sample rate is set to 48 kHz
2. Generate -> Tone...
   - Waveform = Sine
   - Frequency = 440 Hz
   - Amplitude = 1
   - Duration = 1m
3. File -> Export Audio
   - Channels = mono
   - Sample rate = 48000 Hz
   - Encoding = signed 16-bit PCM
4. Run opusenc on the resulting file

The file is also available here for download: https://sotecware.net/files/persistent/mpd-clipping.opus

### Reproducer config

<details>
<summary><code>cat ~/.config/mpd/mpd.conf</code></summary>

```
music_directory "/home/horazont/tmp/music"
playlist_directory "/home/horazont/.local/share/mpd/playlists"
log_file "/home/horazont/.local/share/mpd/log.txt"
pid_file "/run/user/1000/mpd.pid"
state_file "/home/horazont/.config/mpd/state"
sticker_file "/home/horazont/.config/mpd/sticker.sql"
bind_to_address "::"
zeroconf_enabled "yes"
zeroconf_name "Music Player"
input {
	plugin "curl"
}

audio_output {
	type	"pulse"
	name	"Default"
	mixer_type "software"
}

replaygain "auto"

filesystem_charset "UTF-8"
id3v1_encoding	"UTF-8"
```

</details>

Replay gain must be enabled and mpd's volume must be at 100% for the effect to be noticeable.

Let me know if you want more of the reproducer info included in the commit message.