### PR TITLE
output/osx: move the default device query into a function

### DIFF
--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -143,11 +143,12 @@ OSXOutput::OSXOutput(const ConfigBlock &block)
 	}
 }
 
-AudioOutput *
-OSXOutput::Create(EventLoop &, const ConfigBlock &block)
+/**
+ * Query the current default output device.
+ */
+static AudioDeviceID
+GetDefaultOutputDevice(OSType component_subtype)
 {
-	OSXOutput *oo = new OSXOutput(block);
-
 	static constexpr AudioObjectPropertyAddress default_system_output_device{
 		kAudioHardwarePropertyDefaultSystemOutputDevice,
 		kAudioObjectPropertyScopeOutput,
@@ -161,16 +162,24 @@ OSXOutput::Create(EventLoop &, const ConfigBlock &block)
 	};
 
 	const auto &aopa =
-		oo->component_subtype == kAudioUnitSubType_SystemOutput
+		component_subtype == kAudioUnitSubType_SystemOutput
 		// get system output dev_id if configured
 		? default_system_output_device
-		/* fallback to default device initially (can still be
-		   changed by osx_output_set_device) */
 		: default_output_device;
 
+	return AudioObjectGetPropertyDataT<AudioDeviceID>(kAudioObjectSystemObject,
+							  aopa);
+}
+
+AudioOutput *
+OSXOutput::Create(EventLoop &, const ConfigBlock &block)
+{
+	OSXOutput *oo = new OSXOutput(block);
+
 	try {
-		oo->dev_id = AudioObjectGetPropertyDataT<AudioDeviceID>(kAudioObjectSystemObject,
-									aopa);
+		/* fallback to default device initially (can still be
+		   changed by osx_output_set_device) */
+		oo->dev_id = GetDefaultOutputDevice(oo->component_subtype);
 	} catch (...) {
 		oo->dev_id = kAudioDeviceUnknown;
 	}

--- a/src/output/plugins/OSXOutputPlugin.cxx
+++ b/src/output/plugins/OSXOutputPlugin.cxx
@@ -97,6 +97,14 @@ struct OSXOutput final : AudioOutput {
 	void SetVolume(unsigned new_volume);
 
 private:
+	/**
+	 * Determine the device to operate on.  Only
+	 * kAudioUnitSubType_HALOutput has a fixed device; the other
+	 * subtypes follow the current default device, which can change
+	 * at any time.
+	 */
+	AudioDeviceID GetDeviceID() const;
+
 	void Enable() override;
 	void Disable() noexcept override;
 
@@ -187,6 +195,13 @@ OSXOutput::Create(EventLoop &, const ConfigBlock &block)
 	return oo;
 }
 
+AudioDeviceID
+OSXOutput::GetDeviceID() const
+{
+	return component_subtype == kAudioUnitSubType_HALOutput
+		? dev_id
+		: GetDefaultOutputDevice(component_subtype);
+}
 
 int
 OSXOutput::GetVolume()
@@ -197,7 +212,7 @@ OSXOutput::GetVolume()
 		kAudioObjectPropertyElementMain,
 	};
 
-	const auto vol = AudioObjectGetPropertyDataT<Float32>(dev_id,
+	const auto vol = AudioObjectGetPropertyDataT<Float32>(GetDeviceID(),
 							      aopa);
 
 	return std::lround(vol * 100.0f);
@@ -213,7 +228,7 @@ OSXOutput::SetVolume(unsigned new_volume)
 	};
 
 	const Float32 vol = new_volume / 100.0f;
-	AudioObjectSetPropertyDataT(dev_id, aopa, vol);
+	AudioObjectSetPropertyDataT(GetDeviceID(), aopa, vol);
 }
 
 static void
@@ -701,7 +716,7 @@ OSXOutput::Open(AudioFormat &audio_format)
 	asbd.mChannelsPerFrame = audio_format.channels;
 
 	[[maybe_unused]] const Float64 sample_rate =
-		osx_output_set_device_format(dev_id, asbd);
+		osx_output_set_device_format(GetDeviceID(), asbd);
 
 #ifdef ENABLE_DSD
 	if (audio_format.format == SampleFormat::DSD &&


### PR DESCRIPTION
Disconnect a Bluetooth headset during playback and the output never opens again, even once the headset is back and is the default output device:

```
mixer: Failed to read mixer for "CoreAudio": The operation couldn't be completed. (OSStatus error 560947818.)
exception: Failed to open "CoreAudio" (osx); The operation couldn't be completed. (OSStatus error 560947818.)
player: problems opening audio device while playing "..."
```

That is `kAudioHardwareBadObjectError`. `Create()` resolves `dev_id` once, and `osx_output_set_device()` only refreshes it for `kAudioUnitSubType_HALOutput`. With `kAudioUnitSubType_DefaultOutput` or `kAudioUnitSubType_SystemOutput` it is never updated, so once that device is gone the id stays dead and `GetVolume()`, `SetVolume()` and `Open()` all fail until a restart.

Re-resolving in `Enable()` would not help either. `InternalEnable()` returns early once `really_enabled` is set, and the open failure path never clears it, so `Enable()` runs once per process.

Since both subtypes track the default device anyway, query it on demand instead of caching it. The `hog_device` calls keep using the stored id so `Disable()` still releases the device `Enable()` hogged.

#932 hit the same error in 2020. Its case (\*), a device pinned by name disappearing, needs different handling and is not addressed here.

First commit is preparation, no functional change. Tested on macOS arm64 with `mixer_type "hardware"` and no `device` set. Before, the output stays unopenable until restart. After, playback recovers on the next open and the log stays clean. Full build, no new warnings.

Both commits apply to v0.24.x if you want a separate PR for that branch.

