### PR TITLE
upnp: defer cleanup for HTTP status errors

### DIFF
--- a/src/lib/upnp/Discovery.cxx
+++ b/src/lib/upnp/Discovery.cxx
@@ -8,6 +8,7 @@
 #include "Error.hxx"
 #include "lib/curl/Global.hxx"
 #include "lib/curl/Handler.hxx"
+#include "lib/curl/HttpStatusError.hxx"
 #include "lib/curl/Request.hxx"
 #include "event/Call.hxx"
 #include "event/InjectEvent.hxx"
@@ -104,10 +105,9 @@ void
 UPnPDeviceDirectory::Downloader::OnHeaders(unsigned status,
 					   Curl::Headers &&)
 {
-	if (status != 200) {
-		Destroy();
-		return;
-	}
+	if (status != 200)
+		throw HttpStatusError(status,
+				      "Failed to download UPnP device description");
 }
 
 void


### PR DESCRIPTION
The UPnP device description downloader deleted itself from `OnHeaders()` when a server returned a non-200 status. `CurlResponseHandlerAdapter` then continued `DataReceived()` and called `OnData()` through the deleted request, causing a use-after-free. A UPnP server on the local network can trigger this when the UPnP database or neighbor plugin is enabled.

Throw `HttpStatusError` instead. The curl adapter records the exception, aborts the transfer, and invokes `OnError()` after leaving the data callback, where the downloader can be destroyed safely.
