### PR TITLE
output/osx: fix format selection bugs and volume truncation

### DIFF
--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -28,6 +28,7 @@
 #include <AudioToolbox/AudioToolbox.h>
 #include <CoreServices/CoreServices.h>
 
+#include <cmath>
 #include <memory>
 #include <span>
 
@@ -197,7 +198,7 @@ OSXOutput::GetVolume()
 	const auto vol = AudioObjectGetPropertyDataT<Float32>(dev_id,
 							      aopa);
 
-	return static_cast<int>(vol * 100.0f);
+	return std::lround(vol * 100.0f);
 }
 
 void

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -388,8 +388,8 @@ osx_output_set_device_format(AudioDeviceID dev_id,
 							       aopa_device_streams);
 
 	bool format_found = false;
-	int output_stream;
-	AudioStreamBasicDescription output_format;
+	AudioStreamID output_stream = kAudioObjectUnknown;
+	AudioStreamBasicDescription output_format{};
 
 	for (const auto stream : streams) {
 		const auto direction =
@@ -424,7 +424,7 @@ osx_output_set_device_format(AudioDeviceID dev_id,
 			if (score > output_score) {
 				output_score  = score;
 				output_format = format_desc;
-				output_stream = stream; // set the idx of the stream in the device
+				output_stream = stream;
 				format_found = true;
 			}
 		}
@@ -442,6 +442,9 @@ osx_output_set_device_format(AudioDeviceID dev_id,
 					      err);
 	}
 
+	/* without a matching format, this returns 0
+	   (kAudioStreamAnyRate), which the caller interprets as "the
+	   requested sample rate is not available" */
 	return output_format.mSampleRate;
 }
 

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -388,6 +388,7 @@ osx_output_set_device_format(AudioDeviceID dev_id,
 							       aopa_device_streams);
 
 	bool format_found = false;
+	float output_score = 0;
 	AudioStreamID output_stream = kAudioObjectUnknown;
 	AudioStreamBasicDescription output_format{};
 
@@ -401,8 +402,6 @@ osx_output_set_device_format(AudioDeviceID dev_id,
 		const auto format_list =
 			AudioObjectGetPropertyDataArray<AudioStreamRangedDescription>(stream,
 										      aopa_stream_phys_formats);
-
-		float output_score = 0;
 
 		for (const auto &format : format_list) {
 			AudioStreamBasicDescription format_desc = format.mFormat;


### PR DESCRIPTION
The stable-branch subset of #2549: the bug fixes, without the cleanup
commits that only make sense on master.

Two bugs in `osx_output_set_device_format()`: if no stream had a
matching linear PCM format, the function returned the sample rate of
an uninitialized struct, and with DSD enabled that garbage decided
whether the DoP-to-PCM fallback was taken. The best-score variable was
also reset on every stream, so on multi-stream devices a worse format
from a later stream could win. Fixed in separate commits.

The third commit rounds the volume with `std::lround()` instead of
truncating, so a SetVolume()/GetVolume() round trip no longer drifts
downwards, like the other mixer plugins.

Each commit builds on its own. Tested on macOS arm64 with and without
ENABLE_DSD.
