### PR TITLE
win32: use InjectBreak() for cross-thread shutdown

### DIFF
--- a/src/win32/Win32Main.cxx
+++ b/src/win32/Win32Main.cxx
@@ -89,7 +89,7 @@ console_handler(DWORD event)
 			// regardless our thread is still active.
 			// If this did not happen within 3 seconds
 			// let's shutdown anyway.
-			global_instance->Break();
+			global_instance->event_loop.InjectBreak();
 			// Under debugger it's better to wait indefinitely
 			// to allow debugging of shutdown code.
 			Sleep(IsDebuggerPresent() ? INFINITE : 3000);


### PR DESCRIPTION
`Break()` only sets a flag without waking `select()`, so the console handler thread and service dispatcher thread can never actually stop the event loop.  Use `InjectBreak()` instead, which writes to the wake pipe to interrupt `select()`.

Without this, ^c in a console and `net stop mpd` both fail to shut down MPD gracefully - the process must be hard-killed, losing the state file.