### PR TITLE
input: wake callers on errors and EOF

### DIFF
--- a/src/input/AsyncInputStream.cxx
+++ b/src/input/AsyncInputStream.cxx
@@ -141,7 +141,6 @@ AsyncInputStream::SeekDone() noexcept
 	open = true;
 
 	seek_state = SeekState::NONE;
-	caller_cond.notify_one();
 	InvokeOnAvailable();
 }
 
@@ -207,10 +206,8 @@ AsyncInputStream::CommitWriteBuffer(size_t nbytes) noexcept
 
 	if (!IsReady())
 		SetReady();
-	else {
-		caller_cond.notify_one();
+	else
 		InvokeOnAvailable();
-	}
 }
 
 void
@@ -240,10 +237,8 @@ AsyncInputStream::AppendToBuffer(std::span<const std::byte> src) noexcept
 
 	if (!IsReady())
 		SetReady();
-	else {
-		caller_cond.notify_one();
+	else
 		InvokeOnAvailable();
-	}
 }
 
 void
@@ -254,7 +249,6 @@ AsyncInputStream::DeferredResume() noexcept
 	if (postponed_exception) [[unlikely]] {
 		/* do not proceed, first the caller must handle the
                    pending error */
-		caller_cond.notify_one();
 		InvokeOnAvailable();
 		return;
 	}
@@ -263,7 +257,6 @@ AsyncInputStream::DeferredResume() noexcept
 		Resume();
 	} catch (...) {
 		postponed_exception = std::current_exception();
-		caller_cond.notify_one();
 		InvokeOnAvailable();
 	}
 }
@@ -279,7 +272,6 @@ AsyncInputStream::DeferredSeek() noexcept
 		/* do not proceed, first the caller must handle the
                    pending error */
 		seek_state = SeekState::NONE;
-		caller_cond.notify_one();
 		InvokeOnAvailable();
 		return;
 	}
@@ -295,7 +287,6 @@ AsyncInputStream::DeferredSeek() noexcept
 	} catch (...) {
 		seek_state = SeekState::NONE;
 		postponed_exception = std::current_exception();
-		caller_cond.notify_one();
 		InvokeOnAvailable();
 	}
 }

--- a/src/input/AsyncInputStream.hxx
+++ b/src/input/AsyncInputStream.hxx
@@ -56,6 +56,14 @@ class AsyncInputStream : public InputStream {
 protected:
 	std::exception_ptr postponed_exception;
 
+	/**
+	 * Notify both the synchronous caller and the InputStream handler.
+	 */
+	void InvokeOnAvailable() noexcept {
+		caller_cond.notify_one();
+		InputStream::InvokeOnAvailable();
+	}
+
 public:
 	AsyncInputStream(EventLoop &event_loop, std::string_view _url,
 			 Mutex &_mutex,

--- a/src/input/plugins/AlsaInputPlugin.cxx
+++ b/src/input/plugins/AlsaInputPlugin.cxx
@@ -244,6 +244,7 @@ try {
 	CommitWriteBuffer(nbytes);
 }
 catch (...) {
+	const std::lock_guard protect{mutex};
 	postponed_exception = std::current_exception();
 	InvokeOnAvailable();
 }

--- a/src/playlist/Length.cxx
+++ b/src/playlist/Length.cxx
@@ -28,7 +28,7 @@ static void
 playlist_provider_length(Response &r,
 			const SongLoader &loader,
 			const char *uri,
-			SongEnumerator &e) noexcept
+			SongEnumerator &e)
 {
 	const auto base_uri = uri != nullptr
 		? PathTraitsUTF8::GetParent(uri)

--- a/src/playlist/Print.cxx
+++ b/src/playlist/Print.cxx
@@ -27,7 +27,7 @@ playlist_provider_print(Response &r,
 			SongEnumerator &e,
 			unsigned start_index,
 			unsigned end_index,
-			bool detail) noexcept
+			bool detail)
 {
 	const auto base_uri = uri != nullptr
 		? PathTraitsUTF8::GetParent(uri)
@@ -61,7 +61,7 @@ playlist_provider_search_print(Response &r,
 			       SongEnumerator &e,
 			       unsigned start_index,
 			       unsigned end_index,
-			       SongFilter *filter) noexcept
+			       SongFilter *filter)
 {
 	const auto base_uri = uri != nullptr
 		? PathTraitsUTF8::GetParent(uri)


### PR DESCRIPTION
`AsyncInputStream::Read()` waits on `caller_cond`, but EOF and error callbacks in asynchronous input implementations only called `InvokeOnAvailable()`. After `bd7830794`, that no longer wakes synchronous readers. Commands that enumerate a truncated remote playlist can therefore leave MPD's main thread blocked indefinitely.

Make `AsyncInputStream` notify `caller_cond` whenever it invokes the availability handler, covering all asynchronous implementations. Remove `noexcept` from the playlist enumeration helpers so I/O errors reach the command handler instead of terminating MPD after the reader is woken.