### PR TITLE
db/update: limit archive entry path length

### DIFF
--- a/src/db/update/Archive.cxx
+++ b/src/db/update/Archive.cxx
@@ -10,6 +10,7 @@
 #include "protocol/Verify.hxx"
 #include "lib/fmt/PathFormatter.hxx"
 #include "fs/AllocatedPath.hxx"
+#include "fs/Limits.hxx"
 #include "storage/FileInfo.hxx"
 #include "archive/ArchiveList.hxx"
 #include "archive/ArchivePlugin.hxx"
@@ -40,6 +41,9 @@ void
 UpdateWalk::UpdateArchiveTree(ArchiveFile &archive, Directory &directory,
 			      std::string_view name) noexcept
 {
+	if (name.size() >= MPD_PATH_MAX)
+		return;
+
 	const auto [child_name, rest] = Split(name, '/');
 	if (rest.data() != nullptr) {
 		if (!VerifyRelativePathUTF8(child_name))


### PR DESCRIPTION
Archive entry names can be much longer than filesystem paths. During a database update, `UpdateArchiveTree()` creates one virtual directory for each path component. A 120 KiB ZIP with one 60,005-byte, 30,000-component entry made an optimized MPD build peak at about 895 MB RSS, compared with about 8.5 MB for an empty music directory. This can exhaust memory if such an archive is placed in the music directory.

Ignore archive entries whose paths do not fit within `MPD_PATH_MAX`. This prevents MPD from constructing the excessively deep virtual directory tree. Peak RSS for the reproducer fell to about 287 MB; the remaining allocation occurs inside zziplib before it invokes MPD’s visitor callback.