### PR TITLE
playlist: limit XML input size

### DIFF
--- a/src/lib/expat/ExpatParser.hxx
+++ b/src/lib/expat/ExpatParser.hxx
@@ -5,6 +5,7 @@
 
 #include <expat.h>
 
+#include <cstddef>
 #include <stdexcept>
 #include <string_view>
 #include <utility>
@@ -60,7 +61,7 @@ public:
 		Parse({}, true);
 	}
 
-	void Parse(InputStream &is);
+	void Parse(InputStream &is, std::size_t max_size);
 
 	[[gnu::pure]]
 	static const char *GetAttribute(const XML_Char **atts,

--- a/src/lib/expat/StreamExpatParser.cxx
+++ b/src/lib/expat/StreamExpatParser.cxx
@@ -6,16 +6,24 @@
 #include "util/SpanCast.hxx"
 
 void
-ExpatParser::Parse(InputStream &is)
+ExpatParser::Parse(InputStream &is, const std::size_t max_size)
 {
 	assert(is.IsReady());
 
+	if (is.KnownSize() && is.GetRest() > max_size)
+		throw std::runtime_error("XML document is too large");
+
+	std::size_t total_size = 0;
 	while (true) {
 		std::byte buffer[4096];
 		size_t nbytes = is.LockRead(buffer);
 		if (nbytes == 0)
 			break;
 
+		if (nbytes > max_size - total_size)
+			throw std::runtime_error("XML document is too large");
+
+		total_size += nbytes;
 		Parse(ToStringView(std::span{buffer}.first(nbytes)));
 	}
 

--- a/src/playlist/plugins/AsxPlaylistPlugin.cxx
+++ b/src/playlist/plugins/AsxPlaylistPlugin.cxx
@@ -2,6 +2,7 @@
 // Copyright The Music Player Daemon Project
 
 #include "AsxPlaylistPlugin.hxx"
+#include "XmlPlaylistPlugin.hxx"
 #include "../PlaylistPlugin.hxx"
 #include "../MemorySongEnumerator.hxx"
 #include "protocol/Verify.hxx"
@@ -150,7 +151,7 @@ asx_open_stream(InputStreamPtr &&is)
 		ExpatParser expat(&parser);
 		expat.SetElementHandler(asx_start_element, asx_end_element);
 		expat.SetCharacterDataHandler(asx_char_data);
-		expat.Parse(*is);
+		expat.Parse(*is, XML_PLAYLIST_MAX_SIZE);
 	}
 
 	parser.songs.reverse();

--- a/src/playlist/plugins/RssPlaylistPlugin.cxx
+++ b/src/playlist/plugins/RssPlaylistPlugin.cxx
@@ -2,6 +2,7 @@
 // Copyright The Music Player Daemon Project
 
 #include "RssPlaylistPlugin.hxx"
+#include "XmlPlaylistPlugin.hxx"
 #include "../PlaylistPlugin.hxx"
 #include "../MemorySongEnumerator.hxx"
 #include "tag/Builder.hxx"
@@ -130,7 +131,7 @@ rss_open_stream(InputStreamPtr &&is)
 		ExpatParser expat(&parser);
 		expat.SetElementHandler(rss_start_element, rss_end_element);
 		expat.SetCharacterDataHandler(rss_char_data);
-		expat.Parse(*is);
+		expat.Parse(*is, XML_PLAYLIST_MAX_SIZE);
 	}
 
 	parser.songs.reverse();

--- a/src/playlist/plugins/XmlPlaylistPlugin.hxx
+++ b/src/playlist/plugins/XmlPlaylistPlugin.hxx
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The Music Player Daemon Project
+
+#pragma once
+
+#include <cstddef>
+
+/* XML playlist plugins materialize the document before returning songs. */
+static constexpr std::size_t XML_PLAYLIST_MAX_SIZE = 16 * 1024 * 1024;

--- a/src/playlist/plugins/XspfPlaylistPlugin.cxx
+++ b/src/playlist/plugins/XspfPlaylistPlugin.cxx
@@ -2,6 +2,7 @@
 // Copyright The Music Player Daemon Project
 
 #include "XspfPlaylistPlugin.hxx"
+#include "XmlPlaylistPlugin.hxx"
 #include "../PlaylistPlugin.hxx"
 #include "../MemorySongEnumerator.hxx"
 #include "protocol/Verify.hxx"
@@ -189,7 +190,7 @@ xspf_open_stream(InputStreamPtr &&is)
 		ExpatParser expat(&parser);
 		expat.SetElementHandler(xspf_start_element, xspf_end_element);
 		expat.SetCharacterDataHandler(xspf_char_data);
-		expat.Parse(*is);
+		expat.Parse(*is, XML_PLAYLIST_MAX_SIZE);
 	}
 
 	parser.songs.reverse();


### PR DESCRIPTION
The ASX, RSS, and XSPF loaders parse and retain the complete XML stream
before returning any songs. A client can load an oversized remote playlist
and grow the daemon heap without bound, regardless of
`max_playlist_length`.

Pass an explicit 16 MiB limit to stream-based Expat parsing. Known-size
streams are rejected before reading, while streams without a declared size
are counted as they are parsed. All three XML playlist loaders now return a
normal protocol error after the limit is reached. I can adjust the 16 MiB
limit to something else if you prefer.
