### PR TITLE
decoder/mad: bound Xing seek table allocations

### DIFF
--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -690,10 +690,28 @@ MadDecoder::DecodeFirstFrame(Tag *tag) noexcept
 		mute_frame = MadDecoderMuteFrame::SKIP;
 
 		if ((xing.flags & XING_FRAMES) && xing.frames) {
-			mad_timer_t duration = frame.header.duration;
-			mad_timer_multiply(&duration, xing.frames);
-			total_time = ToSongTime(duration);
-			max_frames = xing.frames;
+			/*
+			 * Each MPEG audio frame contains at least a four-byte
+			 * header.  Do not let a Xing header amplify a small
+			 * input into a large seek table allocation.  For
+			 * streams of unknown size, retain the conservative
+			 * estimate from FileSizeToSongLength().
+			 */
+			const offset_type available_frames =
+				input_stream.KnownSize()
+				? input_stream.GetSize() / 4
+				: FRAMES_CUSHION;
+
+			if (xing.frames > available_frames) {
+				FmtWarning(mad_domain,
+					   "ignoring implausible Xing frame count: {}",
+					   xing.frames);
+			} else {
+				mad_timer_t duration = frame.header.duration;
+				mad_timer_multiply(&duration, xing.frames);
+				total_time = ToSongTime(duration);
+				max_frames = xing.frames;
+			}
 		}
 
 		struct lame lame;

--- a/src/decoder/plugins/MadDecoderPlugin.cxx
+++ b/src/decoder/plugins/MadDecoderPlugin.cxx
@@ -26,6 +26,7 @@
 
 #include <algorithm> // for std::copy_n()
 #include <cassert>
+#include <new>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -149,13 +150,23 @@ private:
 
 	bool DecodeFirstFrame(Tag *tag) noexcept;
 
-	void AllocateBuffers() noexcept {
+	bool AllocateBuffers() noexcept {
 		assert(max_frames > 0);
 		assert(frame_offsets == nullptr);
 		assert(times == nullptr);
 
-		frame_offsets = new long[max_frames];
-		times = new mad_timer_t[max_frames];
+		frame_offsets = new (std::nothrow) long[max_frames];
+		if (frame_offsets == nullptr)
+			return false;
+
+		times = new (std::nothrow) mad_timer_t[max_frames];
+		if (times == nullptr) {
+			delete[] frame_offsets;
+			frame_offsets = nullptr;
+			return false;
+		}
+
+		return true;
 	}
 
 	[[nodiscard]] [[gnu::pure]]
@@ -960,7 +971,12 @@ MadDecoder::RunDecoder() noexcept
 		return;
 	}
 
-	AllocateBuffers();
+	if (!AllocateBuffers()) {
+		FmtWarning(mad_domain,
+			   "failed to allocate seek table for {} frames",
+			   max_frames);
+		return;
+	}
 
 	client->Ready(CheckAudioFormat(frame.header.samplerate,
 				       SampleFormat::S24_P32,


### PR DESCRIPTION
DecodeFirstFrame() uses the frame count from a Xing header as
max_frames. RunDecoder() then calls AllocateBuffers(), which eagerly
allocates frame_offsets and times arrays using that count.

The existing limit accepts 8,388,608 frames. On x86_64, the two arrays
request about 192 MiB. A crafted 1,189-byte MPEG file can supply this
count, and allocation failure terminates MPD because AllocateBuffers()
is noexcept.

Ignore Xing frame counts that cannot fit within the input even if every
frame were only a four-byte MPEG header. Unknown-size streams retain
the conservative estimate from FileSizeToSongLength(). Also use
nothrow allocation and clean up partial allocations so a remaining
failure stops this decoder instance instead of terminating MPD.
