### PR TITLE
wasapi: prevent audio pops on startup, resume, and seek

### DIFF
--- a/src/output/plugins/wasapi/AudioClient.hxx
+++ b/src/output/plugins/wasapi/AudioClient.hxx
@@ -65,6 +65,14 @@ Stop(IAudioClient &client)
 }
 
 inline void
+Reset(IAudioClient &client)
+{
+	HRESULT result = client.Reset();
+	if (FAILED(result))
+		throw MakeHResultError(result, "Failed to reset client");
+}
+
+inline void
 SetEventHandle(IAudioClient &client, HANDLE h)
 {
 	HRESULT result = client.SetEventHandle(h);

--- a/src/output/plugins/wasapi/WasapiOutputPlugin.cxx
+++ b/src/output/plugins/wasapi/WasapiOutputPlugin.cxx
@@ -218,6 +218,14 @@ public:
 		std::size_t consumed = ring_buffer.WriteFrom(input);
 
 		if (!playing) {
+			/* Wait for enough data to fill the entire
+			   endpoint buffer before starting playback to
+			   prevent a pop on cold start.
+			   https://learn.microsoft.com/en-us/windows/win32/coreaudio/rendering-a-stream */
+			if (ring_buffer.ReadAvailable() <
+			    buffer_size_in_frames * frame_size) {
+				return consumed;
+			}
 			playing = true;
 			Play();
 		}

--- a/src/output/plugins/wasapi/WasapiOutputPlugin.cxx
+++ b/src/output/plugins/wasapi/WasapiOutputPlugin.cxx
@@ -430,10 +430,19 @@ try {
 		event.Wait();
 
 		if (cancel.load()) {
+			/* Stop the client to prevent playing stale data
+			   or silence after discard. Push() will restart
+			   once the ring buffer is full.
+			   https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-start */
+			if (started && !is_exclusive) {
+				Stop(client);
+				started = false;
+			}
 			ring_buffer.Discard();
 			cancel.store(false);
 			empty.store(true);
 			InterruptWaiter();
+			continue;
 		}
 
 		Status current_state = status.load();

--- a/src/output/plugins/wasapi/WasapiOutputPlugin.cxx
+++ b/src/output/plugins/wasapi/WasapiOutputPlugin.cxx
@@ -454,6 +454,15 @@ try {
 
 		UINT32 write_in_frames = buffer_size_in_frames;
 		DWORD mode = 0;
+
+		/* Flush any pending data left in the endpoint buffer
+		   after Stop() and reset the stream position to 0.
+		   Without this, Start() would play stale audio.
+		   https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-reset */
+		if (!started) {
+			Reset(client);
+		}
+
 		AtScopeExit(&) {
 			render_client->ReleaseBuffer(write_in_frames, mode);
 

--- a/src/output/plugins/wasapi/WasapiOutputPlugin.cxx
+++ b/src/output/plugins/wasapi/WasapiOutputPlugin.cxx
@@ -144,6 +144,14 @@ SetDSDFallback(AudioFormat &audio_format) noexcept
 
 } // namespace
 
+/**
+ * Renders audio from a ring buffer into a WASAPI endpoint buffer.
+ * To avoid pops, the client is started only when the endpoint buffer
+ * can be filled completely (see Push()), after flushing whatever is
+ * left over from a previous Stop() (see Work()).
+ *
+ * https://learn.microsoft.com/en-us/windows/win32/coreaudio/rendering-a-stream
+ */
 class WasapiOutputThread {
 	Thread thread{BIND_THIS_METHOD(Work)};
 	WinEvent event;
@@ -221,6 +229,14 @@ public:
 		std::size_t consumed = ring_buffer.WriteFrom(input);
 
 		if (!playing) {
+			/* Don't start playback until the endpoint
+			   buffer can be filled completely, or the
+			   device will play a short burst of audio
+			   followed by silence */
+			if (ring_buffer.ReadAvailable() <
+			    buffer_size_in_frames * frame_size) {
+				return consumed;
+			}
 			playing = true;
 			Play();
 		}
@@ -283,6 +299,16 @@ public:
 	}
 
 private:
+	/**
+	 * Stop the client; must be called on the worker thread while
+	 * started is true.  Anything left in the endpoint buffer is
+	 * flushed later, just before the client gets started again.
+	 */
+	void HaltClient() {
+		Stop(client);
+		started = false;
+	}
+
 	void SetStatus(Status s) noexcept {
 		status.store(s);
 		event.Set();
@@ -465,10 +491,19 @@ try {
 		}
 
 		if (cancel.load()) {
+			/* Stop the client or it will keep playing
+			   silence after the discard; Push() will
+			   restart it later.
+			   NOTE: Only in shared mode, in exclusive
+			   mode stopping here breaks playback */
+			if (started && !is_exclusive)
+				HaltClient();
+
 			ring_buffer.Discard();
 			cancel.store(false);
 			empty.store(true);
 			InterruptWaiter();
+			continue;
 		}
 
 		Status current_state = status.load();
@@ -479,16 +514,8 @@ try {
 			return;
 
 		case Status::PAUSE:
-			if (!started)
-				/* don't bother starting the
-				   IAudioClient if we're paused */
-				continue;
-
-			/* stop the IAudioClient while paused; it will
-			   be restarted as soon as we're asked to
-			   resume playback */
-			Stop(client);
-			started = false;
+			if (started)
+				HaltClient();
 			continue;
 
 		case Status::PLAY:
@@ -496,15 +523,13 @@ try {
 		}
 
 		UINT32 write_in_frames = buffer_size_in_frames;
-		DWORD mode = 0;
-		AtScopeExit(&) {
-			render_client->ReleaseBuffer(write_in_frames, mode);
 
-			if (!started) {
-				Start(client);
-				started = true;
-			}
-		};
+		/* Flush anything left over from a previous Stop(); the
+		   padding check below needs zero padding, or we would
+		   neither render nor start.  Do not do this directly
+		   after Stop(). */
+		if (!started)
+			Reset(client);
 
 		if (!is_exclusive) {
 			UINT32 data_in_frames =
@@ -522,6 +547,16 @@ try {
 		    FAILED(result)) {
 			throw MakeHResultError(result, "Failed to get buffer");
 		}
+
+		DWORD mode = 0;
+		AtScopeExit(&) {
+			render_client->ReleaseBuffer(write_in_frames, mode);
+
+			if (!started) {
+				Start(client);
+				started = true;
+			}
+		};
 
 		const UINT32 write_size = write_in_frames * frame_size;
 		std::span w{data, write_size};


### PR DESCRIPTION
Fixes annoying audio pops in the wasapi output caused by sample waveform discontinuities. Most of them, at least. The remaining ones can only be masked by something like fade in/out, which MPD doesn't have.