### PR TITLE
decoder/dsdiff: reject overflowing chunk offsets

### DIFF
--- a/src/decoder/plugins/DsdiffDecoderPlugin.cxx
+++ b/src/decoder/plugins/DsdiffDecoderPlugin.cxx
@@ -21,6 +21,8 @@
 #include "tag/Handler.hxx"
 #include "DsdLib.hxx"
 
+#include <limits>
+
 struct DsdiffHeader {
 	DsdId id;
 	PackedBE64 size;
@@ -326,6 +328,10 @@ dsdiff_read_metadata(DecoderClient *client, InputStream &is,
 		} else {
 			/* ignore unknown chunk */
 			const offset_type chunk_size = chunk_header.GetSize();
+			if (chunk_size >
+			    std::numeric_limits<offset_type>::max() - is.GetOffset())
+				return false;
+
 			const offset_type chunk_end_offset =
 				is.GetOffset() + chunk_size;
 


### PR DESCRIPTION
dsdiff_read_metadata() reads a 64-bit chunk size from the DFF file and
adds it to the current input offset. If this addition overflows, the
result can point backward. For seekable input, dsdlib_skip_to() then
seeks back to the same chunk header, causing metadata scans to loop
indefinitely. Playback follows the same parsing path and can spin until
stopped.

Use checked offset addition in dsdiff_read_metadata(),
dsdiff_read_prop(), and dsdiff_read_prop_snd(). Also reject overflow
when applying DSDIFF even-byte padding and in dsdlib_skip() relative
seeks. Absolute backward seeks remain supported because the tag reader
uses them intentionally.

Verified with a 28-byte DFF file whose unknown chunk size wraps the
offset from 28 back to 16. The checked calculation now rejects the
chunk.
