### PR TITLE
command: fix underflow in relative range moves

### DIFF
--- a/src/command/PositionArg.cxx
+++ b/src/command/PositionArg.cxx
@@ -65,7 +65,8 @@ ParseMoveDestination(const char *s, const RangeArg range, const playlist &p)
 
 		return current + 1 +
 			ParseCommandArgUnsigned(s + 1,
-						queue_length - current - range.Count());
+						queue_length - range.Count() -
+						current - 1);
 	} else if (*s == '-') {
 		/* before the current song */
 
@@ -78,8 +79,7 @@ ParseMoveDestination(const char *s, const RangeArg range, const playlist &p)
 			current -= range.Count();
 
 		return current -
-			ParseCommandArgUnsigned(s + 1,
-						queue_length - current - range.Count());
+			ParseCommandArgUnsigned(s + 1, current);
 	} else
 		/* absolute position */
 		return ParseCommandArgUnsigned(s,

--- a/src/queue/PlaylistEdit.cxx
+++ b/src/queue/PlaylistEdit.cxx
@@ -301,11 +301,11 @@ playlist::StaleSong(PlayerControl &pc, const char *uri) noexcept
 void
 playlist::MoveRange(PlayerControl &pc, RangeArg range, unsigned to)
 {
-	if (!queue.IsValidPosition(range.start) ||
-	    !queue.IsValidPosition(range.end - 1))
+	const unsigned length = GetLength();
+	if (range.IsEmpty() || range.start >= length || range.end > length)
 		throw PlaylistError::BadRange();
 
-	if (to + range.Count() - 1 >= GetLength())
+	if (to > length - range.Count())
 		throw PlaylistError::BadRange();
 
 	if (range.start == to)


### PR DESCRIPTION
A negative relative `move` validates its offset against the number of songs after the current song. If the moved range contains every song before the current song, an offset such as `-1` can underflow the destination to `UINT_MAX`.

The addition-based bounds check in `playlist::MoveRange()` also overflows and accepts that destination, causing `Queue::MoveRange()` to access memory out of bounds and crash MPD.

Validate negative offsets against the adjusted current position, correct the positive offset limit, and rewrite the playlist bounds check without overflowing arithmetic.

For example, with five queued songs and song 4 current, `move 0:4 -1` now returns an argument error instead of crashing MPD.