### PR TITLE
qobuz: require HTTPS for API requests

### DIFF
--- a/src/input/plugins/QobuzInputPlugin.cxx
+++ b/src/input/plugins/QobuzInputPlugin.cxx
@@ -115,7 +115,9 @@ InitQobuzInput(EventLoop &event_loop, const ConfigBlock &block)
 	GlobalInitMD5();
 
 	const char *base_url = block.GetBlockValue("base_url",
-						   "http://www.qobuz.com/api.json/0.2/");
+						   "https://www.qobuz.com/api.json/0.2/");
+	if (!StringStartsWithIgnoreCase(base_url, "https://"sv))
+		throw PluginUnconfigured("Qobuz base_url must use HTTPS");
 
 	const char *app_id = block.GetBlockValue("app_id");
 	if (app_id == nullptr)


### PR DESCRIPTION
The Qobuz input plugin defaults to an HTTP API URL and includes the configured password in the login URL query. An on-path attacker can read the credentials and login response.\n\nUse the HTTPS endpoint by default and reject non-HTTPS base_url values.