### PR TITLE
decoder/mad: limit ID3 tag allocations

### DIFF
--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -32,6 +32,7 @@
 #include <string.h>
 
 static constexpr unsigned long FRAMES_CUSHION = 2000;
+static constexpr size_t MAX_ID3_TAG_SIZE = 4 * 1024 * 1024;
 
 enum class MadDecoderAction {
 	SKIP,
@@ -362,7 +363,15 @@ MadDecoder::DecodeNextFrame(bool skip, Tag *tag) noexcept
 							    stream.this_frame);
 
 			if (tagsize > 0) {
-				ParseId3((size_t)tagsize, tag);
+				const auto size = static_cast<size_t>(tagsize);
+				if (size > MAX_ID3_TAG_SIZE) {
+					FmtWarning(mad_domain,
+						   "ID3 tag is too large: {}",
+						   size);
+					return MadDecoderAction::SKIP;
+				}
+
+				ParseId3(size, tag);
 				return MadDecoderAction::CONT;
 			}
 		}


### PR DESCRIPTION
When libmad reports MAD_ERROR_LOSTSYNC, DecodeNextFrame() checks for an
ID3 header and passes its declared size to ParseId3(). Unlike the normal
tag/Id3Load.cxx path, this decoder-specific path did not enforce the
4 MiB ID3 size limit.

ParseId3() can consequently allocate the full attacker-controlled size
inside a noexcept call chain. A ten-byte ID3 header can declare a tag of
about 256 MiB, causing MPD to terminate if the allocation fails.

Apply the existing 4 MiB policy before calling ParseId3(). Oversized
tags stop this decoder attempt instead of retrying the same header.
