### PR TITLE
command/StickerCommands: fix crash in "sticker delete" without a name

### DIFF
--- a/src/command/StickerCommands.cxx
+++ b/src/command/StickerCommands.cxx
@@ -84,7 +84,12 @@ public:
 			   ? sticker_database.Delete(sticker_type, uri)
 			   : sticker_database.DeleteValue(sticker_type, uri, name);
 		if (!ret) {
-			response.FmtError(ACK_ERROR_NO_EXIST, "no such sticker: {:?}", name);
+			if (name == nullptr)
+				response.FmtError(ACK_ERROR_NO_EXIST,
+						  "no stickers found: {:?}", uri);
+			else
+				response.FmtError(ACK_ERROR_NO_EXIST,
+						  "no such sticker: {:?}", name);
 			return CommandResult::ERROR;
 		}
 


### PR DESCRIPTION
The three-argument form of "sticker delete" deletes all stickers of a
URI and passes a null "name" to DomainHandler::Delete().  If the delete
affects no rows, the error path formats that null pointer with libfmt,
which aborts the process.  Any client can terminate the daemon with

	sticker delete song "foo.ogg"

on a song that has no stickers.

Report the URI instead when no name was given.  Reproduced on 099971ba1
with a minimal build: the stock binary dies with SIGABRT, the patched
binary answers ACK [50@0] {sticker} no stickers found: "a.wav" and stays
up.

I kept the existing error semantics for the no-name form; if you would
rather it return OK when there is nothing to delete, I can change that.
