### PR TITLE
python/build/libs.py: add mpg123 1.33.6

### DIFF
--- a/python/build/libs.py
+++ b/python/build/libs.py
@@ -562,6 +562,17 @@ ffmpeg = FfmpegProject(
     ],
 )
 
+libmpg123 = AutotoolsProject(
+    'https://mpg123.de/download/mpg123-1.33.6.tar.bz2',
+    '0b10b3b33547f51e52694d069ca3cfe6',
+    'lib/libmpg123.a',
+    [
+        '--disable-shared', '--enable-static',
+        '--disable-components', '--enable-libmpg123',
+        '--disable-modules', '--disable-debug',
+    ],
+)
+
 libnfs = AutotoolsProject(
     'https://github.com/sahlberg/libnfs/archive/libnfs-6.0.2.tar.gz',
     '4e5459cc3e0242447879004e9ad28286d4d27daa42cbdcde423248fad911e747',

--- a/win32/build.py
+++ b/win32/build.py
@@ -44,6 +44,7 @@ thirdparty_libs = [
     wildmidi,
     gme,
     ffmpeg,
+    libmpg123,
     libnfs,
     libsamplerate,
 ]


### PR DESCRIPTION
Adds mpg123 as a third-party library, giving the cross-compiled build a dedicated MP3 decoder instead of falling back on ffmpeg.

The main reason to add it is to work around a pretty old ffmpeg bug where id3v2.4 multi-value tags (e.g. multiple genres, artists) are truncated to only the first value: https://trac.ffmpeg.org/ticket/6949

As a bonus, it is also **significantly** faster for library scanning, nearly 20x on 25k MP3 files compared to ffmpeg, tested on NTFS.