### PR TITLE
playlist/pls: limit input size

### DIFF
--- a/src/input/LimitedInputStream.cxx
+++ b/src/input/LimitedInputStream.cxx
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The Music Player Daemon Project
+
+#include "LimitedInputStream.hxx"
+
+#include <cassert>
+#include <stdexcept>
+
+LimitedInputStream::LimitedInputStream(InputStreamPtr _input,
+				       const offset_type max_size)
+	:ProxyInputStream(std::move(_input)), remaining(max_size)
+{
+	ProxyInputStream::Update();
+	Check();
+}
+
+void
+LimitedInputStream::CheckSize()
+{
+	if (size_checked || !IsReady())
+		return;
+
+	if (input->KnownSize() && input->GetRest() > remaining)
+		throw std::runtime_error("Input stream is too large");
+
+	size_checked = true;
+}
+
+void
+LimitedInputStream::Check()
+{
+	ProxyInputStream::Check();
+	CheckSize();
+}
+
+std::size_t
+LimitedInputStream::Read(std::unique_lock<Mutex> &lock,
+			 std::span<std::byte> dest)
+{
+	assert(!dest.empty());
+
+	if (remaining < dest.size())
+		dest = dest.first(static_cast<std::size_t>(remaining) + 1);
+
+	const std::size_t nbytes = input->Read(lock, dest);
+	if (nbytes > remaining)
+		throw std::runtime_error("Input stream is too large");
+
+	remaining -= nbytes;
+	CopyAttributes();
+	return nbytes;
+}

--- a/src/input/LimitedInputStream.hxx
+++ b/src/input/LimitedInputStream.hxx
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The Music Player Daemon Project
+
+#pragma once
+
+#include "ProxyInputStream.hxx"
+
+/**
+ * An #InputStream proxy which limits the amount of data that may be
+ * read from the underlying stream.
+ */
+class LimitedInputStream final : public ProxyInputStream {
+	offset_type remaining;
+	bool size_checked = false;
+
+	void CheckSize();
+
+public:
+	LimitedInputStream(InputStreamPtr _input, offset_type max_size);
+
+	/* virtual methods from class InputStream */
+	void Check() override;
+	std::size_t Read(std::unique_lock<Mutex> &lock,
+			 std::span<std::byte> dest) override;
+};

--- a/src/input/meson.build
+++ b/src/input/meson.build
@@ -23,6 +23,7 @@ input_basic = static_library(
   'input_basic',
   'AsyncInputStream.cxx',
   'LastInputStream.cxx',
+  'LimitedInputStream.cxx',
   'MemoryInputStream.cxx',
   'ProxyInputStream.cxx',
   'RewindInputStream.cxx',

--- a/src/playlist/plugins/PlsPlaylistPlugin.cxx
+++ b/src/playlist/plugins/PlsPlaylistPlugin.cxx
@@ -4,6 +4,7 @@
 #include "PlsPlaylistPlugin.hxx"
 #include "../PlaylistPlugin.hxx"
 #include "../MemorySongEnumerator.hxx"
+#include "input/LimitedInputStream.hxx"
 #include "input/TextInputStream.hxx"
 #include "input/InputStream.hxx"
 #include "song/DetachedSong.hxx"
@@ -18,6 +19,9 @@
 #include <string>
 
 using std::string_view_literals::operator""sv;
+
+/* PLS playlists are materialized before any songs are returned. */
+static constexpr offset_type PLS_PLAYLIST_MAX_SIZE = 16 * 1024 * 1024;
 
 static bool
 FindPlaylistSection(TextInputStream &is)
@@ -133,7 +137,9 @@ ParsePls(TextInputStream &is, std::forward_list<DetachedSong> &songs)
 static bool
 ParsePls(InputStreamPtr &&is, std::forward_list<DetachedSong> &songs)
 {
-	TextInputStream tis(std::move(is));
+	InputStreamPtr limited = std::make_unique<LimitedInputStream>
+		(std::move(is), PLS_PLAYLIST_MAX_SIZE);
+	TextInputStream tis(std::move(limited));
 	if (!ParsePls(tis, songs)) {
 		is = tis.StealInputStream();
 		return false;


### PR DESCRIPTION
The PLS parser materializes up to 65,536 entries before returning any songs. Each entry can retain a file URI and title near the text line limit, allowing a playlist to consume hundreds of MiB.

Add an optional byte limit to `TextInputStream` and reject PLS input over 16 MiB. Known-size streams are rejected before parsing, and the read limit also covers streams without a known size. I can adjust the 16 MiB limit to something else if you prefer.