### PR TITLE
db/update: truncate mtime to seconds during song db checks

### DIFF
--- a/src/db/update/UpdateSong.cxx
+++ b/src/db/update/UpdateSong.cxx
@@ -14,6 +14,15 @@
 
 #include <unistd.h>
 
+/* Truncate to seconds to match the DB round-trip through time_t */
+static inline bool
+CompareMtimeCoarse(std::chrono::system_clock::time_point info_mtime,
+		 std::chrono::system_clock::time_point song_mtime) noexcept
+{
+	return std::chrono::system_clock::to_time_t(info_mtime) ==
+	       std::chrono::system_clock::to_time_t(song_mtime);
+}
+
 inline void
 UpdateWalk::UpdateSongFile2(Directory &directory,
 			    std::string_view name, std::string_view suffix,
@@ -32,7 +41,9 @@ try {
 		return;
 	}
 
-	if (!(song != nullptr && info.mtime == song->mtime && !walk_discard) &&
+	if (!(song != nullptr &&
+	      CompareMtimeCoarse(info.mtime, song->mtime) &&
+	      !walk_discard) &&
 	    UpdateContainerFile(directory, name, suffix, info)) {
 		return;
 	}
@@ -61,7 +72,8 @@ try {
 		modified = true;
 		FmtNotice(update_domain, "added {}/{}",
 			  directory.GetPath(), name);
-	} else if (info.mtime != song->mtime || walk_discard) {
+	} else if (!CompareMtimeCoarse(info.mtime, song->mtime) ||
+		   walk_discard) {
 		FmtNotice(update_domain, "updating {}/{}",
 			  directory.GetPath(), name);
 		if (song->UpdateFile(storage, info))


### PR DESCRIPTION
FILETIME has 100ns precision but the database stores mtimes as time_t (seconds).  After restart, the comparison between the full-precision FILETIME value and the second-precision DB value always mismatches, forcing a full rescan on every startup.