### PR TITLE
command/StickerCommands: validate find arguments

### DIFF
--- a/src/command/StickerCommands.cxx
+++ b/src/command/StickerCommands.cxx
@@ -524,7 +524,12 @@ handle_sticker(Client &client, Request args, Response &r)
 			args.pop_back();
 		}
 
-		bool has_op = args.size() > 4;
+		if (args.size() != 4 && args.size() != 6) {
+			r.Error(ACK_ERROR_ARG, "bad request");
+			return CommandResult::ERROR;
+		}
+
+		const bool has_op = args.size() == 6;
 		auto value = has_op ? args[5] : nullptr;
 		StickerOperator op = StickerOperator::EXISTS;
 		if (has_op) {


### PR DESCRIPTION
After optional `sort` and `window` clauses are removed, `sticker find` expects either four arguments or an operator/value pair for a total of six. With five arguments, the handler reads a nonexistent sixth element and may crash the daemon.

Reject all other argument counts before accessing the optional value.