### PR TITLE
tag/Id3Load: cap ID3v2 tag-size allocation at 4 MB

### DIFF
--- a/src/tag/Id3Load.cxx
+++ b/src/tag/Id3Load.cxx
@@ -47,6 +47,9 @@ try {
 
 	const std::size_t tag_size = static_cast<std::size_t>(query);
 
+	if (tag_size > 4 * 1024 * 1024)
+		return nullptr;
+
 	/* Found a tag.  Allocate a buffer and read it in. */
 	if (tag_size <= sizeof(query_buffer))
 		/* we have enough data already */


### PR DESCRIPTION
ReadId3Tag() allocates a buffer sized by the ID3v2 syncsafe size field
before validating that the file actually contains that many bytes. A
crafted 1 KB file with a header claiming ~256 MB forces a ~256 MB heap
allocation (256000x amplification). The sibling function
tag_id3_riff_aiff_load already caps at 4 MB for the same reason, but the
main ID3v2 path never got the same bound.

A remote MPD client with the default READ permission can trigger this
via the readcomments command pointing at an attacker-controlled HTTP
server that serves a crafted file, causing denial of service through
memory exhaustion (repeatable across connections, and the SEEK-frame
loop in the same function allows repeated spikes within a single
request).

This adds the same 4 MB cap already used by tag_id3_riff_aiff_load,
placed right after tag_size is computed and before the allocation.