### PR TITLE
output/osx: fix two format selection bugs, cleanups for the macOS code

### DIFF
--- a/src/apple/AudioObject.hxx
+++ b/src/apple/AudioObject.hxx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // author: Max Kellermann <max.kellermann@gmail.com>
 
-#ifndef APPLE_AUDIO_OBJECT_HXX
-#define APPLE_AUDIO_OBJECT_HXX
+#pragma once
 
 #include "Throw.hxx"
 #include "util/AllocatedArray.hxx"
@@ -75,5 +74,3 @@ AudioObjectGetPropertyDataArray(AudioObjectID inObjectID,
 
 	return result;
 }
-
-#endif

--- a/src/apple/AudioObject.hxx
+++ b/src/apple/AudioObject.hxx
@@ -46,6 +46,19 @@ AudioObjectGetPropertyDataT(AudioObjectID inObjectID,
 	return value;
 }
 
+template<typename T>
+void
+AudioObjectSetPropertyDataT(AudioObjectID inObjectID,
+			    const AudioObjectPropertyAddress &inAddress,
+			    const T &value)
+{
+	OSStatus status = AudioObjectSetPropertyData(inObjectID, &inAddress,
+						     0, nullptr,
+						     sizeof(value), &value);
+	if (status != noErr)
+		Apple::ThrowOSStatus(status);
+}
+
 Apple::StringRef
 AudioObjectGetStringProperty(AudioObjectID inObjectID,
 			     const AudioObjectPropertyAddress &inAddress);

--- a/src/apple/AudioUnit.hxx
+++ b/src/apple/AudioUnit.hxx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // author: Max Kellermann <max.kellermann@gmail.com>
 
-#ifndef APPLE_AUDIO_UNIT_HXX
-#define APPLE_AUDIO_UNIT_HXX
+#pragma once
 
 #include "Throw.hxx"
 
@@ -81,5 +80,3 @@ AudioUnitSetBufferFrameSize(AudioUnit inUnit, const UInt32 &value)
 			      kAudioUnitScope_Global, 0,
 			      value);
 }
-
-#endif

--- a/src/apple/ErrorRef.hxx
+++ b/src/apple/ErrorRef.hxx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // author: Max Kellermann <max.kellermann@gmail.com>
 
-#ifndef APPLE_ERROR_REF_HXX
-#define APPLE_ERROR_REF_HXX
+#pragma once
 
 #include <CoreFoundation/CFError.h>
 
@@ -49,5 +48,3 @@ public:
 };
 
 } // namespace Apple
-
-#endif

--- a/src/apple/StringRef.hxx
+++ b/src/apple/StringRef.hxx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // author: Max Kellermann <max.kellermann@gmail.com>
 
-#ifndef APPLE_STRING_REF_HXX
-#define APPLE_STRING_REF_HXX
+#pragma once
 
 #include <CoreFoundation/CFString.h>
 
@@ -43,5 +42,3 @@ public:
 };
 
 } // namespace Apple
-
-#endif

--- a/src/apple/Throw.cxx
+++ b/src/apple/Throw.cxx
@@ -33,7 +33,7 @@ ThrowOSStatus(OSStatus status, const char *prefix)
 
 	char description[1024];
 	if (cfstr.GetCString(description, sizeof(description)))
-		throw std::runtime_error(std::string{prefix} + description);
+		throw std::runtime_error(std::string{prefix} + ": " + description);
 
 	throw std::runtime_error(prefix);
 }

--- a/src/apple/Throw.hxx
+++ b/src/apple/Throw.hxx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // author: Max Kellermann <max.kellermann@gmail.com>
 
-#ifndef APPLE_THROW_HXX
-#define APPLE_THROW_HXX
+#pragma once
 
 #include <CoreFoundation/CFBase.h>
 
@@ -15,5 +14,3 @@ void
 ThrowOSStatus(OSStatus status, const char *msg);
 
 } // namespace Apple
-
-#endif

--- a/src/apple/meson.build
+++ b/src/apple/meson.build
@@ -3,8 +3,9 @@ if not is_darwin
   subdir_done()
 endif
 
-audiounit_dep = declare_dependency(
-  link_args: ['-framework', 'AudioUnit', '-framework', 'CoreAudio', '-framework', 'CoreServices'],
+audiounit_dep = dependency(
+  'appleframeworks',
+  modules: ['AudioToolbox', 'AudioUnit', 'CoreAudio', 'CoreFoundation'],
 )
 
 apple = static_library(

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -172,15 +172,12 @@ OSXOutput::Create(EventLoop &, const ConfigBlock &block)
 		   changed by osx_output_set_device) */
 		: default_output_device;
 
-	AudioDeviceID dev_id = kAudioDeviceUnknown;
-	UInt32 dev_id_size = sizeof(dev_id);
-	AudioObjectGetPropertyData(kAudioObjectSystemObject,
-				   &aopa,
-				   0,
-				   NULL,
-				   &dev_id_size,
-				   &dev_id);
-	oo->dev_id = dev_id;
+	try {
+		oo->dev_id = AudioObjectGetPropertyDataT<AudioDeviceID>(kAudioObjectSystemObject,
+									aopa);
+	} catch (...) {
+		oo->dev_id = kAudioDeviceUnknown;
+	}
 
 	return oo;
 }

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -14,20 +14,16 @@
 #include "util/Manual.hxx"
 #include "pcm/Export.hxx"
 #include "pcm/Features.h" // for ENABLE_DSD
-#include "thread/Mutex.hxx"
-#include "thread/Cond.hxx"
 #include "util/ByteOrder.hxx"
 #include "util/CharUtil.hxx"
 #include "util/RingBuffer.hxx"
 #include "util/RoundPowerOfTwo.hxx"
 #include "util/StringAPI.hxx"
-#include "util/StringBuffer.hxx"
 #include "Log.hxx"
 
 #include <CoreAudio/CoreAudio.h>
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioToolbox.h>
-#include <CoreServices/CoreServices.h>
 
 #include <cmath>
 #include <memory>

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -19,6 +19,7 @@
 #include "util/ByteOrder.hxx"
 #include "util/CharUtil.hxx"
 #include "util/RingBuffer.hxx"
+#include "util/RoundPowerOfTwo.hxx"
 #include "util/StringAPI.hxx"
 #include "util/StringBuffer.hxx"
 #include "Log.hxx"
@@ -454,13 +455,8 @@ osx_output_set_buffer_size(AudioUnit au, AudioStreamBasicDescription desc)
 	auto buffer_frame_size = AudioUnitGetBufferFrameSize(au);
 	buffer_frame_size *= desc.mBytesPerFrame;
 
-	// We set the frame size to a power of two integer that
-	// is larger than buffer_frame_size.
-	UInt32 frame_size = 1;
-	while (frame_size < buffer_frame_size + 1)
-		frame_size <<= 1;
-
-	return frame_size;
+	// the smallest power of two larger than buffer_frame_size
+	return RoundUpToPowerOfTwo(buffer_frame_size + 1);
 }
 
 static void

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -41,7 +41,7 @@ static constexpr AudioObjectPropertySelector kAudioHardwareServiceDeviceProperty
 static constexpr unsigned MPD_OSX_BUFFER_TIME_MS = 100;
 
 static auto
-StreamDescriptionToString(const AudioStreamBasicDescription desc) noexcept
+StreamDescriptionToString(const AudioStreamBasicDescription &desc) noexcept
 {
 	// Only convert the lpcm formats (nothing else supported / used by MPD)
 	assert(desc.mFormatID == kAudioFormatLinearPCM);
@@ -389,7 +389,6 @@ osx_output_set_device_format(AudioDeviceID dev_id,
 
 		for (const auto &format : format_list) {
 			AudioStreamBasicDescription format_desc = format.mFormat;
-			std::string format_string;
 
 			// for devices with kAudioStreamAnyRate
 			// we use the requested samplerate here
@@ -585,7 +584,7 @@ osx_render(void *vdata,
 	   UInt32 in_number_frames,
 	   AudioBufferList *buffer_list)
 {
-	OSXOutput *od = (OSXOutput *) vdata;
+	auto *od = static_cast<OSXOutput *>(vdata);
 
 	std::size_t count = in_number_frames * od->asbd.mBytesPerFrame;
 	buffer_list->mBuffers[0].mDataByteSize =
@@ -604,7 +603,7 @@ OSXOutput::Enable()
 	desc.componentFlagsMask = 0;
 
 	AudioComponent comp = AudioComponentFindNext(nullptr, &desc);
-	if (comp == 0)
+	if (comp == nullptr)
 		throw std::runtime_error("Error finding OS X component");
 
 	OSStatus status = AudioComponentInstanceNew(comp, &au);
@@ -692,7 +691,8 @@ OSXOutput::Open(AudioFormat &audio_format)
 	asbd.mBytesPerFrame = asbd.mBytesPerPacket;
 	asbd.mChannelsPerFrame = audio_format.channels;
 
-	Float64 sample_rate = osx_output_set_device_format(dev_id, asbd);
+	[[maybe_unused]] const Float64 sample_rate =
+		osx_output_set_device_format(dev_id, asbd);
 
 #ifdef ENABLE_DSD
 	if (audio_format.format == SampleFormat::DSD &&

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -373,8 +373,6 @@ osx_output_set_device_format(AudioDeviceID dev_id,
 		kAudioObjectPropertyElementMain
 	};
 
-	OSStatus err;
-
 	const auto streams =
 		AudioObjectGetPropertyDataArray<AudioStreamID>(dev_id,
 							       aopa_device_streams);
@@ -422,15 +420,14 @@ osx_output_set_device_format(AudioDeviceID dev_id,
 	}
 
 	if (format_found) {
-		err = AudioObjectSetPropertyData(output_stream,
-						 &aopa_stream_phys_format,
-						 0,
-						 NULL,
-						 sizeof(output_format),
-						 &output_format);
+		OSStatus err = AudioObjectSetPropertyData(output_stream,
+							  &aopa_stream_phys_format,
+							  0,
+							  nullptr,
+							  sizeof(output_format),
+							  &output_format);
 		if (err != noErr)
-			throw FmtRuntimeError("Failed to change the stream format: {}",
-					      err);
+			Apple::ThrowOSStatus(err, "Failed to change the stream format");
 	}
 
 	/* without a matching format, this returns 0
@@ -772,7 +769,8 @@ OSXOutput::Play(std::span<const std::byte> input)
 	if (!started) {
 		OSStatus status = AudioOutputUnitStart(au);
 		if (status != noErr)
-			throw std::runtime_error("Unable to restart audio output after pause");
+			Apple::ThrowOSStatus(status,
+					     "Unable to start audio output");
 
 		started = true;
 	}

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -32,13 +32,13 @@
 #include <memory>
 #include <span>
 
-// Backward compatibility from OSX 12.0 API change
-#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 120000)
-	#define KAUDIO_OBJECT_PROPERTY_ELEMENT_MM kAudioObjectPropertyElementMain
-	#define KAUDIO_HARDWARE_SERVICE_DEVICE_PROPERTY_VV kAudioHardwareServiceDeviceProperty_VirtualMainVolume
-#else
-	#define KAUDIO_OBJECT_PROPERTY_ELEMENT_MM kAudioObjectPropertyElementMaster
-	#define KAUDIO_HARDWARE_SERVICE_DEVICE_PROPERTY_VV kAudioHardwareServiceDeviceProperty_VirtualMasterVolume
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED < 120000)
+/* the "Main" identifiers were introduced in the macOS 12 SDK,
+   renaming the deprecated "Master" identifiers */
+static constexpr AudioObjectPropertyElement kAudioObjectPropertyElementMain =
+	kAudioObjectPropertyElementMaster;
+static constexpr AudioObjectPropertySelector kAudioHardwareServiceDeviceProperty_VirtualMainVolume =
+	kAudioHardwareServiceDeviceProperty_VirtualMasterVolume;
 #endif
 
 static constexpr unsigned MPD_OSX_BUFFER_TIME_MS = 100;
@@ -154,13 +154,13 @@ OSXOutput::Create(EventLoop &, const ConfigBlock &block)
 	static constexpr AudioObjectPropertyAddress default_system_output_device{
 		kAudioHardwarePropertyDefaultSystemOutputDevice,
 		kAudioObjectPropertyScopeOutput,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM,
+		kAudioObjectPropertyElementMain,
 	};
 
 	static constexpr AudioObjectPropertyAddress default_output_device{
 		kAudioHardwarePropertyDefaultOutputDevice,
 		kAudioObjectPropertyScopeOutput,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM
+		kAudioObjectPropertyElementMain
 	};
 
 	const auto &aopa =
@@ -189,9 +189,9 @@ int
 OSXOutput::GetVolume()
 {
 	static constexpr AudioObjectPropertyAddress aopa = {
-		KAUDIO_HARDWARE_SERVICE_DEVICE_PROPERTY_VV,
+		kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
 		kAudioObjectPropertyScopeOutput,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM,
+		kAudioObjectPropertyElementMain,
 	};
 
 	const auto vol = AudioObjectGetPropertyDataT<Float32>(dev_id,
@@ -205,9 +205,9 @@ OSXOutput::SetVolume(unsigned new_volume)
 {
 	Float32 vol = new_volume / 100.0;
 	static constexpr AudioObjectPropertyAddress aopa = {
-		KAUDIO_HARDWARE_SERVICE_DEVICE_PROPERTY_VV,
+		kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
 		kAudioObjectPropertyScopeOutput,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM
+		kAudioObjectPropertyElementMain
 	};
 	UInt32 size = sizeof(vol);
 	OSStatus status = AudioObjectSetPropertyData(dev_id,
@@ -360,25 +360,25 @@ osx_output_set_device_format(AudioDeviceID dev_id,
 	static constexpr AudioObjectPropertyAddress aopa_device_streams = {
 		kAudioDevicePropertyStreams,
 		kAudioObjectPropertyScopeOutput,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM
+		kAudioObjectPropertyElementMain
 	};
 
 	static constexpr AudioObjectPropertyAddress aopa_stream_direction = {
 		kAudioStreamPropertyDirection,
 		kAudioObjectPropertyScopeOutput,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM
+		kAudioObjectPropertyElementMain
 	};
 
 	static constexpr AudioObjectPropertyAddress aopa_stream_phys_formats = {
 		kAudioStreamPropertyAvailablePhysicalFormats,
 		kAudioObjectPropertyScopeOutput,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM
+		kAudioObjectPropertyElementMain
 	};
 
 	static constexpr AudioObjectPropertyAddress aopa_stream_phys_format = {
 		kAudioStreamPropertyPhysicalFormat,
 		kAudioObjectPropertyScopeOutput,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM
+		kAudioObjectPropertyElementMain
 	};
 
 	OSStatus err;
@@ -480,7 +480,7 @@ osx_output_hog_device(AudioDeviceID dev_id, bool hog) noexcept
 	static constexpr AudioObjectPropertyAddress aopa = {
 		kAudioDevicePropertyHogMode,
 		kAudioObjectPropertyScopeOutput,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM
+		kAudioObjectPropertyElementMain
 	};
 
 	pid_t hog_pid;
@@ -534,7 +534,7 @@ IsAudioDeviceName(AudioDeviceID id, const char *expected_name) noexcept
 	static constexpr AudioObjectPropertyAddress aopa_name{
 		kAudioObjectPropertyName,
 		kAudioObjectPropertyScopeGlobal,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM,
+		kAudioObjectPropertyElementMain,
 	};
 
 	char actual_name[256];
@@ -557,7 +557,7 @@ FindAudioDeviceByName(const char *name)
 	static constexpr AudioObjectPropertyAddress aopa_hw_devices{
 		kAudioHardwarePropertyDevices,
 		kAudioObjectPropertyScopeGlobal,
-		KAUDIO_OBJECT_PROPERTY_ELEMENT_MM,
+		kAudioObjectPropertyElementMain,
 	};
 
 	const auto ids =

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -203,22 +203,14 @@ OSXOutput::GetVolume()
 void
 OSXOutput::SetVolume(unsigned new_volume)
 {
-	Float32 vol = new_volume / 100.0;
 	static constexpr AudioObjectPropertyAddress aopa = {
 		kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
 		kAudioObjectPropertyScopeOutput,
 		kAudioObjectPropertyElementMain
 	};
-	UInt32 size = sizeof(vol);
-	OSStatus status = AudioObjectSetPropertyData(dev_id,
-						     &aopa,
-						     0,
-						     NULL,
-						     size,
-						     &vol);
 
-	if (status != noErr)
-		Apple::ThrowOSStatus(status);
+	const Float32 vol = new_volume / 100.0f;
+	AudioObjectSetPropertyDataT(dev_id, aopa, vol);
 }
 
 static void
@@ -508,23 +500,19 @@ osx_output_hog_device(AudioDeviceID dev_id, bool hog) noexcept
 	}
 
 	hog_pid = hog ? getpid() : -1;
-	UInt32 size = sizeof(hog_pid);
-	OSStatus err;
-	err = AudioObjectSetPropertyData(dev_id,
-					 &aopa,
-					 0,
-					 NULL,
-					 size,
-					 &hog_pid);
-	if (err != noErr) {
-		FmtDebug(osx_output_domain,
-			 "Cannot hog the device: {}", err);
-	} else {
-		LogDebug(osx_output_domain,
-			 hog_pid == -1
-			 ? "Device is unhogged"
-			 : "Device is hogged");
+
+	try {
+		AudioObjectSetPropertyDataT(dev_id, aopa, hog_pid);
+	} catch (...) {
+		Log(LogLevel::DEBUG, std::current_exception(),
+		    "Cannot hog the device");
+		return;
 	}
+
+	LogDebug(osx_output_domain,
+		 hog_pid == -1
+		 ? "Device is unhogged"
+		 : "Device is hogged");
 }
 
 [[gnu::pure]]


### PR DESCRIPTION
The cleanup part of the macOS work; the format selection bug fixes were
split into #2550 and merged onto v0.24.x separately, so this branch was
rebased and now only carries the cleanups.

Errors now go through `Apple::ThrowOSStatus()` so they carry the
CoreAudio error description instead of a bare number, a new
`AudioObjectSetPropertyDataT()` wrapper mirrors the existing getter, the
buffer size uses `RoundUpToPowerOfTwo()`, and the macOS 12 "Main" rename
is handled with constexpr aliases for old SDKs instead of macros.

apple/meson.build switches to the "appleframeworks" dependency and
drops CoreServices, a leftover from the Component Manager API. Also
"#pragma once" in the apple headers and some unused includes removed.

Each commit builds on its own. Tested on macOS arm64 with and without
ENABLE_DSD.
